### PR TITLE
3.9.1 — cohort_scope admission-gate validation (#150 Ask 3, the trust-graph-free enforcement slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [3.9.3] — 2026-06-01
+
+**CIRISPersist 3.9.3 — bulk peer-level `cohort_scope` filter on `list_federation_keys` (CIRISPersist#151).**
+
+Answers *"which key_ids belong to cohort X?"* in one indexed query at the wheel surface, replacing the O(N) per-key `peer_metadata_for` fan-out consumers fall back to today. This is the **peer-level** `cohort_scope` — the free-form membership label in `federation_peer_metadata.policy_blob` (e.g. `"family-acme"`) — distinct from the v3.9.0/3.9.1 **envelope-level** closed-set `cohort_scope` on `federation_attestations`.
+
+### Read surface (Option A — the preferred shape from the issue)
+
+- **`FederationKeyFilter.cohort_scope: Option<String>`** (NEW) — composes AND-style with the existing `agent_id_hash` / `algorithm` / `revoked` / `pqc_completed` filters. `#[serde(default)]` so existing payloads are unaffected; `engine.list_federation_keys({"cohort_scope": "family-acme"}, cursor, limit)` now returns exactly the matching peers as a `FederationKeyListPage`.
+- **Both backends** EXISTS-join the sibling `federation_peer_metadata` row and match the `policy_blob` JSON slot — Postgres `policy_blob->>'cohort_scope'`, SQLite `json_extract(policy_blob, '$.cohort_scope')`. Because cohort membership is a *live* property, **soft-removed peers (`removed_at IS NULL`) are excluded**.
+- **Cursor pagination preserved** — large cohorts page in O(limit) per call on the existing `(valid_from DESC, key_id DESC)` cursor.
+- **PyO3** — no binding change needed; `list_federation_keys` already deserializes `FederationKeyFilter` from `filter_json`, so the new key flows through automatically (docstring updated).
+
+### Migration
+
+- **V057** (both backends) — a functional **partial** index over the peer-metadata `cohort_scope` JSON path (`WHERE removed_at IS NULL AND policy_blob IS NOT NULL`), keeping the cohort lookup O(log N). Idempotent (`CREATE INDEX IF NOT EXISTS`); the `subject_key_ids[]` reader can reuse the same SQL pattern.
+
+### Tests
+
+- Both backends: empty match, multi-match (exactly the cohort's peers, not others), multi-page cursor (limit=1 → distinct pages), and soft-removed-peer exclusion. The PG test uses a per-run unique cohort label so the shared CI DB's leftover peers can't bleed in.
+- 547/547 sqlite lib tests green; postgres + pyo3 targets compile; clippy clean across `sqlite` / `pyo3`.
+
 ## [3.9.2] — 2026-06-01
 
 **CIRISPersist 3.9.2 — `holds_bytes` suppression for `cohort_scope: self | family`: the structural-invisibility primitive (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [3.9.1] — 2026-06-01
+
+**CIRISPersist 3.9.1 — `cohort_scope` admission-gate validation: the first enforcement slice on the v3.9.0 schema foundation (CIRISPersist#150 Ask 3).**
+
+v3.9.0 landed the `cohort_scope` column + struct + `is_valid()` predicate as schema foundation, with the admission/read enforcement explicitly deferred to v3.10+. This cut takes the one piece of that enforcement that is **trust-graph-free and self-contained**: validating the producer-side `cohort_scope` value at attestation write time.
+
+### Enforcement
+
+- **`admission::check_cohort_scope`** (NEW, re-exported at `crate::federation::check_cohort_scope`) — rejects any `cohort_scope` outside the closed set `{self, family, community, affiliations, species, biosphere, federation}` via the existing `types::cohort_scope::is_valid` predicate. Notably rejects `global`, which is a CEG §8.1.8 *feed-name* (aggregating `{species, biosphere, federation}`), **never** a wire value — exactly as the V056 migration comment promised ("Producers writing `global` get rejected at the admission gate").
+- **`put_attestation` admission hook (both backends)** — the check runs immediately after the dimension-admission `check()`, BEFORE `persist_row_hash` computation + INSERT, so a rejected row leaves no trace. The V056 `CHECK (cohort_scope IN (...))` constraint remains the defense-in-depth backstop for direct-SQL bypass.
+- **`Error::CohortScopeRejected { cohort_scope }`** (NEW) — typed, machine-readable rejection (`kind() == "federation_cohort_scope_rejected"`), distinct from `InvalidArgument` so consumers can pattern-match the cohort_scope outcome deterministically. Mirrors the `ReservedPrefixEmitterMismatch` / `DimensionRejected` admission-error discipline.
+
+### Tests
+
+- Unit (`admission.rs`): every closed-set value admits; `global` rejects with the pinned `kind()` token; empty / mis-cased / `partnered` (a §4.2.4 peer-policy value, not an envelope value) reject.
+- Integration (both backends): `put_attestation` with `cohort_scope = "global"` → `CohortScopeRejected`, no row persisted; `cohort_scope = "self"` admits and round-trips through `list_attestations_for`.
+
+### What's still v3.10+ (unchanged from 3.9.0)
+
+The caller-vs-scope admission rules (#150 Ask 3 — `self` requires `attesting_key_id == local_key_id`, `family` requires `trust:partnered`/`trust:direct`, …), read-time viewer filtering (Ask 4), the §8.1.8.1 promotion ceremony (Ask 5), the PyO3 surface (Ask 6), and the #153 `holds_bytes` suppression / at-rest DEK cascade for `cohort_scope: self|family` all remain deferred — they need `federation_keys` / trust-graph walks, background tokio tasks, and the consumer-tier wheel surface that don't fit a patch cut. This cut is the value-validation floor those layers build on.
+
 ## [3.9.0] — 2026-05-31
 
 **CIRISPersist 3.9.0 — CEG 0.4 / 0.6 schema foundation: `cohort_scope` column on `federation_attestations` + consent_record + canonical-binding + SLA-watcher state tables (V056).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [3.9.2] — 2026-06-01
+
+**CIRISPersist 3.9.2 — `holds_bytes` suppression for `cohort_scope: self | family`: the structural-invisibility primitive (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4).**
+
+The substrate-side enforcement of the ciris.ai/cewp privacy claim — *"self and family content never emits the attestation that would tell the rest of the network it exists."* The `holds_bytes:sha256:*` directory attestation **is** the discovery surface a peer walks to learn a blob exists; not emitting it is the privacy primitive. This cut makes persist own that decision instead of trusting consumers to withhold the announcement.
+
+### Enforcement
+
+- **`cohort_scope::suppresses_holds_bytes(&str) -> bool`** (NEW) — the structural-invisibility classification: `true` for `self` and `family`, `false` for `community` / `affiliations` / `species` / `biosphere` / `federation`. CEG 0.8 §8.1.13.3 is explicit that community content is NOT suppressed (communities can be large; byte-level invisibility is infeasible — their privacy property is cohort-filtered visibility). This is the FEDERATION_SCALING_MODEL §9.5 locality dividend: self/family bytes never cost the federation a directory entry.
+- **`BlobStorage::store_blob_local`** (NEW, both backends) — stores blob bytes with the same inline-cap + hash-on-write validation as `put_blob`, but emits **no** `holds_bytes` attestation. No signer, and deliberately **no `AdmissionGate` trust check** — local content is the operator's own data, and the substrate is never the right place to refuse it (the #149 anti-recommendation).
+- **`BlobStorage::put_blob_signing_scoped`** (NEW, default method) — cohort-scope-aware write. Dispatches `self`/`family` → `store_blob_local` (structurally invisible), every other validated scope → `put_blob_signing` (federation-tier signed announcement, unchanged). An out-of-closed-set scope (e.g. the §8.1.8 feed-name `global`) is rejected with `BlobError::InvalidArgument`, mirroring the v3.9.1 attestation admission gate at the blob-write boundary.
+- **PyO3 `store_blob_local_json`** (NEW) — wheel-surface primitive; the `put_blob_json` payload minus the `attestation` field. Lets a consumer store `self`/`family` bytes without announcing them.
+
+### Also
+
+- **Fix:** the v3.9.1 `Error::CohortScopeRejected` variant is now handled in the PyO3 `federation_err_to_py` mapper (caller-fault → `ValueError`/4xx). v3.9.1 verified sqlite+postgres but not the `pyo3` feature, whose exhaustive `match` on `federation::Error` would have failed the wheel build; folded in here so the branch HEAD is green across every feature axis.
+
+### Tests
+
+- Unit: `suppresses_holds_bytes` true only for self/family; false for the five federating scopes and for unknown values.
+- Both backends: `store_blob_local` persists bytes (readable via `get_blob`) with an empty `list_holders` (nothing announced).
+- Dispatch (sqlite, backend-agnostic default method): `self` suppresses holds_bytes; `federation` emits holds_bytes (`list_holders == [host]`); `global` → `InvalidArgument` with nothing stored.
+- 546/546 sqlite lib tests green; postgres + pyo3 targets compile; clippy clean across `sqlite` / `pyo3`.
+
+### What's still v3.10+ (the rest of #153 / #152)
+
+The `family` + `identity_occurrence` admission tables and consensus-protocol gate (#153 Asks 1-3), the at-rest **DEK cascade** that wraps content keys to new members via HPKE `key_grant` (#153 Ask 4 / #152), forward-secrecy-on-removal (#153 Ask 6), and the Policy-L read accessors (#153 Ask 7) remain deferred — they need the new identity/family substrate tables, a membership-change watcher task, and the consumer hardware-enclave unwrap path. This cut lands the one load-bearing primitive those build on: bytes that are never announced.
+
 ## [3.9.1] — 2026-06-01
 
 **CIRISPersist 3.9.1 — `cohort_scope` admission-gate validation: the first enforcement slice on the v3.9.0 schema foundation (CIRISPersist#150 Ask 3).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "3.9.2"
+version = "3.9.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "3.9.1"
+version = "3.9.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "3.9.0"
+version = "3.9.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V057__peer_metadata_cohort_scope_index.sql
+++ b/migrations/postgres/lens/V057__peer_metadata_cohort_scope_index.sql
@@ -1,0 +1,21 @@
+-- V057 — peer-level cohort_scope membership read index
+--        (CIRISPersist#151, v3.9.3).
+--
+-- Backs FederationKeyFilter.cohort_scope: the bulk "which key_ids
+-- belong to cohort X?" reader added at the wheel surface. The filter
+-- EXISTS-joins federation_peer_metadata and matches the policy_blob
+-- JSONB `cohort_scope` slot for *live* peers (removed_at IS NULL).
+--
+-- This functional partial index keeps that lookup O(log N) instead of
+-- a full peer-metadata scan. Partial (removed_at IS NULL AND
+-- policy_blob IS NOT NULL) so it only covers the live, cohort-tagged
+-- rows the filter actually probes — soft-removed and untagged peers
+-- never enter the index.
+--
+-- Note this is the PEER-level cohort_scope (free-form membership label,
+-- e.g. 'family-acme'), distinct from the V056 envelope-level closed-set
+-- federation_attestations.cohort_scope.
+
+CREATE INDEX IF NOT EXISTS federation_peer_metadata_cohort_scope
+    ON cirislens.federation_peer_metadata ((policy_blob->>'cohort_scope'))
+    WHERE removed_at IS NULL AND policy_blob IS NOT NULL;

--- a/migrations/sqlite/lens/V057__peer_metadata_cohort_scope_index.sql
+++ b/migrations/sqlite/lens/V057__peer_metadata_cohort_scope_index.sql
@@ -1,0 +1,16 @@
+-- V057 — peer-level cohort_scope membership read index — SQLite
+--        dialect (CIRISPersist#151, v3.9.3).
+--
+-- Postgres parity (postgres/lens/V057): functional partial index over
+-- the federation_peer_metadata policy_blob `cohort_scope` slot for
+-- live peers, backing FederationKeyFilter.cohort_scope.
+--
+-- SQLite extracts the slot via json_extract(policy_blob,
+-- '$.cohort_scope') (the Postgres `policy_blob->>'cohort_scope'`
+-- equivalent). Partial (removed_at IS NULL AND policy_blob IS NOT
+-- NULL) so it covers only the live, cohort-tagged rows the filter
+-- probes. See migrations/postgres/lens/V057 for the full rationale.
+
+CREATE INDEX IF NOT EXISTS federation_peer_metadata_cohort_scope
+    ON federation_peer_metadata (json_extract(policy_blob, '$.cohort_scope'))
+    WHERE removed_at IS NULL AND policy_blob IS NOT NULL;

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -645,6 +645,42 @@ pub fn envelope_dimension(envelope: &serde_json::Value) -> Option<&str> {
     envelope.get("dimension").and_then(|v| v.as_str())
 }
 
+/// v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4) — admission-gate
+/// validation of the producer-side `cohort_scope` field.
+///
+/// Rejects any value outside the closed set
+/// `{self, family, community, affiliations, species, biosphere,
+/// federation}` ([`crate::federation::types::cohort_scope::is_valid`])
+/// BEFORE the row is hashed and inserted, so a malformed envelope —
+/// notably `global`, which is a §8.1.8 *feed-name* aggregating
+/// `{species, biosphere, federation}` and **never** a wire value —
+/// leaves no trace. Returns [`Error::CohortScopeRejected`] on a bad
+/// value; the row is not stored.
+///
+/// This is the trust-graph-free first layer of #150 Ask 3 (the
+/// caller-vs-scope admission rules that need `federation_keys` /
+/// trust-graph walks are deferred to the v3.10+ enforcement cut). It
+/// is the application-layer companion to the V056 `CHECK
+/// (cohort_scope IN (...))` constraint: the constraint is
+/// defense-in-depth for rows that bypass this hook (direct SQL); this
+/// hook produces the machine-readable typed rejection consumers
+/// pattern-match on (`kind() == "federation_cohort_scope_rejected"`).
+///
+/// `self`-tier locality enforcement (a `cohort_scope: self`
+/// attestation MUST NOT emit `holds_bytes` to peers — the
+/// FEDERATION_SCALING_MODEL §9.5 locality dividend) is a separate,
+/// emission-side concern tracked by #153 Ask 5 and is not part of this
+/// value-validation layer.
+pub fn check_cohort_scope(cohort_scope: &str) -> Result<(), Error> {
+    if crate::federation::types::cohort_scope::is_valid(cohort_scope) {
+        Ok(())
+    } else {
+        Err(Error::CohortScopeRejected {
+            cohort_scope: cohort_scope.to_string(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1178,5 +1214,54 @@ mod tests {
             identity_type::WITNESS,
         )
         .unwrap();
+    }
+
+    // ── #150 Ask 3: cohort_scope admission-gate validation ─────────
+
+    #[test]
+    fn cohort_scope_admits_every_closed_set_value() {
+        use crate::federation::types::cohort_scope as cs;
+        for scope in [
+            cs::SELF,
+            cs::FAMILY,
+            cs::COMMUNITY,
+            cs::AFFILIATIONS,
+            cs::SPECIES,
+            cs::BIOSPHERE,
+            cs::FEDERATION,
+        ] {
+            check_cohort_scope(scope)
+                .unwrap_or_else(|e| panic!("closed-set value {scope:?} must admit, got {e:?}"));
+        }
+    }
+
+    #[test]
+    fn cohort_scope_rejects_global_feed_name() {
+        // `global` is a §8.1.8 feed-name (aggregates species/biosphere/
+        // federation), NEVER a wire value — it must be rejected.
+        let err = check_cohort_scope("global").unwrap_err();
+        match err {
+            Error::CohortScopeRejected { ref cohort_scope } => {
+                assert_eq!(cohort_scope, "global");
+                assert_eq!(err.kind(), "federation_cohort_scope_rejected");
+            }
+            other => panic!("expected CohortScopeRejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cohort_scope_rejects_garbage_and_empty() {
+        assert!(matches!(
+            check_cohort_scope("").unwrap_err(),
+            Error::CohortScopeRejected { .. }
+        ));
+        assert!(matches!(
+            check_cohort_scope("Self").unwrap_err(),
+            Error::CohortScopeRejected { .. }
+        ));
+        assert!(matches!(
+            check_cohort_scope("partnered").unwrap_err(),
+            Error::CohortScopeRejected { .. }
+        ));
     }
 }

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -1264,4 +1264,31 @@ mod tests {
             Error::CohortScopeRejected { .. }
         ));
     }
+
+    // ── #153 Ask 5: structural-invisibility classification ─────────
+
+    #[test]
+    fn cohort_scope_suppresses_holds_bytes_only_for_self_and_family() {
+        use crate::federation::types::cohort_scope as cs;
+        // self + family are structurally invisible — no holds_bytes.
+        assert!(cs::suppresses_holds_bytes(cs::SELF));
+        assert!(cs::suppresses_holds_bytes(cs::FAMILY));
+        // everything else federates and emits holds_bytes per status quo
+        // (CEG 0.8 §8.1.13.3 is explicit that community is NOT suppressed).
+        for scope in [
+            cs::COMMUNITY,
+            cs::AFFILIATIONS,
+            cs::SPECIES,
+            cs::BIOSPHERE,
+            cs::FEDERATION,
+        ] {
+            assert!(
+                !cs::suppresses_holds_bytes(scope),
+                "{scope:?} must federate (emit holds_bytes)"
+            );
+        }
+        // unknown values are not suppressors (they're rejected upstream
+        // by is_valid / the admission gate).
+        assert!(!cs::suppresses_holds_bytes("global"));
+    }
 }

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -222,6 +222,43 @@ pub trait BlobStorage: Send + Sync {
         attestation: PutBlobAttestation,
     ) -> impl Future<Output = Result<(), BlobError>> + Send;
 
+    /// v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — store blob
+    /// bytes **without** emitting a `holds_bytes:sha256:*` directory
+    /// attestation.
+    ///
+    /// The structural-invisibility primitive for
+    /// [`cohort_scope`](crate::federation::types::cohort_scope)
+    /// `self` / `family` content: the bytes are persisted locally
+    /// (and readable via [`get_blob`](BlobStorage::get_blob) /
+    /// streamable as the operator's own data) but the substrate
+    /// announces nothing — no `holds_bytes` row is created, so a
+    /// non-member peer walking the federation directory cannot
+    /// discover the bytes exist. This is the difference between
+    /// [`put_blob`](BlobStorage::put_blob) (federation-tier: bytes +
+    /// holds_bytes announcement) and local-only storage.
+    ///
+    /// Validation is identical to [`put_blob`] for the bytes
+    /// themselves — inline-size cap + hash-on-write — but there is no
+    /// attestation, no signer, and (deliberately) no
+    /// [`AdmissionGate`](crate::federation::AdmissionGate) trust check:
+    /// local content is the operator's own data, and the substrate is
+    /// never the right place to refuse it (the #149 anti-recommendation
+    /// — "Don't block local writes ever").
+    ///
+    /// Idempotent on SHA collision (first-write-wins on
+    /// `storage_kind` / `external_ref`), exactly as [`put_blob`].
+    /// Callers normally reach this via
+    /// [`put_blob_signing_scoped`](BlobStorage::put_blob_signing_scoped),
+    /// which dispatches here when
+    /// [`suppresses_holds_bytes`](crate::federation::types::cohort_scope::suppresses_holds_bytes)
+    /// is true.
+    fn store_blob_local(
+        &self,
+        sha256: &[u8; 32],
+        body: BlobBody,
+        media_type: Option<&str>,
+    ) -> impl Future<Output = Result<(), BlobError>> + Send;
+
     /// Read a blob by its SHA-256.
     ///
     /// Returns the [`BlobBody`] variant matching the row's stored
@@ -397,6 +434,74 @@ pub trait BlobStorage: Send + Sync {
             };
 
             self.put_blob(sha256, body, media_type, att).await
+        }
+    }
+
+    /// v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — cohort-scope-
+    /// aware blob write. The substrate-side enforcement of the
+    /// structural-invisibility privacy claim.
+    ///
+    /// Dispatches on
+    /// [`cohort_scope::suppresses_holds_bytes`](crate::federation::types::cohort_scope::suppresses_holds_bytes):
+    ///
+    /// - `self` / `family` → [`store_blob_local`](BlobStorage::store_blob_local):
+    ///   bytes are persisted, **no** `holds_bytes` attestation is
+    ///   emitted, the signer is never invoked (there is no attestation
+    ///   to sign). The content is structurally invisible to the
+    ///   federation.
+    /// - every other (validated) scope → [`put_blob_signing`](BlobStorage::put_blob_signing):
+    ///   the federation-tier path that signs + emits the `holds_bytes`
+    ///   announcement exactly as today.
+    ///
+    /// `cohort_scope` MUST be one of the closed-set values
+    /// ([`cohort_scope::is_valid`](crate::federation::types::cohort_scope::is_valid));
+    /// an unknown value (e.g. the §8.1.8 feed-name `global`) is
+    /// rejected with [`BlobError::InvalidArgument`] — the same closed
+    /// set the v3.9.1 attestation admission gate enforces, applied here
+    /// at the blob-write boundary.
+    ///
+    /// # Default impl
+    ///
+    /// Composed from the two existing surfaces; no per-backend override
+    /// is intended.
+    #[allow(clippy::too_many_arguments)]
+    fn put_blob_signing_scoped<'s>(
+        &'s self,
+        cohort_scope: &'s str,
+        sha256: &'s [u8; 32],
+        body: BlobBody,
+        media_type: Option<&'s str>,
+        attesting_key_id: &'s str,
+        signer: &'s dyn ciris_keyring::HardwareSigner,
+        now: chrono::DateTime<chrono::Utc>,
+        attestation_id: uuid::Uuid,
+    ) -> impl Future<Output = Result<(), BlobError>> + Send + 's
+    where
+        Self: Sync,
+    {
+        async move {
+            if !crate::federation::types::cohort_scope::is_valid(cohort_scope) {
+                return Err(BlobError::InvalidArgument(format!(
+                    "cohort_scope {cohort_scope:?} is not in the closed set \
+                     {{self, family, community, affiliations, species, biosphere, federation}}"
+                )));
+            }
+            if crate::federation::types::cohort_scope::suppresses_holds_bytes(cohort_scope) {
+                // Structurally invisible (CEG §10.1.4): store the bytes,
+                // announce nothing. No signer, no holds_bytes row.
+                self.store_blob_local(sha256, body, media_type).await
+            } else {
+                self.put_blob_signing(
+                    sha256,
+                    body,
+                    media_type,
+                    attesting_key_id,
+                    signer,
+                    now,
+                    attestation_id,
+                )
+                .await
+            }
         }
     }
 

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -77,8 +77,8 @@ pub(crate) mod serde_bytes_b64 {
 }
 
 pub use admission::{
-    AttestationLadderTransitionPolicy, DimensionAdmissionPolicy, DimensionRejectionReason,
-    ReservedPrefixRule, ATTESTATION_LADDER_MECHANISMS,
+    check_cohort_scope, AttestationLadderTransitionPolicy, DimensionAdmissionPolicy,
+    DimensionRejectionReason, ReservedPrefixRule, ATTESTATION_LADDER_MECHANISMS,
 };
 pub use blackhole::{BlackholeRecord, BlackholeRules, RETICULUM_IDENTITY_HASH_LEN};
 pub use blobs::{
@@ -910,6 +910,26 @@ pub enum Error {
         threshold: f64,
     },
 
+    /// v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4). The submitted
+    /// attestation's `cohort_scope` is outside the closed set
+    /// `{self, family, community, affiliations, species, biosphere,
+    /// federation}` — most commonly `global`, which is a §8.1.8
+    /// feed-name (`{species, biosphere, federation}` aggregate), not a
+    /// wire value. Rejected at admission by
+    /// [`admission::check_cohort_scope`]; the row is not stored.
+    /// Distinct from [`Error::InvalidArgument`] so consumers can
+    /// pattern-match the cohort_scope rejection deterministically. The
+    /// V056 `CHECK (cohort_scope IN (...))` constraint is the
+    /// defense-in-depth backstop for rows that bypass this hook.
+    #[error(
+        "cohort_scope {cohort_scope:?} is not in the closed set \
+         {{self, family, community, affiliations, species, biosphere, federation}}"
+    )]
+    CohortScopeRejected {
+        /// The rejected `cohort_scope` value as submitted.
+        cohort_scope: String,
+    },
+
     /// Backend-level error (DB connection, serialization, etc.).
     /// String-typed because each backend has its own error tree.
     #[error("backend: {0}")]
@@ -945,6 +965,7 @@ impl Error {
                 "federation_hard_remove_with_active_attestations"
             }
             Error::TrustBelowThreshold { .. } => "federation_trust_below_threshold",
+            Error::CohortScopeRejected { .. } => "federation_cohort_scope_rejected",
             Error::Backend(_) => "federation_backend",
         }
     }

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -447,6 +447,33 @@ pub mod cohort_scope {
             SELF | FAMILY | COMMUNITY | AFFILIATIONS | SPECIES | BIOSPHERE | FEDERATION
         )
     }
+
+    /// v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — the
+    /// structural-invisibility classification.
+    ///
+    /// True iff content tagged with this `cohort_scope` is
+    /// **structurally invisible** to the federation: the substrate
+    /// MUST NOT emit a `holds_bytes:sha256:*` directory attestation
+    /// for it, and MUST NOT propagate it beyond the self-collective /
+    /// family scope via any directory or discovery surface. A
+    /// non-member peer cannot issue a ContentFetch for it and cannot
+    /// even discover the bytes exist — the `holds_bytes` row *is* the
+    /// discovery surface, so not emitting it is the privacy primitive
+    /// (the ciris.ai/cewp "the wire format can't carry them" claim).
+    ///
+    /// True for [`SELF`] and [`FAMILY`]. False for `community` /
+    /// `affiliations` / `species` / `biosphere` / `federation`, which
+    /// federate per status quo and emit `holds_bytes` normally — CEG
+    /// 0.8 §8.1.13.3 is explicit that community content is NOT
+    /// suppressed (communities can be large; per-member byte-level
+    /// invisibility is infeasible, and the community privacy property
+    /// is cohort-filtered visibility, not byte-level invisibility).
+    ///
+    /// This is the locality dividend of FEDERATION_SCALING_MODEL §9.5:
+    /// self/family bytes never cost the federation a directory entry.
+    pub fn suppresses_holds_bytes(s: &str) -> bool {
+        matches!(s, SELF | FAMILY)
+    }
 }
 
 impl Attestation {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7474,6 +7474,12 @@ impl PyEngine {
 
     /// Bulk-list federation_keys with filter + cursor pagination.
     /// Returns JSON-encoded `FederationKeyListPage`.
+    ///
+    /// v3.9.3 (CIRISPersist#151) — `filter_json` accepts a
+    /// `cohort_scope` key, e.g. `{"cohort_scope": "family-acme"}`, to
+    /// list every live peer whose `policy_blob` declares that cohort in
+    /// one indexed query (soft-removed peers excluded) — replacing the
+    /// O(N) per-key `peer_metadata_for` fan-out.
     fn list_federation_keys(
         &self,
         py: Python<'_>,

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4101,6 +4101,48 @@ impl PyEngine {
         })
     }
 
+    /// v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — store blob
+    /// bytes WITHOUT emitting a `holds_bytes` directory attestation.
+    ///
+    /// The wheel-surface primitive for `cohort_scope: self | family`
+    /// content: the bytes are persisted locally (readable via
+    /// `get_blob_json`) but the substrate announces nothing — no
+    /// `holds_bytes` row, so non-member peers cannot discover the bytes
+    /// exist. The payload is the same shape as `put_blob_json` **minus
+    /// the `attestation` field** (there is no attestation to sign):
+    /// `{"sha256": "<hex>", "body": {"inline": "<b64>"}|{"external":
+    /// {...}}, "media_type": "...|null"}`.
+    fn store_blob_local_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let (sha256, body, media_type) = parse_store_blob_local_payload(payload_json)?;
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .store_blob_local(&sha256, body, media_type.as_deref())
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .store_blob_local(&sha256, body, media_type.as_deref())
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
     /// Federation blob storage: read a blob by SHA-256 (hex).
     ///
     /// Returns `None` when no row exists; otherwise a JSON string of
@@ -16790,6 +16832,9 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         crate::federation::Error::ReservedPrefixEmitterMismatch { .. } => {
             PyValueError::new_err(kind)
         }
+        // v3.9.1 (CIRISPersist#150 Ask 3) — cohort_scope admission
+        // rejection is caller-fault malformed-content; ValueError (4xx).
+        crate::federation::Error::CohortScopeRejected { .. } => PyValueError::new_err(kind),
         // v2.5.0 (CIRISPersist#102 Ask 4 + Ask 8) — all the new
         // admission-hook rejections are caller-fault malformed-
         // content; ValueError (4xx).
@@ -16956,6 +17001,39 @@ fn parse_put_blob_payload(json: &str) -> PyResult<PutBlobPayload> {
         media_type: wire.media_type,
         attestation,
     })
+}
+
+/// v3.9.2 (CIRISPersist#153 Ask 5) — wire shape for
+/// `store_blob_local_json`: `put_blob_json` minus the `attestation`
+/// field (local-only storage emits no holds_bytes attestation).
+#[derive(serde::Deserialize)]
+struct StoreBlobLocalJsonWire {
+    sha256: String,
+    body: PutBlobWireBody,
+    #[serde(default)]
+    media_type: Option<String>,
+}
+
+/// v3.9.2 (CIRISPersist#153 Ask 5) — decode the `store_blob_local_json`
+/// payload into the trait-call argument shape.
+fn parse_store_blob_local_payload(
+    json: &str,
+) -> PyResult<([u8; 32], crate::federation::BlobBody, Option<String>)> {
+    let wire: StoreBlobLocalJsonWire = serde_json::from_str(json)
+        .map_err(|e| PyValueError::new_err(format!("store_blob_local_json decode: {e}")))?;
+    let sha = parse_sha256_hex(&wire.sha256)?;
+    let body = match wire.body {
+        PutBlobWireBody::Inline(b64) => {
+            use base64::engine::general_purpose::STANDARD as B64;
+            use base64::Engine as _;
+            let bytes = B64.decode(&b64).map_err(|e| {
+                PyValueError::new_err(format!("store_blob_local_json inline base64 decode: {e}"))
+            })?;
+            crate::federation::BlobBody::Inline(bytes)
+        }
+        PutBlobWireBody::External(e) => crate::federation::BlobBody::External(e),
+    };
+    Ok((sha, body, wire.media_type))
 }
 
 /// v2.3 (CIRISPersist#103) — parse a 64-char hex string into a

--- a/src/read/federation.rs
+++ b/src/read/federation.rs
@@ -47,6 +47,24 @@ pub struct FederationKeyFilter {
     /// `pqc_completed_at IS NOT NULL`; `Some(false)` returns only
     /// hybrid-pending keys.
     pub pqc_completed: Option<bool>,
+
+    /// v3.9.3 (CIRISPersist#151) — filter to keys whose **peer**
+    /// declares this `cohort_scope` in its
+    /// `federation_peer_metadata.policy_blob` (the peer-level
+    /// membership slot, e.g. `"family-acme"` — distinct from the
+    /// envelope-level closed-set `cohort_scope` on
+    /// `federation_attestations`).
+    ///
+    /// Answers "which key_ids belong to cohort X?" in one indexed
+    /// query instead of an O(N) per-key `peer_metadata_for` fan-out.
+    /// Matches via an `EXISTS` join against
+    /// `federation_peer_metadata` (Postgres `policy_blob->>'cohort_scope'`,
+    /// SQLite `json_extract(policy_blob, '$.cohort_scope')`), and —
+    /// because membership is a *live* property — **excludes
+    /// soft-removed peers** (`removed_at IS NULL`). A V057 functional
+    /// index over the JSON path keeps it O(log N).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cohort_scope: Option<String>,
 }
 
 /// Opaque cursor for [`super::ReadEngine::list_federation_keys`].

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1474,6 +1474,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             &attesting_identity_type,
         )?;
 
+        // v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4) — cohort_scope
+        // admission-gate validation. Rejects out-of-closed-set values
+        // (notably `global`, a §8.1.8 feed-name, never a wire value)
+        // BEFORE persist_row_hash + INSERT so rejected rows leave no
+        // trace. The V056 CHECK constraint is the defense-in-depth
+        // backstop for direct-SQL bypass.
+        crate::federation::admission::check_cohort_scope(&row.cohort_scope)?;
+
         // v3.0.0 (CIRISPersist#116, CEG 0.2 §6.1) — structural-composer
         // dedup on `(references_attestation_id, attestation_type,
         // attesting_key_id)`. A second put with the same triple is a
@@ -12235,6 +12243,107 @@ mod tests {
             }
             other => panic!("expected DimensionRejected, got {other:?}"),
         }
+    }
+
+    /// v3.9.1 (CIRISPersist#150 Ask 3) — the cohort_scope admission
+    /// gate rejects an out-of-closed-set value (`global`) with the
+    /// typed `CohortScopeRejected`, leaving no row behind.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_put_attestation_rejects_invalid_cohort_scope() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::FederationDirectory;
+        let steward = format!("pg-cs-bad-stw-§150-{}", uuid_like());
+        let agent_k = format!("pg-cs-bad-agt-§150-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &steward,
+                    "registry",
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &agent_k,
+                    "primitive-cs-bad",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        let mut att = pg_scores_attestation(&steward, &agent_k, &steward, "identity_binding:v1");
+        att.cohort_scope = "global".to_string();
+        let err = backend
+            .put_attestation(crate::federation::SignedAttestation { attestation: att })
+            .await
+            .unwrap_err();
+        match err {
+            crate::federation::Error::CohortScopeRejected { ref cohort_scope } => {
+                assert_eq!(cohort_scope, "global");
+                assert_eq!(err.kind(), "federation_cohort_scope_rejected");
+            }
+            other => panic!("expected CohortScopeRejected, got {other:?}"),
+        }
+        // Rejected before INSERT — no row leaked through.
+        assert!(backend
+            .list_attestations_for(&agent_k)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    /// v3.9.1 (CIRISPersist#150 Ask 3) — a valid narrow cohort_scope
+    /// (`self`) is admitted and round-trips through the read path.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_put_attestation_accepts_self_cohort_scope() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::FederationDirectory;
+        let steward = format!("pg-cs-self-stw-§150-{}", uuid_like());
+        let agent_k = format!("pg-cs-self-agt-§150-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &steward,
+                    "registry",
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &agent_k,
+                    "primitive-cs-self",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        let mut att = pg_scores_attestation(&steward, &agent_k, &steward, "identity_binding:v1");
+        att.cohort_scope = crate::federation::types::cohort_scope::SELF.to_string();
+        backend
+            .put_attestation(crate::federation::SignedAttestation { attestation: att })
+            .await
+            .unwrap();
+        let rows = backend.list_attestations_for(&agent_k).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cohort_scope, "self");
     }
 
     #[tokio::test]

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -14363,7 +14363,10 @@ mod tests {
         let fam_b = format!("peer-fam-b-{}", uuid_like());
         let other = format!("peer-other-{}", uuid_like());
         for id in [&fam_a, &fam_b] {
-            backend.add_peer_record(id, "AAAA", "agent", None).await.unwrap();
+            backend
+                .add_peer_record(id, "AAAA", "agent", None)
+                .await
+                .unwrap();
             backend
                 .update_peer_policy(
                     id,
@@ -14372,7 +14375,10 @@ mod tests {
                 .await
                 .unwrap();
         }
-        backend.add_peer_record(&other, "BBBB", "agent", None).await.unwrap();
+        backend
+            .add_peer_record(&other, "BBBB", "agent", None)
+            .await
+            .unwrap();
         backend
             .update_peer_policy(
                 &other,
@@ -14405,7 +14411,10 @@ mod tests {
         assert_eq!(ids, vec![fam_a.as_str(), fam_b.as_str()]);
 
         // Multi-page: limit=1 → page + cursor + distinct second page.
-        let p1 = backend.list_federation_keys(mk(&cohort), None, 1).await.unwrap();
+        let p1 = backend
+            .list_federation_keys(mk(&cohort), None, 1)
+            .await
+            .unwrap();
         assert_eq!(p1.items.len(), 1);
         let cursor = p1.next_cursor.clone().expect("next_cursor");
         let p2 = backend
@@ -14422,7 +14431,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            fam_live.items.iter().map(|k| k.key_id.as_str()).collect::<Vec<_>>(),
+            fam_live
+                .items
+                .iter()
+                .map(|k| k.key_id.as_str())
+                .collect::<Vec<_>>(),
             vec![fam_a.as_str()],
         );
     }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3248,6 +3248,64 @@ impl crate::federation::BlobStorage for PostgresBackend {
         Ok(())
     }
 
+    // v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — store blob
+    // bytes WITHOUT a holds_bytes attestation (structural invisibility
+    // for cohort_scope self/family). Same byte-validation as put_blob;
+    // no attestation, no admission gate (local content is the
+    // operator's own data — #149 anti-rec).
+    async fn store_blob_local(
+        &self,
+        sha256: &[u8; 32],
+        body: crate::federation::BlobBody,
+        media_type: Option<&str>,
+    ) -> Result<(), crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        if let crate::federation::BlobBody::Inline(ref bytes) = body {
+            if bytes.len() > cap {
+                return Err(crate::federation::BlobError::InlineSizeExceeded {
+                    size: bytes.len(),
+                    cap,
+                });
+            }
+            crate::federation::blobs::verify_inline_hash(sha256, bytes)?;
+        }
+        let storage_kind = body.storage_kind();
+        let size_bytes_i64 = i64::try_from(body.size_bytes()).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "size_bytes exceeds i64 — federation_blobs.size_bytes is BIGINT".into(),
+            )
+        })?;
+        let (bytes_inline_opt, external_ref_opt) = match &body {
+            crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
+            crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+        };
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let sha_vec = sha256.to_vec();
+        client
+            .execute(
+                "INSERT INTO cirislens.federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type\
+                 ) VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (sha256) DO NOTHING",
+                &[
+                    &sha_vec,
+                    &storage_kind,
+                    &bytes_inline_opt,
+                    &external_ref_opt,
+                    &size_bytes_i64,
+                    &media_type,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("store_blob_local insert: {e}"))
+            })?;
+        Ok(())
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -11791,6 +11849,36 @@ mod tests {
             .expect("put inline");
         let got = backend.get_blob(&sha).await.expect("get").expect("present");
         assert_eq!(got, BlobBody::Inline(bytes));
+    }
+
+    /// v3.9.2 (CIRISPersist#153 Ask 5) — store_blob_local persists the
+    /// bytes but emits NO holds_bytes attestation (structural
+    /// invisibility for cohort_scope self/family). Parity with the
+    /// sqlite `store_blob_local_persists_bytes_without_announcing` test.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn blob_pg_store_blob_local_persists_without_announcing() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::{BlobBody, BlobStorage};
+        let bytes = pg_blob_payload("local-only");
+        let sha = pg_sha256_of(&bytes);
+        backend
+            .store_blob_local(&sha, BlobBody::Inline(bytes.clone()), None)
+            .await
+            .expect("store_blob_local");
+        // Bytes readable locally.
+        let got = backend.get_blob(&sha).await.expect("get").expect("present");
+        assert_eq!(got, BlobBody::Inline(bytes));
+        // Nothing announced — no holds_bytes attestation.
+        assert!(
+            backend.list_holders(&sha).await.unwrap().is_empty(),
+            "self/family content must emit no holds_bytes attestation"
+        );
     }
 
     #[tokio::test]

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -6439,6 +6439,20 @@ impl crate::read::ReadEngine for PostgresBackend {
                 "pqc_completed_at IS NULL".to_owned()
             });
         }
+        // v3.9.3 (CIRISPersist#151) — peer-level cohort_scope membership.
+        // EXISTS-join the sibling federation_peer_metadata row, matching
+        // the policy_blob JSONB `cohort_scope` slot; exclude soft-removed
+        // peers (removed_at IS NULL — membership is a live property).
+        if let Some(cs) = &filter.cohort_scope {
+            params.push(Box::new(cs.clone()));
+            where_parts.push(format!(
+                "EXISTS (SELECT 1 FROM cirislens.federation_peer_metadata pm \
+                     WHERE pm.key_id = cirislens.federation_keys.key_id \
+                       AND pm.removed_at IS NULL \
+                       AND pm.policy_blob->>'cohort_scope' = ${})",
+                params.len()
+            ));
+        }
         if let Some(c) = &cursor {
             if c.version != "v1" {
                 return Err(crate::read::Error::InvalidCursor(format!(
@@ -14326,6 +14340,91 @@ mod tests {
         assert_eq!(meta.1, "untrusted");
         assert_eq!(meta.4.as_deref(), Some("rns://abc"));
         assert!(meta.5.is_none());
+    }
+
+    /// v3.9.3 (CIRISPersist#151) — bulk peer-level cohort_scope filter
+    /// on list_federation_keys. Parity with the sqlite test; uses a
+    /// per-run unique cohort label so the shared PG DB's leftover peers
+    /// can't bleed into the assertions.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn list_federation_keys_filters_by_cohort_scope_pg() {
+        use crate::federation::FederationDirectory;
+        use crate::read::{FederationKeyFilter, ReadEngine};
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let cohort = format!("family-{}", uuid_like());
+        let other_cohort = format!("community-{}", uuid_like());
+        let fam_a = format!("peer-fam-a-{}", uuid_like());
+        let fam_b = format!("peer-fam-b-{}", uuid_like());
+        let other = format!("peer-other-{}", uuid_like());
+        for id in [&fam_a, &fam_b] {
+            backend.add_peer_record(id, "AAAA", "agent", None).await.unwrap();
+            backend
+                .update_peer_policy(
+                    id,
+                    crate::federation::PeerPolicyBlob(serde_json::json!({"cohort_scope": cohort})),
+                )
+                .await
+                .unwrap();
+        }
+        backend.add_peer_record(&other, "BBBB", "agent", None).await.unwrap();
+        backend
+            .update_peer_policy(
+                &other,
+                crate::federation::PeerPolicyBlob(
+                    serde_json::json!({"cohort_scope": other_cohort}),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let mk = |scope: &str| FederationKeyFilter {
+            cohort_scope: Some(scope.to_string()),
+            ..Default::default()
+        };
+
+        // Empty match (a cohort nobody is in).
+        let none = backend
+            .list_federation_keys(mk(&format!("nope-{}", uuid_like())), None, 100)
+            .await
+            .unwrap();
+        assert!(none.items.is_empty());
+
+        // Multi match: exactly the two peers in this run's cohort.
+        let fam_all = backend
+            .list_federation_keys(mk(&cohort), None, 100)
+            .await
+            .unwrap();
+        let mut ids: Vec<&str> = fam_all.items.iter().map(|k| k.key_id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![fam_a.as_str(), fam_b.as_str()]);
+
+        // Multi-page: limit=1 → page + cursor + distinct second page.
+        let p1 = backend.list_federation_keys(mk(&cohort), None, 1).await.unwrap();
+        assert_eq!(p1.items.len(), 1);
+        let cursor = p1.next_cursor.clone().expect("next_cursor");
+        let p2 = backend
+            .list_federation_keys(mk(&cohort), Some(cursor), 1)
+            .await
+            .unwrap();
+        assert_eq!(p2.items.len(), 1);
+        assert_ne!(p1.items[0].key_id, p2.items[0].key_id);
+
+        // Soft-removed peers drop out.
+        backend.remove_peer_record(&fam_b, false).await.unwrap();
+        let fam_live = backend
+            .list_federation_keys(mk(&cohort), None, 100)
+            .await
+            .unwrap();
+        assert_eq!(
+            fam_live.items.iter().map(|k| k.key_id.as_str()).collect::<Vec<_>>(),
+            vec![fam_a.as_str()],
+        );
     }
 
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -6544,6 +6544,20 @@ impl crate::read::ReadEngine for SqliteBackend {
                 "pqc_completed_at IS NULL".to_owned()
             });
         }
+        // v3.9.3 (CIRISPersist#151) — peer-level cohort_scope membership.
+        // EXISTS-join the sibling federation_peer_metadata row, matching
+        // the policy_blob JSON `cohort_scope` slot; exclude soft-removed
+        // peers (removed_at IS NULL — membership is a live property).
+        if let Some(cs) = &filter.cohort_scope {
+            binds.push(SqlValue::Text(cs.clone()));
+            parts.push(format!(
+                "EXISTS (SELECT 1 FROM federation_peer_metadata pm \
+                     WHERE pm.key_id = federation_keys.key_id \
+                       AND pm.removed_at IS NULL \
+                       AND json_extract(pm.policy_blob, '$.cohort_scope') = ?{})",
+                binds.len()
+            ));
+        }
         if let Some(c) = &cursor {
             if c.version != "v1" {
                 return Err(crate::read::Error::InvalidCursor(format!(
@@ -13628,6 +13642,90 @@ mod tests {
         assert_eq!(meta.1, "untrusted");
         assert_eq!(meta.4.as_deref(), Some("rns://abc"));
         assert!(meta.5.is_none(), "removed_at NULL");
+    }
+
+    /// v3.9.3 (CIRISPersist#151) — bulk peer-level cohort_scope filter
+    /// on list_federation_keys: empty match, single/multi match,
+    /// multi-page cursor, and soft-removed-peer exclusion.
+    #[tokio::test]
+    async fn list_federation_keys_filters_by_cohort_scope_sqlite() {
+        use crate::read::FederationKeyFilter;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        // Two peers in family-acme, one in a different cohort.
+        for id in ["peer-fam-1", "peer-fam-2"] {
+            backend.add_peer_record(id, "AAAA", "agent", None).await.unwrap();
+            backend
+                .update_peer_policy(
+                    id,
+                    crate::federation::PeerPolicyBlob(
+                        serde_json::json!({"cohort_scope": "family-acme"}),
+                    ),
+                )
+                .await
+                .unwrap();
+        }
+        backend
+            .add_peer_record("peer-other", "BBBB", "agent", None)
+            .await
+            .unwrap();
+        backend
+            .update_peer_policy(
+                "peer-other",
+                crate::federation::PeerPolicyBlob(
+                    serde_json::json!({"cohort_scope": "community-x"}),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let mk = |scope: &str| FederationKeyFilter {
+            cohort_scope: Some(scope.to_string()),
+            ..Default::default()
+        };
+
+        // Empty match.
+        let none = backend
+            .list_federation_keys(mk("no-such-cohort"), None, 100)
+            .await
+            .unwrap();
+        assert!(none.items.is_empty(), "unknown cohort → no rows");
+
+        // Multi match: exactly the two family-acme peers (not peer-other).
+        let fam_all = backend
+            .list_federation_keys(mk("family-acme"), None, 100)
+            .await
+            .unwrap();
+        let mut ids: Vec<&str> = fam_all.items.iter().map(|k| k.key_id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec!["peer-fam-1", "peer-fam-2"]);
+
+        // Multi-page: limit=1 pages the cohort in O(limit) per call.
+        let p1 = backend
+            .list_federation_keys(mk("family-acme"), None, 1)
+            .await
+            .unwrap();
+        assert_eq!(p1.items.len(), 1);
+        let cursor = p1.next_cursor.clone().expect("next_cursor on full page");
+        let p2 = backend
+            .list_federation_keys(mk("family-acme"), Some(cursor), 1)
+            .await
+            .unwrap();
+        assert_eq!(p2.items.len(), 1);
+        assert_ne!(p1.items[0].key_id, p2.items[0].key_id, "distinct pages");
+
+        // Soft-removed peers are excluded (membership is a live property).
+        backend.remove_peer_record("peer-fam-2", false).await.unwrap();
+        let fam_live = backend
+            .list_federation_keys(mk("family-acme"), None, 100)
+            .await
+            .unwrap();
+        assert_eq!(
+            fam_live.items.iter().map(|k| k.key_id.as_str()).collect::<Vec<_>>(),
+            vec!["peer-fam-1"],
+            "soft-removed peer must drop out of the cohort filter"
+        );
     }
 
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3142,6 +3142,71 @@ impl crate::federation::BlobStorage for SqliteBackend {
         Ok(())
     }
 
+    // v3.9.2 (CIRISPersist#153 Ask 5, CEG 0.7 §10.1.4) — store blob
+    // bytes WITHOUT a holds_bytes attestation (structural invisibility
+    // for cohort_scope self/family). Same byte-validation as put_blob;
+    // no attestation, no admission gate (local content is the
+    // operator's own data — #149 anti-rec).
+    async fn store_blob_local(
+        &self,
+        sha256: &[u8; 32],
+        body: crate::federation::BlobBody,
+        media_type: Option<&str>,
+    ) -> Result<(), crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        if let crate::federation::BlobBody::Inline(ref bytes) = body {
+            if bytes.len() > cap {
+                return Err(crate::federation::BlobError::InlineSizeExceeded {
+                    size: bytes.len(),
+                    cap,
+                });
+            }
+            crate::federation::blobs::verify_inline_hash(sha256, bytes)?;
+        }
+
+        let storage_kind = body.storage_kind().to_owned();
+        let size_bytes_i64 = i64::try_from(body.size_bytes()).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "size_bytes exceeds i64 — federation_blobs.size_bytes is INTEGER".into(),
+            )
+        })?;
+        let (bytes_inline_opt, external_ref_opt) = match &body {
+            crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
+            crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+        };
+        let sha_vec = sha256.to_vec();
+        let media_type_owned = media_type.map(str::to_owned);
+        // V053 last_accessed_at literal-default sentinel — write the
+        // real wall-clock so a fresh blob matches its first_seen_at.
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.clone();
+
+        tokio::task::spawn_blocking(move || -> Result<(), rusqlite::Error> {
+            let conn = conn.blocking_lock();
+            conn.execute(
+                "INSERT INTO federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type, \
+                    last_accessed_at, access_count\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0) \
+                 ON CONFLICT (sha256) DO NOTHING",
+                rusqlite::params![
+                    sha_vec,
+                    storage_kind,
+                    bytes_inline_opt,
+                    external_ref_opt,
+                    size_bytes_i64,
+                    media_type_owned,
+                    now_iso,
+                ],
+            )?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| crate::federation::BlobError::Backend(format!("spawn_blocking join: {e}")))?
+        .map_err(|e| crate::federation::BlobError::Backend(format!("store_blob_local: {e}")))?;
+        Ok(())
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -9844,6 +9909,121 @@ mod tests {
             vec!["actor-a".to_string()],
             "list_holders must include local writer even with stale attestation"
         );
+    }
+
+    // ── #153 Ask 5: holds_bytes suppression for self/family ────────
+
+    /// store_blob_local persists the bytes but emits NO holds_bytes
+    /// attestation — the structural-invisibility primitive. get_blob
+    /// returns the bytes; list_holders is empty (nothing announced).
+    #[tokio::test]
+    async fn store_blob_local_persists_bytes_without_announcing() {
+        use crate::federation::BlobStorage;
+        let backend = blob_test_backend().await;
+        let bytes = b"family photo".to_vec();
+        let sha = sha256_of(&bytes);
+        backend
+            .store_blob_local(&sha, BlobBody::Inline(bytes.clone()), None)
+            .await
+            .unwrap();
+        // Bytes are stored + readable locally.
+        match backend.get_blob(&sha).await.unwrap() {
+            Some(BlobBody::Inline(got)) => assert_eq!(got, bytes),
+            other => panic!("expected inline bytes, got {other:?}"),
+        }
+        // But nothing is announced to the federation.
+        assert!(
+            backend.list_holders(&sha).await.unwrap().is_empty(),
+            "self/family content must emit no holds_bytes attestation"
+        );
+    }
+
+    /// put_blob_signing_scoped("self", ...) dispatches to local-only
+    /// storage: bytes stored, no holds_bytes, signer never consulted.
+    #[tokio::test]
+    async fn put_blob_signing_scoped_self_suppresses_holds_bytes() {
+        use crate::federation::BlobStorage;
+        let backend = blob_test_backend().await;
+        let signer = test_signer_for("host-a");
+        let bytes = b"self journal entry".to_vec();
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob_signing_scoped(
+                crate::federation::types::cohort_scope::SELF,
+                &sha,
+                BlobBody::Inline(bytes.clone()),
+                None,
+                "host-a",
+                &*signer,
+                chrono::Utc::now(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .unwrap();
+        assert!(backend.has_blob(&sha).await.unwrap());
+        assert!(
+            backend.list_holders(&sha).await.unwrap().is_empty(),
+            "cohort_scope=self must not announce holds_bytes"
+        );
+    }
+
+    /// put_blob_signing_scoped("federation", ...) takes the
+    /// federation-tier path: bytes stored AND holds_bytes announced.
+    #[tokio::test]
+    async fn put_blob_signing_scoped_federation_emits_holds_bytes() {
+        use crate::federation::BlobStorage;
+        let backend = blob_test_backend().await;
+        let signer = test_signer_for("host-a");
+        let bytes = b"public corpus doc".to_vec();
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob_signing_scoped(
+                crate::federation::types::cohort_scope::FEDERATION,
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                "host-a",
+                &*signer,
+                chrono::Utc::now(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.list_holders(&sha).await.unwrap(),
+            vec!["host-a".to_string()],
+            "cohort_scope=federation must announce holds_bytes"
+        );
+    }
+
+    /// An out-of-closed-set cohort_scope (`global`) is rejected at the
+    /// blob-write boundary, mirroring the v3.9.1 attestation gate.
+    #[tokio::test]
+    async fn put_blob_signing_scoped_rejects_invalid_cohort_scope() {
+        use crate::federation::BlobStorage;
+        let backend = blob_test_backend().await;
+        let signer = test_signer_for("host-a");
+        let bytes = b"x".to_vec();
+        let sha = sha256_of(&bytes);
+        let err = backend
+            .put_blob_signing_scoped(
+                "global",
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                "host-a",
+                &*signer,
+                chrono::Utc::now(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::federation::BlobError::InvalidArgument(_)
+        ));
+        // Nothing stored on rejection.
+        assert!(!backend.has_blob(&sha).await.unwrap());
     }
 
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -13655,7 +13655,10 @@ mod tests {
 
         // Two peers in family-acme, one in a different cohort.
         for id in ["peer-fam-1", "peer-fam-2"] {
-            backend.add_peer_record(id, "AAAA", "agent", None).await.unwrap();
+            backend
+                .add_peer_record(id, "AAAA", "agent", None)
+                .await
+                .unwrap();
             backend
                 .update_peer_policy(
                     id,
@@ -13716,13 +13719,20 @@ mod tests {
         assert_ne!(p1.items[0].key_id, p2.items[0].key_id, "distinct pages");
 
         // Soft-removed peers are excluded (membership is a live property).
-        backend.remove_peer_record("peer-fam-2", false).await.unwrap();
+        backend
+            .remove_peer_record("peer-fam-2", false)
+            .await
+            .unwrap();
         let fam_live = backend
             .list_federation_keys(mk("family-acme"), None, 100)
             .await
             .unwrap();
         assert_eq!(
-            fam_live.items.iter().map(|k| k.key_id.as_str()).collect::<Vec<_>>(),
+            fam_live
+                .items
+                .iter()
+                .map(|k| k.key_id.as_str())
+                .collect::<Vec<_>>(),
             vec!["peer-fam-1"],
             "soft-removed peer must drop out of the cohort filter"
         );

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1264,6 +1264,14 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             &attesting_identity_type,
         )?;
 
+        // v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4) — cohort_scope
+        // admission-gate validation. Rejects out-of-closed-set values
+        // (notably `global`, a §8.1.8 feed-name, never a wire value)
+        // BEFORE persist_row_hash + INSERT so rejected rows leave no
+        // trace. The V056 CHECK constraint is the defense-in-depth
+        // backstop for direct-SQL bypass.
+        crate::federation::admission::check_cohort_scope(&row.cohort_scope)?;
+
         // v3.0.0 (CIRISPersist#116, CEG 0.2 §6.1) — structural-composer
         // dedup on `(references_attestation_id, attestation_type,
         // attesting_key_id)`. Look up the candidate row's
@@ -9070,6 +9078,85 @@ mod tests {
             }
             other => panic!("expected DimensionRejected, got {other:?}"),
         }
+    }
+
+    /// v3.9.1 (CIRISPersist#150 Ask 3) — the cohort_scope admission
+    /// gate rejects an out-of-closed-set value (`global` — a §8.1.8
+    /// feed-name, never a wire value) with the typed
+    /// `CohortScopeRejected`, and leaves no row behind.
+    #[tokio::test]
+    async fn sqlite_put_attestation_rejects_invalid_cohort_scope() {
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("registry-steward", "registry", "registry-steward"),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("k-a", "primitive-a", "registry-steward"),
+            })
+            .await
+            .unwrap();
+        let mut att = fed_attestation("att-cs-bad", "registry-steward", "k-a", "registry-steward");
+        att.cohort_scope = "global".to_string();
+        let err = backend
+            .put_attestation(SignedAttestation { attestation: att })
+            .await
+            .unwrap_err();
+        match err {
+            crate::federation::Error::CohortScopeRejected { cohort_scope } => {
+                assert_eq!(cohort_scope, "global");
+                assert_eq!(err_kind_cohort(), "federation_cohort_scope_rejected");
+            }
+            other => panic!("expected CohortScopeRejected, got {other:?}"),
+        }
+        // Rejected before INSERT — no row leaked through.
+        assert!(backend
+            .list_attestations_for("k-a")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    /// v3.9.1 (CIRISPersist#150 Ask 3) — a valid narrow cohort_scope
+    /// (`self`) is admitted and round-trips through the read path.
+    #[tokio::test]
+    async fn sqlite_put_attestation_accepts_self_cohort_scope() {
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("registry-steward", "registry", "registry-steward"),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("k-a", "primitive-a", "registry-steward"),
+            })
+            .await
+            .unwrap();
+        let mut att = fed_attestation("att-cs-self", "registry-steward", "k-a", "registry-steward");
+        att.cohort_scope = crate::federation::types::cohort_scope::SELF.to_string();
+        backend
+            .put_attestation(SignedAttestation { attestation: att })
+            .await
+            .unwrap();
+        let rows = backend.list_attestations_for("k-a").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cohort_scope, "self");
+    }
+
+    /// Stable `kind()` token for the cohort_scope rejection — consumers
+    /// pattern-match on this string, so it is pinned.
+    fn err_kind_cohort() -> &'static str {
+        crate::federation::Error::CohortScopeRejected {
+            cohort_scope: "global".to_string(),
+        }
+        .kind()
     }
 
     #[tokio::test]


### PR DESCRIPTION
v3.9.0 landed cohort_scope as schema foundation (column + struct +
is_valid() predicate) and explicitly deferred admission/read
enforcement to v3.10+. This cut takes the one piece of that
enforcement that is self-contained and needs no trust-graph walk or
background task: validating the producer-side cohort_scope value at
attestation write time.

Enforcement:
 - admission::check_cohort_scope (re-exported at
   crate::federation::check_cohort_scope) rejects any cohort_scope
   outside the closed set {self, family, community, affiliations,
   species, biosphere, federation} via the existing
   types::cohort_scope::is_valid predicate. Rejects `global` — a CEG
   §8.1.8 feed-name, never a wire value — exactly as the V056
   migration comment promised.
 - put_attestation (both backends) runs the check right after the
   dimension-admission check(), BEFORE persist_row_hash + INSERT, so a
   rejected row leaves no trace. The V056 CHECK constraint stays the
   defense-in-depth backstop for direct-SQL bypass.
 - New typed Error::CohortScopeRejected { cohort_scope } with stable
   kind() token "federation_cohort_scope_rejected", distinct from
   InvalidArgument so consumers pattern-match deterministically
   (mirrors ReservedPrefixEmitterMismatch / DimensionRejected).

Tests:
 - admission.rs unit: all 7 closed-set values admit; `global` rejects
   with the pinned kind() token; empty / mis-cased / `partnered`
   reject.
 - both backends: put_attestation with cohort_scope="global" →
   CohortScopeRejected + no row persisted; "self" admits and
   round-trips through list_attestations_for.
 - 541/541 sqlite lib tests green; postgres test target compiles;
   clippy clean.

Still v3.10+ (unchanged): caller-vs-scope admission rules, read-time
viewer filtering, §8.1.8.1 promotion ceremony, PyO3 surface, and the
#153 holds_bytes suppression / at-rest DEK cascade for
cohort_scope:self|family — all need trust-graph walks, background
tokio tasks, or the consumer wheel surface.

https://claude.ai/code/session_014Yw2SSUCdinMG8CqCRrmpV