### PR TITLE
Streaming Cut A — get_blob_range (byte-range reads over federation_blobs, #142)

### DIFF
--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -153,6 +153,32 @@ pub enum BlobBody {
     External(ExternalRef),
 }
 
+/// v4.1 (CIRISPersist#142, Cut A) — the result of a
+/// [`BlobStorage::get_blob_range`] byte-range read.
+///
+/// For [`BlobBody::Inline`] blobs the requested range is sliced
+/// **server-side** (no full-buffer load) and returned as
+/// [`BlobRange::Inline`]. For [`BlobBody::External`] blobs persist does
+/// **NOT** dereference the URI — it returns [`BlobRange::External`] with
+/// the ref and the (clamped) range so the *caller* fetches
+/// `[range_start, range_end_inclusive]` from the upstream object store
+/// itself, honoring whatever auth its deployment shape requires.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlobRange {
+    /// The requested byte range, sliced from inline storage.
+    Inline(Vec<u8>),
+    /// External blob — persist does NOT dereference; the caller fetches
+    /// [range_start, range_end_inclusive] from the ref's URI itself.
+    External {
+        /// The stored external pointer (URI + size + media type).
+        external_ref: ExternalRef,
+        /// Clamped inclusive range start the caller should fetch.
+        range_start: u64,
+        /// Clamped inclusive range end the caller should fetch.
+        range_end_inclusive: u64,
+    },
+}
+
 impl BlobBody {
     /// True iff this is the [`BlobBody::Inline`] variant.
     pub fn is_inline(&self) -> bool {
@@ -269,6 +295,19 @@ pub trait BlobStorage: Send + Sync {
         &self,
         sha256: &[u8; 32],
     ) -> impl Future<Output = Result<Option<BlobBody>, BlobError>> + Send;
+
+    /// v4.1 (CIRISPersist#142, Cut A) — byte-range read (RFC 9110 §14.4
+    /// semantics). `range_end_inclusive` is clamped to size-1; a
+    /// `range_start` at or past the blob size is `RangeNotSatisfiable`.
+    /// Inline → server-side substring (no full-buffer load). External →
+    /// the ref + clamped range for the caller to fetch (persist never
+    /// dereferences). Returns None if the blob is absent.
+    fn get_blob_range(
+        &self,
+        sha256: &[u8; 32],
+        range_start: u64,
+        range_end_inclusive: u64,
+    ) -> impl Future<Output = Result<Option<BlobRange>, BlobError>> + Send;
 
     /// Existence check. Cheaper than [`get_blob`](BlobStorage::get_blob)
     /// — does not pull the body column.
@@ -794,6 +833,17 @@ pub enum BlobError {
         threshold: f64,
     },
 
+    /// v4.1 (CIRISPersist#142, Cut A) — a
+    /// [`get_blob_range`](BlobStorage::get_blob_range) `range_start` at or
+    /// past the blob's size (RFC 9110 §14.4 "Range Not Satisfiable").
+    #[error("range start {range_start} not satisfiable for blob of size {size}")]
+    RangeNotSatisfiable {
+        /// The requested (unsatisfiable) range start.
+        range_start: u64,
+        /// The blob's actual size in bytes.
+        size: u64,
+    },
+
     /// Backend-level error (DB connection, serialization, etc.).
     #[error("backend: {0}")]
     Backend(String),
@@ -810,6 +860,7 @@ impl BlobError {
             BlobError::AttestationEmissionFailed(_) => "blob_attestation_emission_failed",
             BlobError::TrustBelowThreshold { .. } => "blob_trust_below_threshold",
             BlobError::HashMatchedKnownBad { .. } => "blob_hash_matched_known_bad",
+            BlobError::RangeNotSatisfiable { .. } => "blob_range_not_satisfiable",
             BlobError::Backend(_) => "blob_backend",
         }
     }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -84,7 +84,7 @@ pub use admission::{
 };
 pub use blackhole::{BlackholeRecord, BlackholeRules, RETICULUM_IDENTITY_HASH_LEN};
 pub use blobs::{
-    holds_bytes_attestation_envelope, holds_bytes_attestation_type, BlobBody, BlobError,
+    holds_bytes_attestation_envelope, holds_bytes_attestation_type, BlobBody, BlobError, BlobRange,
     BlobStorage, EvictActorReport, ExternalRef, PutBlobAttestation, DEFAULT_INLINE_BYTES_CAP,
     HOLDS_BYTES_ATTESTATION_TYPE_PREFIX, HOLDS_BYTES_PREFIX_HEX_LEN,
 };

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4575,6 +4575,71 @@ impl PyEngine {
         })
     }
 
+    /// v4.1 (CIRISPersist#142, Cut A) — byte-range read over a blob by
+    /// SHA-256 (hex). RFC 9110 §14.4 semantics: `end_inclusive` is
+    /// clamped to size-1; a `start` at/past the blob size raises
+    /// `ValueError` (RangeNotSatisfiable); `start > end_inclusive` raises
+    /// `ValueError` (InvalidArgument); an absent blob returns `None`.
+    ///
+    /// Result shape:
+    /// - Inline blob → the requested bytes as `bytes`.
+    /// - External blob → a dict `{"external_uri": str, "range_start":
+    ///   int, "range_end_inclusive": int}` — persist does NOT
+    ///   dereference; the caller fetches that range from the URI itself.
+    fn get_blob_range(
+        &self,
+        py: Python<'_>,
+        sha256_hex: &str,
+        start: u64,
+        end_inclusive: u64,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let sha = parse_sha256_hex(sha256_hex)?;
+            let range_opt = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .get_blob_range(&sha, start, end_inclusive)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .get_blob_range(&sha, start, end_inclusive)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            match range_opt {
+                None => Ok(None),
+                Some(crate::federation::BlobRange::Inline(bytes)) => {
+                    Ok(Some(PyBytes::new(py, &bytes).into_any().unbind()))
+                }
+                Some(crate::federation::BlobRange::External {
+                    external_ref,
+                    range_start,
+                    range_end_inclusive,
+                }) => {
+                    let dict = PyDict::new(py);
+                    dict.set_item("external_uri", external_ref.uri)?;
+                    dict.set_item("range_start", range_start)?;
+                    dict.set_item("range_end_inclusive", range_end_inclusive)?;
+                    Ok(Some(dict.into_any().unbind()))
+                }
+            }
+        })
+    }
+
     /// Federation blob storage: existence check by SHA-256 (hex).
     fn has_blob_json(&self, py: Python<'_>, sha256_hex: &str) -> PyResult<bool> {
         self.ensure_usable()?;
@@ -17939,6 +18004,8 @@ fn blob_err_to_py(e: crate::federation::BlobError) -> PyErr {
         crate::federation::BlobError::TrustBelowThreshold { .. } => PyValueError::new_err(kind),
         // v3.6.0 (CIRISPersist#134) — perceptual-hash matcher hit.
         crate::federation::BlobError::HashMatchedKnownBad { .. } => PyValueError::new_err(kind),
+        // v4.1 (CIRISPersist#142, Cut A) — unsatisfiable byte range.
+        crate::federation::BlobError::RangeNotSatisfiable { .. } => PyValueError::new_err(kind),
         crate::federation::BlobError::Backend(_) => PyRuntimeError::new_err(kind),
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3780,6 +3780,107 @@ impl crate::federation::BlobStorage for PostgresBackend {
         }
     }
 
+    async fn get_blob_range(
+        &self,
+        sha256: &[u8; 32],
+        range_start: u64,
+        range_end_inclusive: u64,
+    ) -> Result<Option<crate::federation::BlobRange>, crate::federation::BlobError> {
+        // v4.1 (CIRISPersist#142, Cut A) — byte-range read, RFC 9110
+        // §14.4 semantics. Inline → server-side `substring(... FROM ..
+        // FOR ..)` (no full-buffer load). External → the ref + clamped
+        // range; persist NEVER dereferences the URI.
+        if range_start > range_end_inclusive {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "range_start > range_end".into(),
+            ));
+        }
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let sha_vec = sha256.to_vec();
+        // 1. UPDATE … RETURNING to bump the access tracker AND fetch the
+        //    row head (storage_kind + size + external metadata) in one
+        //    round-trip. NULL row_opt = blob absent.
+        let row_opt = client
+            .query_opt(
+                "UPDATE cirislens.federation_blobs \
+                    SET access_count = access_count + 1, \
+                        last_accessed_at = NOW() \
+                  WHERE sha256 = $1 \
+                  RETURNING storage_kind, size_bytes, external_ref, media_type",
+                &[&sha_vec],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("get_blob_range update+select: {e}"))
+            })?;
+        let Some(row) = row_opt else {
+            return Ok(None);
+        };
+        let storage_kind: String =
+            row.safe_get_with("storage_kind", crate::federation::BlobError::Backend)?;
+        let size_bytes_i64: i64 =
+            row.safe_get_with("size_bytes", crate::federation::BlobError::Backend)?;
+        let size = u64::try_from(size_bytes_i64).map_err(|_| {
+            crate::federation::BlobError::Backend(
+                "size_bytes column went negative — schema CHECK violated".into(),
+            )
+        })?;
+        // 2. range_start at/past size → RangeNotSatisfiable.
+        if range_start >= size {
+            return Err(crate::federation::BlobError::RangeNotSatisfiable { range_start, size });
+        }
+        // 3. Clamp the inclusive end to size-1.
+        let end = range_end_inclusive.min(size - 1);
+        let len = end - range_start + 1; // >= 1
+        match storage_kind.as_str() {
+            "inline" => {
+                // Server-side substring — PG `substring` is 1-indexed, so
+                // FROM = range_start + 1. NEVER loads the whole
+                // bytes_inline column.
+                let from_i64 = i64::try_from(range_start + 1).map_err(|_| {
+                    crate::federation::BlobError::Backend("range_start overflow".into())
+                })?;
+                let for_i64 = i64::try_from(len).map_err(|_| {
+                    crate::federation::BlobError::Backend("range length overflow".into())
+                })?;
+                let slice_row = client
+                    .query_one(
+                        "SELECT substring(bytes_inline FROM $2 FOR $3) AS slice \
+                             FROM cirislens.federation_blobs WHERE sha256 = $1",
+                        &[&sha_vec, &from_i64, &for_i64],
+                    )
+                    .await
+                    .map_err(|e| {
+                        crate::federation::BlobError::Backend(format!("get_blob_range substr: {e}"))
+                    })?;
+                let slice: Vec<u8> =
+                    slice_row.safe_get_with("slice", crate::federation::BlobError::Backend)?;
+                Ok(Some(crate::federation::BlobRange::Inline(slice)))
+            }
+            "s3" | "external_url" => {
+                let uri: String =
+                    row.safe_get_with("external_ref", crate::federation::BlobError::Backend)?;
+                let media_type: Option<String> =
+                    row.safe_get_with("media_type", crate::federation::BlobError::Backend)?;
+                Ok(Some(crate::federation::BlobRange::External {
+                    external_ref: crate::federation::ExternalRef {
+                        uri,
+                        size_bytes: size,
+                        media_type,
+                    },
+                    range_start,
+                    range_end_inclusive: end,
+                }))
+            }
+            other => Err(crate::federation::BlobError::Backend(format!(
+                "unknown storage_kind: {other}"
+            ))),
+        }
+    }
+
     async fn has_blob(&self, sha256: &[u8; 32]) -> Result<bool, crate::federation::BlobError> {
         let client = self
             .get_client()
@@ -16720,6 +16821,177 @@ mod tests {
             .safe_get_with("access_count", crate::federation::Error::Backend)
             .expect("access_count column present");
         assert_eq!(count, 3);
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut A) — PG get_blob_range parity ──
+
+    /// (a)+(b)+(c) mid-range / full / end-clamp over an Inline blob.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_get_blob_range_inline_slices() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobRange, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let host = format!("range-host-{}", uuid_like());
+        pg_blob_bootstrap_host(&backend, &host).await;
+        // Deterministic 10-byte payload (don't randomize: we assert exact
+        // slice bytes). Unique SHA still derives from these bytes.
+        let bytes = b"abcdefghij".to_vec();
+        let sha = pg_sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes.clone()),
+                None,
+                pg_blob_attestation(&host, &host),
+            )
+            .await
+            .unwrap();
+        // (a) mid-range.
+        assert_eq!(
+            backend.get_blob_range(&sha, 2, 5).await.unwrap().unwrap(),
+            BlobRange::Inline(b"cdef".to_vec())
+        );
+        // (b) full range.
+        assert_eq!(
+            backend.get_blob_range(&sha, 0, 9).await.unwrap().unwrap(),
+            BlobRange::Inline(bytes)
+        );
+        // (c) end past size clamps to tail.
+        assert_eq!(
+            backend.get_blob_range(&sha, 7, 99).await.unwrap().unwrap(),
+            BlobRange::Inline(b"hij".to_vec())
+        );
+    }
+
+    /// (d) range_start >= size → RangeNotSatisfiable.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_get_blob_range_start_past_size_not_satisfiable() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let host = format!("range-oob-host-{}", uuid_like());
+        pg_blob_bootstrap_host(&backend, &host).await;
+        let bytes = b"abcdefghij".to_vec(); // size 10
+        let sha = pg_sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                pg_blob_attestation(&host, &host),
+            )
+            .await
+            .unwrap();
+        match backend.get_blob_range(&sha, 10, 20).await.unwrap_err() {
+            BlobError::RangeNotSatisfiable { range_start, size } => {
+                assert_eq!(range_start, 10);
+                assert_eq!(size, 10);
+            }
+            other => panic!("expected RangeNotSatisfiable, got {other:?}"),
+        }
+    }
+
+    /// (e) range_start > range_end → InvalidArgument; (f) absent → None.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_get_blob_range_invalid_and_absent() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let host = format!("range-inv-host-{}", uuid_like());
+        pg_blob_bootstrap_host(&backend, &host).await;
+        let bytes = pg_blob_payload("range-inv");
+        let sha = pg_sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                pg_blob_attestation(&host, &host),
+            )
+            .await
+            .unwrap();
+        // (e) start > end → InvalidArgument (caught before DB).
+        assert!(matches!(
+            backend.get_blob_range(&sha, 5, 2).await.unwrap_err(),
+            BlobError::InvalidArgument(_)
+        ));
+        // (f) absent blob → None.
+        let absent = [0xEEu8; 32];
+        assert!(backend
+            .get_blob_range(&absent, 0, 10)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    /// (g) External blob → BlobRange::External with ref + clamped range;
+    /// persist did NOT dereference the URI.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_get_blob_range_external_returns_ref_without_fetch() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobRange, BlobStorage, ExternalRef};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let host = format!("range-ext-host-{}", uuid_like());
+        pg_blob_bootstrap_host(&backend, &host).await;
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let mut sha = [0u8; 32];
+        sha[..16].copy_from_slice(&nanos.to_be_bytes());
+        sha[16..].copy_from_slice(&nanos.to_be_bytes());
+        let ext = ExternalRef {
+            uri: format!("s3://bucket/{}", uuid_like()),
+            size_bytes: 1000,
+            media_type: Some("video/mp4".into()),
+        };
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::External(ext.clone()),
+                Some("video/mp4"),
+                pg_blob_attestation(&host, &host),
+            )
+            .await
+            .unwrap();
+        // request [100..=99999] — end clamps to size-1 = 999.
+        match backend
+            .get_blob_range(&sha, 100, 99_999)
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            BlobRange::External {
+                external_ref,
+                range_start,
+                range_end_inclusive,
+            } => {
+                assert_eq!(external_ref, ext);
+                assert_eq!(range_start, 100);
+                assert_eq!(range_end_inclusive, 999);
+            }
+            other => panic!("expected BlobRange::External, got {other:?}"),
+        }
     }
 
     // ─── v3.4.0 (CIRISPersist#123) — PG sweeper parity ─────────────

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3839,18 +3839,22 @@ impl crate::federation::BlobStorage for PostgresBackend {
             "inline" => {
                 // Server-side substring — PG `substring` is 1-indexed, so
                 // FROM = range_start + 1. NEVER loads the whole
-                // bytes_inline column.
-                let from_i64 = i64::try_from(range_start + 1).map_err(|_| {
-                    crate::federation::BlobError::Backend("range_start overflow".into())
+                // bytes_inline column. PG `substring(bytea FROM int FOR
+                // int)` infers the position args as int4, so bind i32 (not
+                // i64 → int8, which fails parameter serialization). Inline
+                // blobs are bounded by MAX_BODY_BYTES (16 MiB), so the
+                // positions always fit i32.
+                let from_i32 = i32::try_from(range_start + 1).map_err(|_| {
+                    crate::federation::BlobError::Backend("range_start exceeds i32".into())
                 })?;
-                let for_i64 = i64::try_from(len).map_err(|_| {
-                    crate::federation::BlobError::Backend("range length overflow".into())
+                let for_i32 = i32::try_from(len).map_err(|_| {
+                    crate::federation::BlobError::Backend("range length exceeds i32".into())
                 })?;
                 let slice_row = client
                     .query_one(
                         "SELECT substring(bytes_inline FROM $2 FOR $3) AS slice \
                              FROM cirislens.federation_blobs WHERE sha256 = $1",
-                        &[&sha_vec, &from_i64, &for_i64],
+                        &[&sha_vec, &from_i32, &for_i32],
                     )
                     .await
                     .map_err(|e| {

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3511,6 +3511,101 @@ impl crate::federation::BlobStorage for SqliteBackend {
         .map_err(|e| crate::federation::BlobError::Backend(format!("get_blob: {e}")))
     }
 
+    async fn get_blob_range(
+        &self,
+        sha256: &[u8; 32],
+        range_start: u64,
+        range_end_inclusive: u64,
+    ) -> Result<Option<crate::federation::BlobRange>, crate::federation::BlobError> {
+        // v4.1 (CIRISPersist#142, Cut A) — byte-range read, RFC 9110
+        // §14.4 semantics. Inline → server-side `substr` (no full-buffer
+        // load). External → the ref + clamped range; persist NEVER
+        // dereferences the URI.
+        if range_start > range_end_inclusive {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "range_start > range_end".into(),
+            ));
+        }
+        let sha_vec = sha256.to_vec();
+        let conn = self.conn.clone();
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        // Outcome of the in-transaction work: None (absent),
+        // Err(RangeNotSatisfiable), or Ok(BlobRange).
+        type RangeOutcome = Option<Result<crate::federation::BlobRange, (u64, u64)>>;
+        let outcome: RangeOutcome = (move || -> Result<RangeOutcome, rusqlite::Error> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction()?;
+            // 1. Fetch storage_kind + size (+ external metadata) to do the
+            //    bounds check before pulling any bytes.
+            let head_opt = tx
+                .query_row(
+                    "SELECT storage_kind, size_bytes, external_ref, media_type \
+                         FROM federation_blobs WHERE sha256 = ?1",
+                    rusqlite::params![sha_vec],
+                    |row| {
+                        let storage_kind: String = row.get("storage_kind")?;
+                        let size_bytes: i64 = row.get("size_bytes")?;
+                        let external_ref: Option<String> = row.get("external_ref")?;
+                        let media_type: Option<String> = row.get("media_type")?;
+                        Ok((storage_kind, size_bytes, external_ref, media_type))
+                    },
+                )
+                .optional()?;
+            let (storage_kind, size_bytes, external_ref, media_type) = match head_opt {
+                None => return Ok(None),
+                Some(h) => h,
+            };
+            let size: u64 = size_bytes.max(0) as u64;
+            // 2. Bump access-tracking columns on the hit (mirrors get_blob).
+            tx.execute(
+                "UPDATE federation_blobs SET access_count = access_count + 1, \
+                     last_accessed_at = ?2 WHERE sha256 = ?1",
+                rusqlite::params![sha_vec, now_iso],
+            )?;
+            // 3. range_start at/past size → RangeNotSatisfiable.
+            if range_start >= size {
+                tx.commit()?;
+                return Ok(Some(Err((range_start, size))));
+            }
+            // 4. Clamp the inclusive end to size-1.
+            let end = range_end_inclusive.min(size - 1);
+            let len = end - range_start + 1; // >= 1
+            if storage_kind == "inline" {
+                // Server-side substring — SQLite `substr` is 1-indexed, so
+                // start = range_start + 1. NEVER loads the whole
+                // bytes_inline column.
+                let slice: Vec<u8> = tx.query_row(
+                    "SELECT substr(bytes_inline, ?2, ?3) \
+                         FROM federation_blobs WHERE sha256 = ?1",
+                    rusqlite::params![sha_vec, (range_start + 1) as i64, len as i64],
+                    |row| row.get(0),
+                )?;
+                tx.commit()?;
+                Ok(Some(Ok(crate::federation::BlobRange::Inline(slice))))
+            } else {
+                // External — return the ref + clamped range; do NOT fetch.
+                tx.commit()?;
+                Ok(Some(Ok(crate::federation::BlobRange::External {
+                    external_ref: crate::federation::ExternalRef {
+                        uri: external_ref.unwrap_or_default(),
+                        size_bytes: size,
+                        media_type,
+                    },
+                    range_start,
+                    range_end_inclusive: end,
+                })))
+            }
+        })()
+        .map_err(|e| crate::federation::BlobError::Backend(format!("get_blob_range: {e}")))?;
+        match outcome {
+            None => Ok(None),
+            Some(Err((range_start, size))) => {
+                Err(crate::federation::BlobError::RangeNotSatisfiable { range_start, size })
+            }
+            Some(Ok(range)) => Ok(Some(range)),
+        }
+    }
+
     async fn has_blob(&self, sha256: &[u8; 32]) -> Result<bool, crate::federation::BlobError> {
         let sha_vec = sha256.to_vec();
         let conn = self.conn.clone();
@@ -11454,7 +11549,9 @@ mod tests {
 
     // ─── BlobStorage tests (v2.3, CIRISPersist#103) ────────────────
 
-    use crate::federation::{BlobBody, BlobError, BlobStorage, ExternalRef, PutBlobAttestation};
+    use crate::federation::{
+        BlobBody, BlobError, BlobRange, BlobStorage, ExternalRef, PutBlobAttestation,
+    };
 
     fn blob_attestation(
         attesting_key_id: &str,
@@ -16426,6 +16523,166 @@ mod tests {
         .unwrap();
         // 2 get_blob hits + 1 has_blob = 3.
         assert_eq!(count, 3);
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut A) — get_blob_range tests ───
+
+    /// (a) mid-range slice of an Inline blob returns exactly those bytes.
+    #[tokio::test]
+    async fn get_blob_range_inline_mid_range() {
+        let backend = blob_test_backend().await;
+        let bytes = b"abcdefghij".to_vec(); // 10 bytes, indices 0..=9
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        let got = backend.get_blob_range(&sha, 2, 5).await.unwrap().unwrap();
+        assert_eq!(got, BlobRange::Inline(b"cdef".to_vec()));
+    }
+
+    /// (b) full range == whole blob.
+    #[tokio::test]
+    async fn get_blob_range_inline_full() {
+        let backend = blob_test_backend().await;
+        let bytes = b"abcdefghij".to_vec();
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes.clone()),
+                None,
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        let got = backend.get_blob_range(&sha, 0, 9).await.unwrap().unwrap();
+        assert_eq!(got, BlobRange::Inline(bytes));
+    }
+
+    /// (c) range_end past size clamps to the tail.
+    #[tokio::test]
+    async fn get_blob_range_inline_end_clamped_to_tail() {
+        let backend = blob_test_backend().await;
+        let bytes = b"abcdefghij".to_vec(); // size 10
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        // request [7..=99] — clamps to [7..=9] = "hij".
+        let got = backend.get_blob_range(&sha, 7, 99).await.unwrap().unwrap();
+        assert_eq!(got, BlobRange::Inline(b"hij".to_vec()));
+    }
+
+    /// (d) range_start >= size → RangeNotSatisfiable.
+    #[tokio::test]
+    async fn get_blob_range_start_past_size_not_satisfiable() {
+        let backend = blob_test_backend().await;
+        let bytes = b"abcdefghij".to_vec(); // size 10
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        let err = backend
+            .get_blob_range(&sha, 10, 20)
+            .await
+            .expect_err("start at size must be RangeNotSatisfiable");
+        match err {
+            BlobError::RangeNotSatisfiable { range_start, size } => {
+                assert_eq!(range_start, 10);
+                assert_eq!(size, 10);
+            }
+            other => panic!("expected RangeNotSatisfiable, got {other:?}"),
+        }
+    }
+
+    /// (e) range_start > range_end → InvalidArgument.
+    #[tokio::test]
+    async fn get_blob_range_start_after_end_invalid() {
+        let backend = blob_test_backend().await;
+        let bytes = b"abcdefghij".to_vec();
+        let sha = sha256_of(&bytes);
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::Inline(bytes),
+                None,
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        let err = backend
+            .get_blob_range(&sha, 5, 2)
+            .await
+            .expect_err("start > end must be InvalidArgument");
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    /// (f) absent blob → None.
+    #[tokio::test]
+    async fn get_blob_range_absent_returns_none() {
+        let backend = blob_test_backend().await;
+        let sha = [0xEEu8; 32];
+        let got = backend.get_blob_range(&sha, 0, 10).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    /// (g) an External blob returns BlobRange::External with the ref +
+    /// clamped range; persist did NOT fetch anything (the URI is a
+    /// non-resolvable placeholder — no network access happens).
+    #[tokio::test]
+    async fn get_blob_range_external_returns_ref_without_fetch() {
+        let backend = blob_test_backend().await;
+        let ext = ExternalRef {
+            uri: "s3://my-bucket/path/to/object".into(),
+            size_bytes: 1000,
+            media_type: Some("video/mp4".into()),
+        };
+        let sha = [0x55u8; 32];
+        backend
+            .put_blob(
+                &sha,
+                BlobBody::External(ext.clone()),
+                Some("video/mp4"),
+                blob_attestation("host-a", "host-a", &uuid::Uuid::new_v4().to_string()),
+            )
+            .await
+            .unwrap();
+        // request [100..=99999] — clamps end to size-1 = 999.
+        let got = backend
+            .get_blob_range(&sha, 100, 99_999)
+            .await
+            .unwrap()
+            .unwrap();
+        match got {
+            BlobRange::External {
+                external_ref,
+                range_start,
+                range_end_inclusive,
+            } => {
+                assert_eq!(external_ref, ext);
+                assert_eq!(range_start, 100);
+                assert_eq!(range_end_inclusive, 999);
+            }
+            other => panic!("expected BlobRange::External, got {other:?}"),
+        }
     }
 
     /// Admission ordering test — trust rejection beats inline-size


### PR DESCRIPTION
**Cut A of the streaming substrate** ([`FSD/V4_1_STREAMING_SUBSTRATE.md`](FSD/V4_1_STREAMING_SUBSTRATE.md) §4.1; CIRISPersist#142). Pure-additive — no schema, no migration, no CEG change. The byte-range seam every later streaming cut builds on, and immediately useful for ranged reads over existing media.

## What it adds
- `BlobStorage::get_blob_range(sha256, range_start, range_end_inclusive) -> Option<BlobRange>` — RFC 9110 §14.4 range semantics, both backends.
- `BlobRange::{ Inline(Vec<u8>), External { external_ref, range_start, range_end_inclusive } }`.
- `BlobError::RangeNotSatisfiable { range_start, size }`.
- PyO3 `get_blob_range(sha256_hex, start, end_inclusive)` — `PyBytes` for inline, ref+range dict for external.

## Invariant respected
**Persist never dereferences External URIs.** `get_blob_range` serves bytes only for `Inline` (server-side `substr`/`substring` — no full-buffer load); for `External` it returns the ref + clamped range for the *caller* to fetch. Zero network calls from persist.

## Bounds (uniform both backends)
`start > end` → `InvalidArgument`; absent → `None`; `start >= size` → `RangeNotSatisfiable`; else `end` clamped to `size-1`, serve `[start..=end]`.

## Verification
- **650 lib tests** (+7 new range tests: mid-slice, full, tail-clamp, unsatisfiable, invalid, absent, external-no-fetch)
- Clean under `-D warnings`: `--no-default-features`, **`--features test-panic,pyo3`** (the no-backend combo that broke v4.0.0 — verified before ship this time), `--features sqlite`, and the full CI gated combo
- Backend parity: SQLite `substr` + Postgres `substring`, both server-side; PG tests gated on `CIRIS_PERSIST_TEST_PG_URL`

Next: Cut B (`BlobBody::ChunkDag`) builds on this; Cut C (live + epoch cascade) is the CEG-1.0 unblocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)