### PR TITLE
Streaming Cut B — BlobBody::ChunkDag + put_blob_chunks + chunked get_blob_range (#142)

### DIFF
--- a/migrations/postgres/lens/V061__federation_blobs_chunk_dag_storage_kind.sql
+++ b/migrations/postgres/lens/V061__federation_blobs_chunk_dag_storage_kind.sql
@@ -1,0 +1,53 @@
+-- V061 — admit 'chunk_dag' into federation_blobs.storage_kind, Postgres
+-- dialect (CIRISPersist#142, Cut B — BlobBody::ChunkDag).
+--
+-- Cut B adds a fourth storage_kind: 'chunk_dag'. The manifest (a
+-- JCS-canonical chunk list) is stored in `bytes_inline` exactly like an
+-- 'inline' body, and `external_ref` is NULL. V047 carries two CHECKs
+-- that close the door on this value:
+--
+--   * federation_blobs_storage_kind_check
+--       CHECK (storage_kind IN ('inline','s3','external_url'))
+--   * federation_blobs_storage_kind_columns_match
+--       CHECK ( (inline → bytes_inline present, external_ref NULL)
+--               OR (s3/external_url → bytes_inline NULL, external_ref present) )
+--
+-- Postgres supports in-place constraint swap (DROP + ADD), so this is
+-- the bounded half. Both CHECKs are dropped and re-added with the
+-- 'chunk_dag' arm. The chunk_dag arm mirrors the 'inline' body shape:
+-- bytes_inline IS NOT NULL AND external_ref IS NULL.
+--
+-- The SQLite sibling (sqlite/lens/V061) does the 12-step table rebuild
+-- because table-level CHECKs can't be ALTERed there.
+
+-- 1. storage_kind enum CHECK — admit 'chunk_dag'.
+ALTER TABLE cirislens.federation_blobs
+    DROP CONSTRAINT federation_blobs_storage_kind_check;
+
+ALTER TABLE cirislens.federation_blobs
+    ADD CONSTRAINT federation_blobs_storage_kind_check
+        CHECK (storage_kind IN ('inline', 's3', 'external_url', 'chunk_dag'));
+
+-- 2. Cross-column CHECK — add the chunk_dag arm (manifest in
+--    bytes_inline, like inline; external_ref NULL).
+ALTER TABLE cirislens.federation_blobs
+    DROP CONSTRAINT federation_blobs_storage_kind_columns_match;
+
+ALTER TABLE cirislens.federation_blobs
+    ADD CONSTRAINT federation_blobs_storage_kind_columns_match
+        CHECK (
+            (storage_kind = 'inline'
+                AND bytes_inline IS NOT NULL
+                AND external_ref IS NULL)
+            OR
+            (storage_kind = 'chunk_dag'
+                AND bytes_inline IS NOT NULL
+                AND external_ref IS NULL)
+            OR
+            (storage_kind IN ('s3', 'external_url')
+                AND bytes_inline IS NULL
+                AND external_ref IS NOT NULL)
+        );
+
+COMMENT ON COLUMN cirislens.federation_blobs.storage_kind IS
+    'How the bytes are stored: inline (bytes_inline) | s3 (external_ref) | external_url (external_ref) | chunk_dag (JCS manifest in bytes_inline; CIRISPersist#142 Cut B). First-write-wins on conflict — see put_blob doc.';

--- a/migrations/sqlite/lens/V061__federation_blobs_chunk_dag_storage_kind.sql
+++ b/migrations/sqlite/lens/V061__federation_blobs_chunk_dag_storage_kind.sql
@@ -1,0 +1,116 @@
+-- V061 — admit 'chunk_dag' into federation_blobs.storage_kind, SQLite
+-- dialect (CIRISPersist#142, Cut B — BlobBody::ChunkDag).
+--
+-- Mirrors postgres/lens/V061. Cut B adds a fourth storage_kind:
+-- 'chunk_dag' (the JCS manifest lives in `bytes_inline`, like 'inline').
+-- V047 baked TWO table-level CHECKs into CREATE TABLE:
+--   * the storage_kind enum     CHECK (storage_kind IN (...))
+--   * the cross-column rule      CHECK (inline → bytes_inline / s3,url → external_ref)
+--
+-- SQLite CANNOT `ALTER TABLE ... DROP CONSTRAINT` table-level CHECKs —
+-- they're part of the CREATE TABLE statement. So this is the standard
+-- 12-step table rebuild (mirrors V035 / V020):
+--
+--   1. PRAGMA defer_foreign_keys = ON
+--   2. CREATE TABLE federation_blobs_new with the extended CHECKs +
+--      ALL columns (incl. the V053 access-tracking columns
+--      last_accessed_at / access_count)
+--   3. INSERT INTO new (cols...) SELECT cols... FROM old  (preserve data)
+--   4. DROP TABLE old
+--   5. ALTER TABLE new RENAME TO federation_blobs
+--   6. Recreate ALL THREE indexes (V047 size_bytes + first_seen_at,
+--      V053 eviction_score)
+--
+-- No triggers exist on federation_blobs (verified: only V047 + V053
+-- touch it), so none to recreate. Refinery wraps each migration in its
+-- own transaction; defer_foreign_keys resets at COMMIT.
+
+PRAGMA defer_foreign_keys = ON;
+
+CREATE TABLE federation_blobs_new (
+    -- SHA-256 content hash (32 bytes raw).
+    sha256        BLOB PRIMARY KEY
+        CHECK (length(sha256) = 32),
+
+    -- 'inline' | 's3' | 'external_url' | 'chunk_dag'  (V061 adds chunk_dag).
+    storage_kind  TEXT NOT NULL
+        CHECK (storage_kind IN ('inline', 's3', 'external_url', 'chunk_dag')),
+
+    -- Inline body OR (V061) the JCS chunk-DAG manifest. Present iff
+    -- storage_kind in ('inline','chunk_dag').
+    bytes_inline  BLOB,
+
+    -- External URI/URL. Present iff storage_kind in ('s3','external_url').
+    external_ref  TEXT,
+
+    size_bytes    INTEGER NOT NULL CHECK (size_bytes >= 0),
+
+    media_type    TEXT,
+
+    first_seen_at TEXT NOT NULL DEFAULT (datetime('now', 'subsec')),
+
+    -- JSON array string. Empty array = no region-specific tracking.
+    regions_held  TEXT NOT NULL DEFAULT '[]',
+
+    -- V053 access-tracking columns (MUST survive the rebuild).
+    last_accessed_at TEXT NOT NULL
+        DEFAULT '1970-01-01T00:00:00+00:00',
+    access_count  INTEGER NOT NULL DEFAULT 0,
+
+    -- Cross-column rule, extended with the chunk_dag arm (manifest in
+    -- bytes_inline, like inline; external_ref NULL).
+    CHECK (
+        (storage_kind = 'inline'
+            AND bytes_inline IS NOT NULL
+            AND external_ref IS NULL)
+        OR
+        (storage_kind = 'chunk_dag'
+            AND bytes_inline IS NOT NULL
+            AND external_ref IS NULL)
+        OR
+        (storage_kind IN ('s3', 'external_url')
+            AND bytes_inline IS NULL
+            AND external_ref IS NOT NULL)
+    )
+);
+
+-- Preserve every existing row (column list is explicit so a future
+-- column-order drift can't silently misalign the copy).
+INSERT INTO federation_blobs_new (
+    sha256,
+    storage_kind,
+    bytes_inline,
+    external_ref,
+    size_bytes,
+    media_type,
+    first_seen_at,
+    regions_held,
+    last_accessed_at,
+    access_count
+)
+SELECT
+    sha256,
+    storage_kind,
+    bytes_inline,
+    external_ref,
+    size_bytes,
+    media_type,
+    first_seen_at,
+    regions_held,
+    last_accessed_at,
+    access_count
+FROM federation_blobs;
+
+DROP TABLE federation_blobs;
+
+ALTER TABLE federation_blobs_new RENAME TO federation_blobs;
+
+-- Recreate ALL indexes (V047 + V053).
+CREATE INDEX IF NOT EXISTS federation_blobs_size_bytes
+    ON federation_blobs (size_bytes);
+
+CREATE INDEX IF NOT EXISTS federation_blobs_first_seen_at
+    ON federation_blobs (first_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS federation_blobs_eviction_score
+    ON federation_blobs (last_accessed_at ASC, access_count ASC);

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -139,9 +139,148 @@ pub struct ExternalRef {
     pub media_type: Option<String>,
 }
 
+/// v4.1 (CIRISPersist#142, Cut B) — one chunk's content address + size
+/// in a [`ChunkManifest`]. Serialized inside the manifest as a
+/// JCS-canonical object `{"sha":"<lowercase-hex32>","size":<u32>}`.
+///
+/// The derived serde impl (used only because [`BlobBody`] derives serde)
+/// emits `sha` as a 32-element byte array — that path is NOT the wire
+/// format; the on-the-wire/at-rest manifest is the JCS shape produced by
+/// [`ChunkManifest::to_jcs_bytes`] (sha as lowercase hex).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkRef {
+    /// SHA-256 of the chunk's bytes. The chunk is its own
+    /// `federation_blobs` row keyed on this SHA.
+    pub sha: [u8; 32],
+    /// Byte length of the chunk.
+    pub size: u32,
+}
+
+/// v4.1 (CIRISPersist#142, Cut B) — a flat (one-level) content-addressed
+/// chunk DAG manifest. Stored in the manifest row's `bytes_inline` as
+/// **JCS-canonical JSON** (CEG §0.9); the row's `content_sha256` =
+/// SHA-256 over those canonical bytes, and the row's `size_bytes` =
+/// [`total_size`](ChunkManifest::total_size).
+///
+/// Wire shape (JCS — keys lexicographically sorted, no whitespace,
+/// `sha` as lowercase hex):
+///
+/// ```json
+/// {"chunks":[{"sha":"<hex32>","size":<u32>},…],"total_size":<u64>,"v":<u32>}
+/// ```
+///
+/// One-level DAG only (UnixFS flat-leaves; no nested DAGs). Each chunk
+/// is its own `federation_blobs` row (`Inline` or `External`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkManifest {
+    /// Manifest schema version (currently `1`).
+    pub v: u32,
+    /// Total byte size of the reassembled blob. MUST equal the sum of
+    /// every [`ChunkRef::size`].
+    pub total_size: u64,
+    /// The ordered chunk list. Concatenating each chunk's bytes in
+    /// order reproduces the original blob.
+    pub chunks: Vec<ChunkRef>,
+}
+
+/// v4.1 (CIRISPersist#142, Cut B) — current `ChunkManifest` schema
+/// version.
+pub const CHUNK_MANIFEST_VERSION: u32 = 1;
+
+impl ChunkManifest {
+    /// Serialize to **JCS-canonical JSON bytes** (CEG §0.9).
+    ///
+    /// The manifest shape is fully ASCII (top-level keys
+    /// `chunks`/`total_size`/`v`, per-chunk keys `sha`/`size`; values are
+    /// hex strings and non-negative integers), so the JCS rules collapse
+    /// to lexicographically-ordered object keys, no insignificant
+    /// whitespace, and plain-decimal integers. This is emitted directly
+    /// from the typed struct (no `serde_json::Value` hot path), so the
+    /// bytes are deterministic and the manifest's `content_sha256` is
+    /// stable.
+    pub fn to_jcs_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        // Top-level keys, lexicographically: "chunks" < "total_size" < "v".
+        buf.extend_from_slice(b"{\"chunks\":[");
+        for (i, c) in self.chunks.iter().enumerate() {
+            if i > 0 {
+                buf.push(b',');
+            }
+            // Per-chunk keys, lexicographically: "sha" < "size".
+            buf.extend_from_slice(b"{\"sha\":\"");
+            buf.extend_from_slice(hex::encode(c.sha).as_bytes());
+            buf.extend_from_slice(b"\",\"size\":");
+            buf.extend_from_slice(c.size.to_string().as_bytes());
+            buf.push(b'}');
+        }
+        buf.extend_from_slice(b"],\"total_size\":");
+        buf.extend_from_slice(self.total_size.to_string().as_bytes());
+        buf.extend_from_slice(b",\"v\":");
+        buf.extend_from_slice(self.v.to_string().as_bytes());
+        buf.push(b'}');
+        buf
+    }
+
+    /// Parse a manifest from its JCS-canonical JSON bytes (the inverse
+    /// of [`to_jcs_bytes`](ChunkManifest::to_jcs_bytes)). Tolerant of
+    /// key order on the way in (uses `serde_json` to parse), but the
+    /// round-trip through `to_jcs_bytes` re-canonicalizes on the way
+    /// out. Returns [`BlobError::Backend`] on malformed manifest bytes.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub(crate) fn from_manifest_bytes(bytes: &[u8]) -> Result<Self, BlobError> {
+        #[derive(Deserialize)]
+        struct ChunkRefWire {
+            sha: String,
+            size: u32,
+        }
+        #[derive(Deserialize)]
+        struct ManifestWire {
+            v: u32,
+            total_size: u64,
+            chunks: Vec<ChunkRefWire>,
+        }
+        let wire: ManifestWire = serde_json::from_slice(bytes)
+            .map_err(|e| BlobError::Backend(format!("chunk_dag manifest JSON parse: {e}")))?;
+        let mut chunks = Vec::with_capacity(wire.chunks.len());
+        for c in wire.chunks {
+            let raw = hex::decode(&c.sha).map_err(|e| {
+                BlobError::Backend(format!("chunk_dag manifest chunk sha hex: {e}"))
+            })?;
+            if raw.len() != 32 {
+                return Err(BlobError::Backend(format!(
+                    "chunk_dag manifest chunk sha is {} bytes, expected 32",
+                    raw.len()
+                )));
+            }
+            let mut sha = [0u8; 32];
+            sha.copy_from_slice(&raw);
+            chunks.push(ChunkRef { sha, size: c.size });
+        }
+        Ok(ChunkManifest {
+            v: wire.v,
+            total_size: wire.total_size,
+            chunks,
+        })
+    }
+
+    /// Validate internal consistency: `total_size` MUST equal the sum
+    /// of the chunk sizes (computed in u64 to avoid u32 overflow).
+    /// Returns [`BlobError::InvalidArgument`] on mismatch.
+    pub fn validate_total_size(&self) -> Result<(), BlobError> {
+        let sum: u64 = self.chunks.iter().map(|c| u64::from(c.size)).sum();
+        if sum != self.total_size {
+            return Err(BlobError::InvalidArgument(format!(
+                "chunk_dag manifest total_size {} != sum of chunk sizes {}",
+                self.total_size, sum
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// The body of a [`BlobStorage::put_blob`] / [`BlobStorage::get_blob`]
-/// payload — either the inline bytes themselves, or a pointer to an
-/// external store.
+/// payload — either the inline bytes themselves, a pointer to an
+/// external store, or (Cut B) a content-addressed chunk-DAG manifest.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BlobBody {
@@ -151,6 +290,11 @@ pub enum BlobBody {
     Inline(Vec<u8>),
     /// External reference (S3 URI or arbitrary URL).
     External(ExternalRef),
+    /// v4.1 (CIRISPersist#142, Cut B) — a flat content-addressed chunk
+    /// DAG. The wrapped [`ChunkManifest`] is stored JCS-canonical in the
+    /// manifest row's `bytes_inline`; each chunk is its own
+    /// `federation_blobs` row. `storage_kind` = `"chunk_dag"`.
+    ChunkDag(ChunkManifest),
 }
 
 /// v4.1 (CIRISPersist#142, Cut A) — the result of a
@@ -190,6 +334,9 @@ impl BlobBody {
         match self {
             BlobBody::Inline(b) => b.len() as u64,
             BlobBody::External(e) => e.size_bytes,
+            // v4.1 (Cut B) — the reassembled blob's size is the
+            // manifest's total_size, NOT the manifest-bytes length.
+            BlobBody::ChunkDag(m) => m.total_size,
         }
     }
 
@@ -200,6 +347,7 @@ impl BlobBody {
             BlobBody::Inline(_) => "inline",
             BlobBody::External(e) if e.uri.starts_with("s3://") => "s3",
             BlobBody::External(_) => "external_url",
+            BlobBody::ChunkDag(_) => "chunk_dag",
         }
     }
 }
@@ -285,12 +433,46 @@ pub trait BlobStorage: Send + Sync {
         media_type: Option<&str>,
     ) -> impl Future<Output = Result<(), BlobError>> + Send;
 
+    /// v4.1 (CIRISPersist#142, Cut B) — **atomic** chunked-blob upload.
+    ///
+    /// In ONE transaction, inserts:
+    /// - each chunk as a normal `federation_blobs` row (keyed on the
+    ///   chunk SHA; idempotent / first-write-wins on collision, exactly
+    ///   like [`store_blob_local`](BlobStorage::store_blob_local)); and
+    /// - the **manifest row** (`storage_kind = "chunk_dag"`,
+    ///   `bytes_inline` = the [`ChunkManifest`] JCS bytes,
+    ///   `content_sha256` = SHA-256 over those bytes, `size_bytes` =
+    ///   `manifest.total_size`).
+    ///
+    /// No `holds_bytes` attestation is emitted (this is the local-store
+    /// shape; Cut C / a later surface can wrap a signing variant).
+    ///
+    /// # Validation (all-or-nothing — any failure rolls back the txn)
+    ///
+    /// 1. `manifest.total_size` MUST equal the sum of the chunk sizes,
+    ///    else [`BlobError::InvalidArgument`].
+    /// 2. The `chunks` argument MUST line up 1:1 (by SHA, same order)
+    ///    with `manifest.chunks`, else [`BlobError::InvalidArgument`].
+    /// 3. For each `Inline` chunk: the bytes' SHA-256 MUST match its
+    ///    manifest entry's SHA, else [`BlobError::HashMismatch`]; its
+    ///    length MUST match the manifest entry's `size`, else
+    ///    [`BlobError::InvalidArgument`]. `External` chunks are trusted
+    ///    (persist has no bytes to hash), as in [`put_blob`].
+    /// 4. A nested `ChunkDag` chunk is rejected
+    ///    ([`BlobError::InvalidArgument`]) — one-level DAG only.
+    fn put_blob_chunks(
+        &self,
+        manifest: ChunkManifest,
+        chunks: Vec<([u8; 32], BlobBody)>,
+    ) -> impl Future<Output = Result<(), BlobError>> + Send;
+
     /// Read a blob by its SHA-256.
     ///
     /// Returns the [`BlobBody`] variant matching the row's stored
     /// `storage_kind`. Persist never fetches from S3 / external URLs;
     /// the External arm hands back the pointer and the caller streams
-    /// the bytes themselves.
+    /// the bytes themselves. A `chunk_dag` row returns
+    /// [`BlobBody::ChunkDag`] with the parsed manifest.
     fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -844,6 +1026,23 @@ pub enum BlobError {
         size: u64,
     },
 
+    /// v4.1 (CIRISPersist#142, Cut B) — a
+    /// [`get_blob_range`](BlobStorage::get_blob_range) over a
+    /// [`BlobBody::ChunkDag`] where a chunk covering the requested range
+    /// is stored `External` (S3 / URL). Persist cannot dereference an
+    /// external chunk to slice it, so the range read fails fast with the
+    /// offending chunk's SHA. **v-next enhancement**: a future cut may
+    /// proxy the upstream `Range:` for the covering external chunk; for
+    /// now the caller must fetch the external chunk(s) itself.
+    #[error(
+        "range spans an External chunk (sha256={chunk_sha_hex}); persist cannot \
+         dereference it — fetch the chunk from its external ref directly"
+    )]
+    RangeSpansExternalChunk {
+        /// Hex-encoded SHA-256 of the covering chunk that is External.
+        chunk_sha_hex: String,
+    },
+
     /// Backend-level error (DB connection, serialization, etc.).
     #[error("backend: {0}")]
     Backend(String),
@@ -861,6 +1060,7 @@ impl BlobError {
             BlobError::TrustBelowThreshold { .. } => "blob_trust_below_threshold",
             BlobError::HashMatchedKnownBad { .. } => "blob_hash_matched_known_bad",
             BlobError::RangeNotSatisfiable { .. } => "blob_range_not_satisfiable",
+            BlobError::RangeSpansExternalChunk { .. } => "blob_range_spans_external_chunk",
             BlobError::Backend(_) => "blob_backend",
         }
     }
@@ -1005,6 +1205,234 @@ pub(crate) fn verify_inline_hash(expected: &[u8; 32], bytes: &[u8]) -> Result<()
     }
 }
 
+/// v4.1 (CIRISPersist#142, Cut B) — walk a [`ChunkManifest`] to
+/// assemble the bytes covering the inclusive range `[start, end]`
+/// (already clamped to `[0, total_size - 1]` by the caller).
+///
+/// Prefix-sums the chunk sizes to find the covering chunk(s), fetches
+/// each covering chunk's bytes via [`BlobStorage::get_blob`] (which must
+/// return an `Inline` body — persist cannot dereference an `External`
+/// chunk, so that yields [`BlobError::RangeSpansExternalChunk`]), slices
+/// each at the range boundaries, and concatenates.
+///
+/// Per-chunk SHA is re-verified on read (CEG §10.1.1 — full SHA before
+/// consumption at both the manifest and chunk levels).
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) async fn assemble_chunk_dag_range<S: BlobStorage + ?Sized>(
+    storage: &S,
+    manifest: &ChunkManifest,
+    start: u64,
+    end: u64,
+) -> Result<Vec<u8>, BlobError> {
+    use sha2::{Digest, Sha256};
+
+    debug_assert!(start <= end);
+    let want_len = (end - start + 1) as usize;
+    let mut out: Vec<u8> = Vec::with_capacity(want_len);
+
+    // Running byte offset of the START of the current chunk.
+    let mut chunk_start: u64 = 0;
+    for cref in &manifest.chunks {
+        let chunk_len = u64::from(cref.size);
+        if chunk_len == 0 {
+            continue;
+        }
+        let chunk_end = chunk_start + chunk_len - 1; // inclusive
+                                                     // Does this chunk overlap [start, end]?
+        if chunk_end < start {
+            chunk_start = chunk_end + 1;
+            continue;
+        }
+        if chunk_start > end {
+            break; // past the requested range
+        }
+        // Fetch the covering chunk's bytes. Persist cannot deref an
+        // External chunk → typed error (v-next enhancement).
+        let body = storage.get_blob(&cref.sha).await?;
+        let bytes = match body {
+            Some(BlobBody::Inline(b)) => b,
+            Some(BlobBody::External(_)) => {
+                return Err(BlobError::RangeSpansExternalChunk {
+                    chunk_sha_hex: hex::encode(cref.sha),
+                });
+            }
+            Some(BlobBody::ChunkDag(_)) => {
+                // One-level DAG only; a chunk that is itself a DAG is a
+                // corrupt manifest.
+                return Err(BlobError::Backend(format!(
+                    "chunk_dag covering chunk {} is itself a ChunkDag (nested DAG)",
+                    hex::encode(cref.sha)
+                )));
+            }
+            None => {
+                return Err(BlobError::Backend(format!(
+                    "chunk_dag covering chunk {} is missing from federation_blobs",
+                    hex::encode(cref.sha)
+                )));
+            }
+        };
+        // CEG §10.1.1 — verify the chunk SHA before consumption.
+        let computed = Sha256::digest(&bytes);
+        if computed.as_slice() != cref.sha.as_slice() {
+            return Err(BlobError::HashMismatch {
+                expected_hex: hex::encode(cref.sha),
+                got_hex: hex::encode(computed),
+            });
+        }
+        if bytes.len() as u64 != chunk_len {
+            return Err(BlobError::Backend(format!(
+                "chunk_dag chunk {} is {} bytes but manifest size is {}",
+                hex::encode(cref.sha),
+                bytes.len(),
+                chunk_len
+            )));
+        }
+        // Slice the overlap of [start, end] with this chunk, in
+        // chunk-local coordinates.
+        let local_start = start.saturating_sub(chunk_start);
+        let local_end_inclusive = if end >= chunk_end {
+            chunk_len - 1
+        } else {
+            end - chunk_start
+        };
+        out.extend_from_slice(&bytes[local_start as usize..=local_end_inclusive as usize]);
+
+        chunk_start = chunk_end + 1;
+    }
+
+    Ok(out)
+}
+
+/// v4.1 (CIRISPersist#142, Cut B) — a single row prepared for the
+/// `put_blob_chunks` atomic insert. Backend-agnostic: the backend's
+/// transaction loop binds these directly.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+#[derive(Debug)]
+pub(crate) struct PreparedBlobRow {
+    /// SHA-256 (32 raw bytes) — the `sha256` PK.
+    pub sha256: [u8; 32],
+    /// `storage_kind` column value.
+    pub storage_kind: &'static str,
+    /// `bytes_inline` column value (present for inline / chunk_dag).
+    pub bytes_inline: Option<Vec<u8>>,
+    /// `external_ref` column value (present for s3 / external_url).
+    pub external_ref: Option<String>,
+    /// `size_bytes` column value (already range-checked to fit i64).
+    pub size_bytes: i64,
+}
+
+/// v4.1 (CIRISPersist#142, Cut B) — validate a `put_blob_chunks`
+/// request and produce the ordered list of rows to insert in one txn
+/// (the N chunk rows followed by the manifest row last).
+///
+/// Validation order: nested-DAG reject → total_size → chunk alignment →
+/// per-Inline-chunk SHA + size → i64 range. Returns the prepared rows
+/// (chunks first, manifest last) plus the manifest's `content_sha256`.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) fn prepare_chunk_rows(
+    manifest: &ChunkManifest,
+    chunks: &[([u8; 32], BlobBody)],
+    inline_bytes_cap: usize,
+) -> Result<Vec<PreparedBlobRow>, BlobError> {
+    use sha2::{Digest, Sha256};
+
+    // 1. total_size == sum(chunk sizes).
+    manifest.validate_total_size()?;
+
+    // 2. The chunks argument lines up 1:1 (by SHA, same order) with the
+    //    manifest's chunk list.
+    if chunks.len() != manifest.chunks.len() {
+        return Err(BlobError::InvalidArgument(format!(
+            "put_blob_chunks: {} chunk bodies supplied but manifest names {} chunks",
+            chunks.len(),
+            manifest.chunks.len()
+        )));
+    }
+
+    let mut rows: Vec<PreparedBlobRow> = Vec::with_capacity(chunks.len() + 1);
+    for (idx, ((chunk_sha, body), mref)) in chunks.iter().zip(manifest.chunks.iter()).enumerate() {
+        if chunk_sha != &mref.sha {
+            return Err(BlobError::InvalidArgument(format!(
+                "put_blob_chunks: chunk[{idx}] sha {} does not match manifest entry {}",
+                hex::encode(chunk_sha),
+                hex::encode(mref.sha)
+            )));
+        }
+        let (storage_kind, bytes_inline, external_ref, size) = match body {
+            BlobBody::Inline(bytes) => {
+                if bytes.len() > inline_bytes_cap {
+                    return Err(BlobError::InlineSizeExceeded {
+                        size: bytes.len(),
+                        cap: inline_bytes_cap,
+                    });
+                }
+                // Verify the chunk bytes hash to the manifest entry SHA.
+                let computed = Sha256::digest(bytes);
+                if computed.as_slice() != mref.sha.as_slice() {
+                    return Err(BlobError::HashMismatch {
+                        expected_hex: hex::encode(mref.sha),
+                        got_hex: hex::encode(computed),
+                    });
+                }
+                // And the chunk length matches the manifest size.
+                if bytes.len() as u64 != u64::from(mref.size) {
+                    return Err(BlobError::InvalidArgument(format!(
+                        "put_blob_chunks: chunk[{idx}] is {} bytes but manifest size is {}",
+                        bytes.len(),
+                        mref.size
+                    )));
+                }
+                ("inline", Some(bytes.clone()), None, u64::from(mref.size))
+            }
+            BlobBody::External(e) => {
+                let kind = body.storage_kind();
+                (kind, None, Some(e.uri.clone()), e.size_bytes)
+            }
+            BlobBody::ChunkDag(_) => {
+                return Err(BlobError::InvalidArgument(format!(
+                    "put_blob_chunks: chunk[{idx}] is itself a ChunkDag — \
+                     one-level DAG only (no nesting)"
+                )));
+            }
+        };
+        let size_bytes = i64::try_from(size).map_err(|_| {
+            BlobError::InvalidArgument("put_blob_chunks: chunk size_bytes exceeds i64".into())
+        })?;
+        rows.push(PreparedBlobRow {
+            sha256: *chunk_sha,
+            storage_kind,
+            bytes_inline,
+            external_ref,
+            size_bytes,
+        });
+    }
+
+    // The manifest row last (so a covering chunk always exists before
+    // the manifest references it within the same txn — not strictly
+    // required for correctness given the single txn, but it keeps the
+    // insert order intuitive).
+    let manifest_bytes = manifest.to_jcs_bytes();
+    if manifest_bytes.len() > inline_bytes_cap {
+        return Err(BlobError::InlineSizeExceeded {
+            size: manifest_bytes.len(),
+            cap: inline_bytes_cap,
+        });
+    }
+    let manifest_sha: [u8; 32] = Sha256::digest(&manifest_bytes).into();
+    let manifest_size = i64::try_from(manifest.total_size).map_err(|_| {
+        BlobError::InvalidArgument("put_blob_chunks: total_size exceeds i64".into())
+    })?;
+    rows.push(PreparedBlobRow {
+        sha256: manifest_sha,
+        storage_kind: "chunk_dag",
+        bytes_inline: Some(manifest_bytes),
+        external_ref: None,
+        size_bytes: manifest_size,
+    });
+
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1030,6 +1458,133 @@ mod tests {
         assert_eq!(refs[0], hex::encode(sha));
     }
 
+    // ── v4.1 (CIRISPersist#142, Cut B) — ChunkManifest JCS ──────────
+
+    fn sha_of(bytes: &[u8]) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        Sha256::digest(bytes).into()
+    }
+
+    #[test]
+    fn chunk_manifest_jcs_is_canonical() {
+        let c0 = sha_of(b"chunk-zero");
+        let c1 = sha_of(b"chunk-one");
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 19,
+            chunks: vec![
+                ChunkRef { sha: c0, size: 10 },
+                ChunkRef { sha: c1, size: 9 },
+            ],
+        };
+        let bytes = manifest.to_jcs_bytes();
+        let s = String::from_utf8(bytes).unwrap();
+        // Keys lexicographically sorted, no whitespace, sha lowercase hex.
+        let expected = format!(
+            "{{\"chunks\":[{{\"sha\":\"{}\",\"size\":10}},{{\"sha\":\"{}\",\"size\":9}}],\"total_size\":19,\"v\":1}}",
+            hex::encode(c0),
+            hex::encode(c1)
+        );
+        assert_eq!(s, expected);
+        // The hex is lowercase.
+        assert!(!s.chars().any(|ch| ch.is_ascii_uppercase()));
+    }
+
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    #[test]
+    fn chunk_manifest_round_trips_through_bytes() {
+        let c0 = sha_of(b"a");
+        let c1 = sha_of(b"bb");
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 3,
+            chunks: vec![ChunkRef { sha: c0, size: 1 }, ChunkRef { sha: c1, size: 2 }],
+        };
+        let bytes = manifest.to_jcs_bytes();
+        let parsed = ChunkManifest::from_manifest_bytes(&bytes).unwrap();
+        assert_eq!(parsed, manifest);
+    }
+
+    #[test]
+    fn chunk_manifest_validate_total_size() {
+        let m_ok = ChunkManifest {
+            v: 1,
+            total_size: 5,
+            chunks: vec![
+                ChunkRef {
+                    sha: [0; 32],
+                    size: 2,
+                },
+                ChunkRef {
+                    sha: [1; 32],
+                    size: 3,
+                },
+            ],
+        };
+        m_ok.validate_total_size().unwrap();
+
+        let m_bad = ChunkManifest {
+            total_size: 6,
+            ..m_ok
+        };
+        let err = m_bad.validate_total_size().unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    #[test]
+    fn prepare_chunk_rows_rejects_sha_mismatch() {
+        // Manifest claims a chunk sha that the inline bytes don't hash to.
+        let real = sha_of(b"real");
+        let fake = [0xAB; 32];
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 4,
+            chunks: vec![ChunkRef { sha: fake, size: 4 }],
+        };
+        let chunks = vec![(fake, BlobBody::Inline(b"real".to_vec()))];
+        // chunk[0] sha == manifest sha (fake) so alignment passes, but the
+        // bytes hash to `real` != fake → HashMismatch.
+        let _ = real;
+        let err = prepare_chunk_rows(&manifest, &chunks, DEFAULT_INLINE_BYTES_CAP).unwrap_err();
+        assert!(matches!(err, BlobError::HashMismatch { .. }));
+    }
+
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    #[test]
+    fn prepare_chunk_rows_rejects_total_size_mismatch() {
+        let c = sha_of(b"abcd");
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 99, // wrong
+            chunks: vec![ChunkRef { sha: c, size: 4 }],
+        };
+        let chunks = vec![(c, BlobBody::Inline(b"abcd".to_vec()))];
+        let err = prepare_chunk_rows(&manifest, &chunks, DEFAULT_INLINE_BYTES_CAP).unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    #[test]
+    fn prepare_chunk_rows_manifest_row_is_last_and_chunk_dag() {
+        let c = sha_of(b"xyz");
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 3,
+            chunks: vec![ChunkRef { sha: c, size: 3 }],
+        };
+        let chunks = vec![(c, BlobBody::Inline(b"xyz".to_vec()))];
+        let rows = prepare_chunk_rows(&manifest, &chunks, DEFAULT_INLINE_BYTES_CAP).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].storage_kind, "inline");
+        assert_eq!(rows[0].sha256, c);
+        // Manifest row last: storage_kind chunk_dag, sha = SHA(manifest jcs).
+        assert_eq!(rows[1].storage_kind, "chunk_dag");
+        let expect_manifest_sha = sha_of(&manifest.to_jcs_bytes());
+        assert_eq!(rows[1].sha256, expect_manifest_sha);
+        assert_eq!(rows[1].size_bytes, 3);
+    }
+
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
     #[test]
     fn body_storage_kind_strings() {
@@ -1052,6 +1607,19 @@ mod tests {
             .storage_kind(),
             "external_url"
         );
+        // v4.1 (Cut B) — chunk_dag storage_kind + size_bytes = total_size.
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: 42,
+            chunks: vec![ChunkRef {
+                sha: [0; 32],
+                size: 42,
+            }],
+        };
+        let body = BlobBody::ChunkDag(manifest);
+        assert_eq!(body.storage_kind(), "chunk_dag");
+        assert_eq!(body.size_bytes(), 42);
+        assert!(!body.is_inline());
     }
 
     #[cfg(any(feature = "postgres", feature = "sqlite"))]

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -85,8 +85,9 @@ pub use admission::{
 pub use blackhole::{BlackholeRecord, BlackholeRules, RETICULUM_IDENTITY_HASH_LEN};
 pub use blobs::{
     holds_bytes_attestation_envelope, holds_bytes_attestation_type, BlobBody, BlobError, BlobRange,
-    BlobStorage, EvictActorReport, ExternalRef, PutBlobAttestation, DEFAULT_INLINE_BYTES_CAP,
-    HOLDS_BYTES_ATTESTATION_TYPE_PREFIX, HOLDS_BYTES_PREFIX_HEX_LEN,
+    BlobStorage, ChunkManifest, ChunkRef, EvictActorReport, ExternalRef, PutBlobAttestation,
+    CHUNK_MANIFEST_VERSION, DEFAULT_INLINE_BYTES_CAP, HOLDS_BYTES_ATTESTATION_TYPE_PREFIX,
+    HOLDS_BYTES_PREFIX_HEX_LEN,
 };
 pub use goal::{
     canonicalize_goal_text, DeliberationRef, Goal, GoalScope, GoalsFilter, M1Dimension,

--- a/src/federation/schema_resolver.rs
+++ b/src/federation/schema_resolver.rs
@@ -297,7 +297,10 @@ impl<B: BlobStorage + 'static> SchemaResolver for BlobBackedSchemaResolver<B> {
             })?;
             let bytes = match body {
                 Some(BlobBody::Inline(b)) => b,
-                Some(BlobBody::External(_)) | None => {
+                // External + ChunkDag schema bodies aren't directly
+                // available as inline bytes here (persist doesn't
+                // dereference / reassemble for the schema-resolve path).
+                Some(BlobBody::External(_)) | Some(BlobBody::ChunkDag(_)) | None => {
                     return Err(SchemaResolverError::SchemaBlobMissing {
                         axis: axis.to_string(),
                         sha256_hex: hex::encode(sha256),

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4166,6 +4166,47 @@ impl PyEngine {
         })
     }
 
+    /// v4.1 (CIRISPersist#142, Cut B) — atomic chunked-blob upload.
+    ///
+    /// Inserts each chunk row + the chunk_dag manifest row in ONE
+    /// transaction. The manifest's `content_sha256` (the SHA over its
+    /// JCS bytes) is the address `get_blob_json` / `get_blob_range`
+    /// resolve. Payload shape:
+    /// `{"manifest": {"v":1,"total_size":N,"chunks":[{"sha":"<hex>",
+    /// "size":M},…]}, "chunks":[{"sha":"<hex>","body":{"inline":"<b64>"}|
+    /// {"external":{…}}},…]}`. Raises `ValueError` on SHA mismatch,
+    /// total_size mismatch, or chunk/manifest misalignment.
+    fn put_blob_chunks_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let (manifest, chunks) = parse_put_blob_chunks_payload(payload_json)?;
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_blob_chunks(manifest, chunks)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_blob_chunks(manifest, chunks)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
     /// v3.11.0 (CIRISPersist#143, CIRISVerify FEDERATION_THREAT_MODEL
     /// §3.3.2) — verify-coord R1+Q1 constants as a JSON dict for
     /// consumer code that needs to pin τ_normal / τ_partial /
@@ -18006,6 +18047,9 @@ fn blob_err_to_py(e: crate::federation::BlobError) -> PyErr {
         crate::federation::BlobError::HashMatchedKnownBad { .. } => PyValueError::new_err(kind),
         // v4.1 (CIRISPersist#142, Cut A) — unsatisfiable byte range.
         crate::federation::BlobError::RangeNotSatisfiable { .. } => PyValueError::new_err(kind),
+        // v4.1 (CIRISPersist#142, Cut B) — range over a chunk DAG whose
+        // covering chunk is External (persist can't deref).
+        crate::federation::BlobError::RangeSpansExternalChunk { .. } => PyValueError::new_err(kind),
         crate::federation::BlobError::Backend(_) => PyRuntimeError::new_err(kind),
     }
 }
@@ -18133,6 +18177,79 @@ fn parse_store_blob_local_payload(
     Ok((sha, body, wire.media_type))
 }
 
+/// v4.1 (CIRISPersist#142, Cut B) — wire shape for `put_blob_chunks_json`.
+///
+/// ```json
+/// {
+///   "manifest": {"v":1, "total_size":N, "chunks":[{"sha":"<hex>","size":M}, …]},
+///   "chunks":   [{"sha":"<hex>", "body":{"inline":"<b64>"}|{"external":{…}}}, …]
+/// }
+/// ```
+#[derive(serde::Deserialize)]
+struct ChunkRefWire {
+    sha: String,
+    size: u32,
+}
+
+#[derive(serde::Deserialize)]
+struct ChunkManifestWire {
+    v: u32,
+    total_size: u64,
+    chunks: Vec<ChunkRefWire>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChunkBodyWire {
+    sha: String,
+    body: PutBlobWireBody,
+}
+
+#[derive(serde::Deserialize)]
+struct PutBlobChunksJsonWire {
+    manifest: ChunkManifestWire,
+    chunks: Vec<ChunkBodyWire>,
+}
+
+/// v4.1 (CIRISPersist#142, Cut B) — decode the `put_blob_chunks_json`
+/// payload into the trait-call argument shape.
+#[allow(clippy::type_complexity)]
+fn parse_put_blob_chunks_payload(
+    json: &str,
+) -> PyResult<(
+    crate::federation::ChunkManifest,
+    Vec<([u8; 32], crate::federation::BlobBody)>,
+)> {
+    let wire: PutBlobChunksJsonWire = serde_json::from_str(json)
+        .map_err(|e| PyValueError::new_err(format!("put_blob_chunks_json decode: {e}")))?;
+    let mut mrefs = Vec::with_capacity(wire.manifest.chunks.len());
+    for c in wire.manifest.chunks {
+        let sha = parse_sha256_hex(&c.sha)?;
+        mrefs.push(crate::federation::ChunkRef { sha, size: c.size });
+    }
+    let manifest = crate::federation::ChunkManifest {
+        v: wire.manifest.v,
+        total_size: wire.manifest.total_size,
+        chunks: mrefs,
+    };
+    let mut chunks = Vec::with_capacity(wire.chunks.len());
+    for c in wire.chunks {
+        let sha = parse_sha256_hex(&c.sha)?;
+        let body = match c.body {
+            PutBlobWireBody::Inline(b64) => {
+                use base64::engine::general_purpose::STANDARD as B64;
+                use base64::Engine as _;
+                let bytes = B64.decode(&b64).map_err(|e| {
+                    PyValueError::new_err(format!("put_blob_chunks_json inline base64 decode: {e}"))
+                })?;
+                crate::federation::BlobBody::Inline(bytes)
+            }
+            PutBlobWireBody::External(e) => crate::federation::BlobBody::External(e),
+        };
+        chunks.push((sha, body));
+    }
+    Ok((manifest, chunks))
+}
+
 /// v2.3 (CIRISPersist#103) — parse a 64-char hex string into a
 /// `[u8; 32]` SHA-256.
 fn parse_sha256_hex(hex_str: &str) -> PyResult<[u8; 32]> {
@@ -18162,6 +18279,23 @@ fn encode_blob_body_json(body: &crate::federation::BlobBody) -> PyResult<String>
         crate::federation::BlobBody::External(ext) => serde_json::json!({
             "external": ext,
         }),
+        // v4.1 (CIRISPersist#142, Cut B) — surface the parsed manifest
+        // (`{"chunk_dag": {"v":.., "total_size":.., "chunks":[{"sha":
+        // "<hex>", "size":..}, ..]}}`) so the Python caller can walk it.
+        crate::federation::BlobBody::ChunkDag(manifest) => {
+            let chunks: Vec<serde_json::Value> = manifest
+                .chunks
+                .iter()
+                .map(|c| serde_json::json!({ "sha": hex::encode(c.sha), "size": c.size }))
+                .collect();
+            serde_json::json!({
+                "chunk_dag": {
+                    "v": manifest.v,
+                    "total_size": manifest.total_size,
+                    "chunks": chunks,
+                }
+            })
+        }
     };
     serde_json::to_string(&value)
         .map_err(|e| PyRuntimeError::new_err(format!("BlobBody JSON encode: {e}")))

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3495,6 +3495,13 @@ impl crate::federation::BlobStorage for PostgresBackend {
         if let Some(gate) = self.admission_gate() {
             gate.check_blob(&attestation.attesting_key_id).await?;
         }
+        // v4.1 (Cut B) — a ChunkDag body is a multi-row manifest; it
+        // only ever goes through put_blob_chunks.
+        if matches!(body, crate::federation::BlobBody::ChunkDag(_)) {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "put_blob does not accept a ChunkDag body — use put_blob_chunks".into(),
+            ));
+        }
         let cap = self.inline_bytes_cap();
         if let crate::federation::BlobBody::Inline(ref bytes) = body {
             if bytes.len() > cap {
@@ -3526,6 +3533,12 @@ impl crate::federation::BlobStorage for PostgresBackend {
         let (bytes_inline_opt, external_ref_opt) = match &body {
             crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
             crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+            // Rejected above; matched here only for exhaustiveness.
+            crate::federation::BlobBody::ChunkDag(_) => {
+                return Err(crate::federation::BlobError::InvalidArgument(
+                    "put_blob does not accept a ChunkDag body — use put_blob_chunks".into(),
+                ))
+            }
         };
 
         // 3. Compose the holder attestation envelope. Attestation type
@@ -3671,6 +3684,13 @@ impl crate::federation::BlobStorage for PostgresBackend {
         body: crate::federation::BlobBody,
         media_type: Option<&str>,
     ) -> Result<(), crate::federation::BlobError> {
+        // v4.1 (Cut B) — ChunkDag is a multi-row manifest; routed through
+        // put_blob_chunks, never store_blob_local.
+        if matches!(body, crate::federation::BlobBody::ChunkDag(_)) {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "store_blob_local does not accept a ChunkDag body — use put_blob_chunks".into(),
+            ));
+        }
         let cap = self.inline_bytes_cap();
         if let crate::federation::BlobBody::Inline(ref bytes) = body {
             if bytes.len() > cap {
@@ -3690,6 +3710,11 @@ impl crate::federation::BlobStorage for PostgresBackend {
         let (bytes_inline_opt, external_ref_opt) = match &body {
             crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
             crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+            crate::federation::BlobBody::ChunkDag(_) => {
+                return Err(crate::federation::BlobError::InvalidArgument(
+                    "store_blob_local does not accept a ChunkDag body — use put_blob_chunks".into(),
+                ))
+            }
         };
         let client = self
             .get_client()
@@ -3715,6 +3740,56 @@ impl crate::federation::BlobStorage for PostgresBackend {
             .map_err(|e| {
                 crate::federation::BlobError::Backend(format!("store_blob_local insert: {e}"))
             })?;
+        Ok(())
+    }
+
+    // v4.1 (CIRISPersist#142, Cut B) — atomic chunked-blob upload.
+    // Validates the manifest + every chunk (per-Inline-chunk SHA + size,
+    // total_size == sum, 1:1 alignment), then inserts the N chunk rows +
+    // the chunk_dag manifest row in ONE transaction (all-or-nothing).
+    async fn put_blob_chunks(
+        &self,
+        manifest: crate::federation::ChunkManifest,
+        chunks: Vec<([u8; 32], crate::federation::BlobBody)>,
+    ) -> Result<(), crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        // Validation + row preparation (chunks first, manifest last).
+        let rows = crate::federation::blobs::prepare_chunk_rows(&manifest, &chunks, cap)?;
+
+        let mut client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(format!("begin tx: {e}")))?;
+        for row in &rows {
+            let sha_vec = row.sha256.to_vec();
+            // media_type is NULL for chunk rows + the manifest row.
+            let media_type_null: Option<String> = None;
+            tx.execute(
+                "INSERT INTO cirislens.federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type\
+                 ) VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (sha256) DO NOTHING",
+                &[
+                    &sha_vec,
+                    &row.storage_kind,
+                    &row.bytes_inline,
+                    &row.external_ref,
+                    &row.size_bytes,
+                    &media_type_null,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_blob_chunks insert: {e}"))
+            })?;
+        }
+        tx.commit().await.map_err(|e| {
+            crate::federation::BlobError::Backend(format!("put_blob_chunks commit: {e}"))
+        })?;
         Ok(())
     }
 
@@ -3753,6 +3828,14 @@ impl crate::federation::BlobStorage for PostgresBackend {
                 let bytes: Vec<u8> =
                     row.safe_get_with("bytes_inline", crate::federation::BlobError::Backend)?;
                 Ok(Some(crate::federation::BlobBody::Inline(bytes)))
+            }
+            // v4.1 (Cut B) — parse the JCS manifest from bytes_inline.
+            "chunk_dag" => {
+                let manifest_bytes: Vec<u8> =
+                    row.safe_get_with("bytes_inline", crate::federation::BlobError::Backend)?;
+                let manifest =
+                    crate::federation::blobs::ChunkManifest::from_manifest_bytes(&manifest_bytes)?;
+                Ok(Some(crate::federation::BlobBody::ChunkDag(manifest)))
             }
             "s3" | "external_url" => {
                 let uri: String =
@@ -3863,6 +3946,33 @@ impl crate::federation::BlobStorage for PostgresBackend {
                 let slice: Vec<u8> =
                     slice_row.safe_get_with("slice", crate::federation::BlobError::Backend)?;
                 Ok(Some(crate::federation::BlobRange::Inline(slice)))
+            }
+            // v4.1 (Cut B) — chunk DAG: pull the manifest, walk the
+            // prefix-sum, fetch + slice the covering chunk(s).
+            "chunk_dag" => {
+                let manifest_row = client
+                    .query_one(
+                        "SELECT bytes_inline FROM cirislens.federation_blobs WHERE sha256 = $1",
+                        &[&sha_vec],
+                    )
+                    .await
+                    .map_err(|e| {
+                        crate::federation::BlobError::Backend(format!(
+                            "get_blob_range chunk_dag manifest fetch: {e}"
+                        ))
+                    })?;
+                let manifest_bytes: Vec<u8> = manifest_row
+                    .safe_get_with("bytes_inline", crate::federation::BlobError::Backend)?;
+                let manifest =
+                    crate::federation::blobs::ChunkManifest::from_manifest_bytes(&manifest_bytes)?;
+                let assembled = crate::federation::blobs::assemble_chunk_dag_range(
+                    self,
+                    &manifest,
+                    range_start,
+                    end,
+                )
+                .await?;
+                Ok(Some(crate::federation::BlobRange::Inline(assembled)))
             }
             "s3" | "external_url" => {
                 let uri: String =
@@ -16996,6 +17106,252 @@ mod tests {
             }
             other => panic!("expected BlobRange::External, got {other:?}"),
         }
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut B) — PG ChunkDag parity ────────
+
+    /// Build a 3-chunk inline manifest with run-unique chunk bytes (the
+    /// PG test DB is shared, so the SHAs must not collide across runs).
+    #[allow(clippy::type_complexity)]
+    fn pg_three_chunk_manifest(
+        tag: &str,
+    ) -> (
+        crate::federation::ChunkManifest,
+        Vec<([u8; 32], crate::federation::BlobBody)>,
+        [u8; 32],
+    ) {
+        use crate::federation::{BlobBody, ChunkManifest, ChunkRef};
+        let salt = uuid_like();
+        let c0 = format!("{tag}-AAAA-{salt}").into_bytes();
+        let c1 = format!("{tag}-BBBB-{salt}").into_bytes();
+        let c2 = format!("{tag}-CC-{salt}").into_bytes();
+        let s0 = pg_sha256_of(&c0);
+        let s1 = pg_sha256_of(&c1);
+        let s2 = pg_sha256_of(&c2);
+        let total = (c0.len() + c1.len() + c2.len()) as u64;
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: total,
+            chunks: vec![
+                ChunkRef {
+                    sha: s0,
+                    size: c0.len() as u32,
+                },
+                ChunkRef {
+                    sha: s1,
+                    size: c1.len() as u32,
+                },
+                ChunkRef {
+                    sha: s2,
+                    size: c2.len() as u32,
+                },
+            ],
+        };
+        let manifest_sha = pg_sha256_of(&manifest.to_jcs_bytes());
+        let chunks = vec![
+            (s0, BlobBody::Inline(c0)),
+            (s1, BlobBody::Inline(c1)),
+            (s2, BlobBody::Inline(c2)),
+        ];
+        (manifest, chunks, manifest_sha)
+    }
+
+    /// put_blob_chunks round-trips a 3-chunk blob; get_blob returns the
+    /// manifest; get_blob_range assembles across + within a chunk.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_chunk_dag_round_trip_and_range() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobRange, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let (manifest, chunks, manifest_sha) = pg_three_chunk_manifest("dag-rt");
+        // Compute the assembled full bytes for the assertion.
+        let mut full = Vec::new();
+        for (_, b) in &chunks {
+            if let BlobBody::Inline(bytes) = b {
+                full.extend_from_slice(bytes);
+            }
+        }
+        let (c0_len, c1_len) = (
+            manifest.chunks[0].size as u64,
+            manifest.chunks[1].size as u64,
+        );
+        backend
+            .put_blob_chunks(manifest.clone(), chunks)
+            .await
+            .unwrap();
+
+        // get_blob returns the parsed manifest.
+        match backend.get_blob(&manifest_sha).await.unwrap().unwrap() {
+            BlobBody::ChunkDag(m) => assert_eq!(m, manifest),
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+
+        // Full range assembles the whole blob.
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, 0, manifest.total_size - 1)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(full.clone())
+        );
+
+        // A range spanning the chunk0/chunk1 boundary: last 2 of chunk0 +
+        // first 2 of chunk1.
+        let span_start = c0_len - 2;
+        let span_end = c0_len + 1; // 2 bytes into chunk1
+        let expect: Vec<u8> = full[span_start as usize..=span_end as usize].to_vec();
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, span_start, span_end)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(expect)
+        );
+
+        // A range entirely within chunk1.
+        let inner_start = c0_len + 1;
+        let inner_end = c0_len + c1_len - 2;
+        let expect_inner: Vec<u8> = full[inner_start as usize..=inner_end as usize].to_vec();
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, inner_start, inner_end)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(expect_inner)
+        );
+
+        // Cleanup (shared DB).
+        let _ = backend.delete_blob(&manifest_sha).await;
+        let _ = backend.delete_blob(&manifest.chunks[0].sha).await;
+        let _ = backend.delete_blob(&manifest.chunks[1].sha).await;
+        let _ = backend.delete_blob(&manifest.chunks[2].sha).await;
+    }
+
+    /// SHA-mismatch chunk rejected; total_size mismatch rejected.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_chunk_dag_rejects_bad_inputs() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        // SHA mismatch: corrupt chunk[0]'s bytes.
+        let (manifest, mut chunks, _) = pg_three_chunk_manifest("dag-bad-sha");
+        chunks[0].1 = BlobBody::Inline(b"corrupted-bytes".to_vec());
+        assert!(matches!(
+            backend
+                .put_blob_chunks(manifest.clone(), chunks)
+                .await
+                .unwrap_err(),
+            BlobError::HashMismatch { .. }
+        ));
+        // Atomicity: chunk[1] did not land.
+        assert!(!backend.has_blob(&manifest.chunks[1].sha).await.unwrap());
+
+        // total_size mismatch.
+        let (mut manifest2, chunks2, _) = pg_three_chunk_manifest("dag-bad-size");
+        manifest2.total_size += 1;
+        assert!(matches!(
+            backend
+                .put_blob_chunks(manifest2, chunks2)
+                .await
+                .unwrap_err(),
+            BlobError::InvalidArgument(_)
+        ));
+    }
+
+    /// A range spanning an External chunk → typed RangeSpansExternalChunk.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_chunk_dag_range_spans_external_chunk() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{
+            BlobBody, BlobError, BlobRange, BlobStorage, ChunkManifest, ChunkRef, ExternalRef,
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let salt = uuid_like();
+        let c0 = format!("ext-AAAA-{salt}").into_bytes();
+        let s0 = pg_sha256_of(&c0);
+        // A run-unique External chunk SHA.
+        let mut s_ext = [0u8; 32];
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        s_ext[..16].copy_from_slice(&nanos.to_be_bytes());
+        s_ext[16..].copy_from_slice(&nanos.to_be_bytes());
+        let manifest = ChunkManifest {
+            v: 1,
+            total_size: c0.len() as u64 + 100,
+            chunks: vec![
+                ChunkRef {
+                    sha: s0,
+                    size: c0.len() as u32,
+                },
+                ChunkRef {
+                    sha: s_ext,
+                    size: 100,
+                },
+            ],
+        };
+        let manifest_sha = pg_sha256_of(&manifest.to_jcs_bytes());
+        let chunks = vec![
+            (s0, BlobBody::Inline(c0.clone())),
+            (
+                s_ext,
+                BlobBody::External(ExternalRef {
+                    uri: format!("s3://bucket/{}", uuid_like()),
+                    size_bytes: 100,
+                    media_type: None,
+                }),
+            ),
+        ];
+        backend
+            .put_blob_chunks(manifest.clone(), chunks)
+            .await
+            .unwrap();
+
+        // Range inside chunk0 only → fine.
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, 0, (c0.len() - 1) as u64)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(c0.clone())
+        );
+        // Range reaching into the External chunk → typed error.
+        match backend
+            .get_blob_range(&manifest_sha, 0, c0.len() as u64 + 10)
+            .await
+            .unwrap_err()
+        {
+            BlobError::RangeSpansExternalChunk { chunk_sha_hex } => {
+                assert_eq!(chunk_sha_hex, hex::encode(s_ext));
+            }
+            other => panic!("expected RangeSpansExternalChunk, got {other:?}"),
+        }
+
+        // Cleanup.
+        let _ = backend.delete_blob(&manifest_sha).await;
+        let _ = backend.delete_blob(&s0).await;
+        let _ = backend.delete_blob(&s_ext).await;
     }
 
     // ─── v3.4.0 (CIRISPersist#123) — PG sweeper parity ─────────────

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3247,6 +3247,14 @@ impl crate::federation::BlobStorage for SqliteBackend {
         if let Some(gate) = self.admission_gate() {
             gate.check_blob(&attestation.attesting_key_id).await?;
         }
+        // v4.1 (Cut B) — a ChunkDag body is a multi-row manifest; it
+        // only ever goes through put_blob_chunks (which inserts the
+        // chunk rows + the manifest row atomically).
+        if matches!(body, crate::federation::BlobBody::ChunkDag(_)) {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "put_blob does not accept a ChunkDag body — use put_blob_chunks".into(),
+            ));
+        }
         let cap = self.inline_bytes_cap();
         if let crate::federation::BlobBody::Inline(ref bytes) = body {
             if bytes.len() > cap {
@@ -3274,6 +3282,12 @@ impl crate::federation::BlobStorage for SqliteBackend {
         let (bytes_inline_opt, external_ref_opt) = match &body {
             crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
             crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+            // Rejected above; matched here only for exhaustiveness.
+            crate::federation::BlobBody::ChunkDag(_) => {
+                return Err(crate::federation::BlobError::InvalidArgument(
+                    "put_blob does not accept a ChunkDag body — use put_blob_chunks".into(),
+                ))
+            }
         };
 
         // 2. Compose the holder attestation envelope.
@@ -3413,6 +3427,13 @@ impl crate::federation::BlobStorage for SqliteBackend {
             crate::federation::blobs::verify_inline_hash(sha256, bytes)?;
         }
 
+        // v4.1 (Cut B) — ChunkDag is a multi-row manifest; routed through
+        // put_blob_chunks, never store_blob_local.
+        if matches!(body, crate::federation::BlobBody::ChunkDag(_)) {
+            return Err(crate::federation::BlobError::InvalidArgument(
+                "store_blob_local does not accept a ChunkDag body — use put_blob_chunks".into(),
+            ));
+        }
         let storage_kind = body.storage_kind().to_owned();
         let size_bytes_i64 = i64::try_from(body.size_bytes()).map_err(|_| {
             crate::federation::BlobError::InvalidArgument(
@@ -3422,6 +3443,11 @@ impl crate::federation::BlobStorage for SqliteBackend {
         let (bytes_inline_opt, external_ref_opt) = match &body {
             crate::federation::BlobBody::Inline(b) => (Some(b.clone()), None),
             crate::federation::BlobBody::External(e) => (None, Some(e.uri.clone())),
+            crate::federation::BlobBody::ChunkDag(_) => {
+                return Err(crate::federation::BlobError::InvalidArgument(
+                    "store_blob_local does not accept a ChunkDag body — use put_blob_chunks".into(),
+                ))
+            }
         };
         let sha_vec = sha256.to_vec();
         let media_type_owned = media_type.map(str::to_owned);
@@ -3454,6 +3480,49 @@ impl crate::federation::BlobStorage for SqliteBackend {
         Ok(())
     }
 
+    // v4.1 (CIRISPersist#142, Cut B) — atomic chunked-blob upload.
+    // Validates the manifest + every chunk (per-Inline-chunk SHA + size,
+    // total_size == sum, 1:1 alignment), then inserts the N chunk rows +
+    // the chunk_dag manifest row in ONE transaction (all-or-nothing).
+    async fn put_blob_chunks(
+        &self,
+        manifest: crate::federation::ChunkManifest,
+        chunks: Vec<([u8; 32], crate::federation::BlobBody)>,
+    ) -> Result<(), crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        // Validation + row preparation (chunks first, manifest last).
+        let rows = crate::federation::blobs::prepare_chunk_rows(&manifest, &chunks, cap)?;
+
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction()?;
+            for row in &rows {
+                let sha_vec = row.sha256.to_vec();
+                tx.execute(
+                    "INSERT INTO federation_blobs (\
+                        sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type, \
+                        last_accessed_at, access_count\
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, 0) \
+                     ON CONFLICT (sha256) DO NOTHING",
+                    rusqlite::params![
+                        sha_vec,
+                        row.storage_kind,
+                        row.bytes_inline,
+                        row.external_ref,
+                        row.size_bytes,
+                        now_iso,
+                    ],
+                )?;
+            }
+            tx.commit()?;
+            Ok(())
+        })()
+        .map_err(|e| crate::federation::BlobError::Backend(format!("put_blob_chunks tx: {e}")))?;
+        Ok(())
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -3465,7 +3534,8 @@ impl crate::federation::BlobStorage for SqliteBackend {
         // shape; we do SELECT first, then bump in the same transaction
         // so the counter survives a concurrent get_blob.
         let now_iso = chrono::Utc::now().to_rfc3339();
-        (move || -> Result<Option<crate::federation::BlobBody>, rusqlite::Error> {
+        type GetBlobRow = (String, Option<Vec<u8>>, Option<String>, i64, Option<String>);
+        let row_opt = (move || -> Result<Option<GetBlobRow>, rusqlite::Error> {
             let mut conn = conn.lock();
             let tx = conn.transaction()?;
             let row_opt = tx
@@ -3497,18 +3567,29 @@ impl crate::federation::BlobStorage for SqliteBackend {
                 )?;
             }
             tx.commit()?;
-            Ok(
-                row_opt.map(|(kind, inline, ext, size, mt)| match kind.as_str() {
-                    "inline" => crate::federation::BlobBody::Inline(inline.unwrap_or_default()),
-                    _ => crate::federation::BlobBody::External(crate::federation::ExternalRef {
-                        uri: ext.unwrap_or_default(),
-                        size_bytes: size.max(0) as u64,
-                        media_type: mt,
-                    }),
-                }),
-            )
+            // chunk_dag is handled outside the closure (manifest parse
+            // returns a typed BlobError, not rusqlite::Error).
+            Ok(row_opt)
         })()
-        .map_err(|e| crate::federation::BlobError::Backend(format!("get_blob: {e}")))
+        .map_err(|e| crate::federation::BlobError::Backend(format!("get_blob: {e}")))?;
+        let Some((kind, inline, ext, size, mt)) = row_opt else {
+            return Ok(None);
+        };
+        Ok(Some(match kind.as_str() {
+            "inline" => crate::federation::BlobBody::Inline(inline.unwrap_or_default()),
+            // v4.1 (Cut B) — parse the JCS manifest stored in bytes_inline.
+            "chunk_dag" => {
+                let manifest = crate::federation::blobs::ChunkManifest::from_manifest_bytes(
+                    &inline.unwrap_or_default(),
+                )?;
+                crate::federation::BlobBody::ChunkDag(manifest)
+            }
+            _ => crate::federation::BlobBody::External(crate::federation::ExternalRef {
+                uri: ext.unwrap_or_default(),
+                size_bytes: size.max(0) as u64,
+                media_type: mt,
+            }),
+        }))
     }
 
     async fn get_blob_range(
@@ -3529,10 +3610,17 @@ impl crate::federation::BlobStorage for SqliteBackend {
         let sha_vec = sha256.to_vec();
         let conn = self.conn.clone();
         let now_iso = chrono::Utc::now().to_rfc3339();
-        // Outcome of the in-transaction work: None (absent),
-        // Err(RangeNotSatisfiable), or Ok(BlobRange).
-        type RangeOutcome = Option<Result<crate::federation::BlobRange, (u64, u64)>>;
-        let outcome: RangeOutcome = (move || -> Result<RangeOutcome, rusqlite::Error> {
+        // Outcome of the in-transaction work. The chunk_dag case can't
+        // be resolved inside the blocking tx (it needs async get_blob on
+        // covering chunks), so it returns the manifest bytes + clamped
+        // [start, end] for the outer async walk.
+        enum RangeDecision {
+            Absent,
+            NotSatisfiable { range_start: u64, size: u64 },
+            Resolved(crate::federation::BlobRange),
+            ChunkDag { manifest_bytes: Vec<u8>, end: u64 },
+        }
+        let outcome = (move || -> Result<RangeDecision, rusqlite::Error> {
             let mut conn = conn.lock();
             let tx = conn.transaction()?;
             // 1. Fetch storage_kind + size (+ external metadata) to do the
@@ -3552,7 +3640,7 @@ impl crate::federation::BlobStorage for SqliteBackend {
                 )
                 .optional()?;
             let (storage_kind, size_bytes, external_ref, media_type) = match head_opt {
-                None => return Ok(None),
+                None => return Ok(RangeDecision::Absent),
                 Some(h) => h,
             };
             let size: u64 = size_bytes.max(0) as u64;
@@ -3565,7 +3653,7 @@ impl crate::federation::BlobStorage for SqliteBackend {
             // 3. range_start at/past size → RangeNotSatisfiable.
             if range_start >= size {
                 tx.commit()?;
-                return Ok(Some(Err((range_start, size))));
+                return Ok(RangeDecision::NotSatisfiable { range_start, size });
             }
             // 4. Clamp the inclusive end to size-1.
             let end = range_end_inclusive.min(size - 1);
@@ -3581,28 +3669,60 @@ impl crate::federation::BlobStorage for SqliteBackend {
                     |row| row.get(0),
                 )?;
                 tx.commit()?;
-                Ok(Some(Ok(crate::federation::BlobRange::Inline(slice))))
+                Ok(RangeDecision::Resolved(
+                    crate::federation::BlobRange::Inline(slice),
+                ))
+            } else if storage_kind == "chunk_dag" {
+                // v4.1 (Cut B) — pull the manifest bytes; the chunk walk
+                // happens in the async outer scope (needs get_blob).
+                let manifest_bytes: Vec<u8> = tx.query_row(
+                    "SELECT bytes_inline FROM federation_blobs WHERE sha256 = ?1",
+                    rusqlite::params![sha_vec],
+                    |row| row.get(0),
+                )?;
+                tx.commit()?;
+                Ok(RangeDecision::ChunkDag {
+                    manifest_bytes,
+                    end,
+                })
             } else {
                 // External — return the ref + clamped range; do NOT fetch.
                 tx.commit()?;
-                Ok(Some(Ok(crate::federation::BlobRange::External {
-                    external_ref: crate::federation::ExternalRef {
-                        uri: external_ref.unwrap_or_default(),
-                        size_bytes: size,
-                        media_type,
+                Ok(RangeDecision::Resolved(
+                    crate::federation::BlobRange::External {
+                        external_ref: crate::federation::ExternalRef {
+                            uri: external_ref.unwrap_or_default(),
+                            size_bytes: size,
+                            media_type,
+                        },
+                        range_start,
+                        range_end_inclusive: end,
                     },
-                    range_start,
-                    range_end_inclusive: end,
-                })))
+                ))
             }
         })()
         .map_err(|e| crate::federation::BlobError::Backend(format!("get_blob_range: {e}")))?;
         match outcome {
-            None => Ok(None),
-            Some(Err((range_start, size))) => {
+            RangeDecision::Absent => Ok(None),
+            RangeDecision::NotSatisfiable { range_start, size } => {
                 Err(crate::federation::BlobError::RangeNotSatisfiable { range_start, size })
             }
-            Some(Ok(range)) => Ok(Some(range)),
+            RangeDecision::Resolved(range) => Ok(Some(range)),
+            RangeDecision::ChunkDag {
+                manifest_bytes,
+                end,
+            } => {
+                let manifest =
+                    crate::federation::blobs::ChunkManifest::from_manifest_bytes(&manifest_bytes)?;
+                let assembled = crate::federation::blobs::assemble_chunk_dag_range(
+                    self,
+                    &manifest,
+                    range_start,
+                    end,
+                )
+                .await?;
+                Ok(Some(crate::federation::BlobRange::Inline(assembled)))
+            }
         }
     }
 
@@ -16683,6 +16803,312 @@ mod tests {
             }
             other => panic!("expected BlobRange::External, got {other:?}"),
         }
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut B) — ChunkDag tests ─────────────
+
+    /// Build a 3-chunk inline manifest from three byte slices.
+    #[allow(clippy::type_complexity)]
+    fn three_chunk_manifest(
+        c0: &[u8],
+        c1: &[u8],
+        c2: &[u8],
+    ) -> (
+        crate::federation::ChunkManifest,
+        Vec<([u8; 32], BlobBody)>,
+        [u8; 32],
+    ) {
+        let s0 = sha256_of(c0);
+        let s1 = sha256_of(c1);
+        let s2 = sha256_of(c2);
+        let total = (c0.len() + c1.len() + c2.len()) as u64;
+        let manifest = crate::federation::ChunkManifest {
+            v: 1,
+            total_size: total,
+            chunks: vec![
+                crate::federation::ChunkRef {
+                    sha: s0,
+                    size: c0.len() as u32,
+                },
+                crate::federation::ChunkRef {
+                    sha: s1,
+                    size: c1.len() as u32,
+                },
+                crate::federation::ChunkRef {
+                    sha: s2,
+                    size: c2.len() as u32,
+                },
+            ],
+        };
+        let manifest_sha = sha256_of(&manifest.to_jcs_bytes());
+        let chunks = vec![
+            (s0, BlobBody::Inline(c0.to_vec())),
+            (s1, BlobBody::Inline(c1.to_vec())),
+            (s2, BlobBody::Inline(c2.to_vec())),
+        ];
+        (manifest, chunks, manifest_sha)
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_put_and_get_manifest_round_trip() {
+        let backend = blob_test_backend().await;
+        let (manifest, chunks, manifest_sha) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        backend
+            .put_blob_chunks(manifest.clone(), chunks)
+            .await
+            .unwrap();
+        // get_blob on the manifest sha returns the parsed manifest.
+        let got = backend.get_blob(&manifest_sha).await.unwrap().unwrap();
+        match got {
+            BlobBody::ChunkDag(m) => assert_eq!(m, manifest),
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+        // The individual chunks landed as their own rows.
+        assert!(backend.has_blob(&sha256_of(b"AAAA")).await.unwrap());
+        assert!(backend.has_blob(&sha256_of(b"CC")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_get_range_spans_boundary() {
+        let backend = blob_test_backend().await;
+        // chunks: "AAAA"(0..=3) "BBBB"(4..=7) "CC"(8..=9), total 10.
+        let (manifest, chunks, manifest_sha) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        backend.put_blob_chunks(manifest, chunks).await.unwrap();
+        // [2..=5] spans the chunk0/chunk1 boundary: "AA" + "BB".
+        let got = backend
+            .get_blob_range(&manifest_sha, 2, 5)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, BlobRange::Inline(b"AABB".to_vec()));
+        // Full range assembles the whole blob.
+        let full = backend
+            .get_blob_range(&manifest_sha, 0, 9)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(full, BlobRange::Inline(b"AAAABBBBCC".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_get_range_within_single_chunk() {
+        let backend = blob_test_backend().await;
+        let (manifest, chunks, manifest_sha) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        backend.put_blob_chunks(manifest, chunks).await.unwrap();
+        // [5..=6] is entirely inside chunk1 ("BBBB" at 4..=7) → "BB".
+        let got = backend
+            .get_blob_range(&manifest_sha, 5, 6)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, BlobRange::Inline(b"BB".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_get_range_end_clamped() {
+        let backend = blob_test_backend().await;
+        let (manifest, chunks, manifest_sha) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        backend.put_blob_chunks(manifest, chunks).await.unwrap();
+        // [8..=999] clamps to [8..=9] = "CC".
+        let got = backend
+            .get_blob_range(&manifest_sha, 8, 999)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, BlobRange::Inline(b"CC".to_vec()));
+        // start past total_size → RangeNotSatisfiable.
+        let err = backend
+            .get_blob_range(&manifest_sha, 10, 20)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BlobError::RangeNotSatisfiable { size: 10, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_rejects_sha_mismatch_chunk() {
+        let backend = blob_test_backend().await;
+        let (manifest, mut chunks, _) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        // Corrupt chunk[0]'s bytes so they don't hash to its manifest sha.
+        chunks[0].1 = BlobBody::Inline(b"XXXX".to_vec());
+        let err = backend.put_blob_chunks(manifest, chunks).await.unwrap_err();
+        assert!(matches!(err, BlobError::HashMismatch { .. }));
+        // Atomicity: nothing landed.
+        assert!(!backend.has_blob(&sha256_of(b"BBBB")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_rejects_total_size_mismatch() {
+        let backend = blob_test_backend().await;
+        let (mut manifest, chunks, _) = three_chunk_manifest(b"AAAA", b"BBBB", b"CC");
+        manifest.total_size = 999; // lie
+        let err = backend.put_blob_chunks(manifest, chunks).await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    #[tokio::test]
+    async fn chunk_dag_range_spans_external_chunk_typed_error() {
+        let backend = blob_test_backend().await;
+        // chunk1 is External — persist can't deref to slice it.
+        let c0 = b"AAAA";
+        let s0 = sha256_of(c0);
+        let s_ext = [0x9Au8; 32];
+        let manifest = crate::federation::ChunkManifest {
+            v: 1,
+            total_size: 4 + 100,
+            chunks: vec![
+                crate::federation::ChunkRef { sha: s0, size: 4 },
+                crate::federation::ChunkRef {
+                    sha: s_ext,
+                    size: 100,
+                },
+            ],
+        };
+        let manifest_sha = sha256_of(&manifest.to_jcs_bytes());
+        let chunks = vec![
+            (s0, BlobBody::Inline(c0.to_vec())),
+            (
+                s_ext,
+                BlobBody::External(ExternalRef {
+                    uri: "s3://bucket/chunk1".into(),
+                    size_bytes: 100,
+                    media_type: None,
+                }),
+            ),
+        ];
+        backend.put_blob_chunks(manifest, chunks).await.unwrap();
+        // A range entirely inside chunk0 is fine.
+        let ok = backend
+            .get_blob_range(&manifest_sha, 0, 3)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(ok, BlobRange::Inline(b"AAAA".to_vec()));
+        // A range reaching into the External chunk → typed error.
+        let err = backend
+            .get_blob_range(&manifest_sha, 2, 50)
+            .await
+            .unwrap_err();
+        match err {
+            BlobError::RangeSpansExternalChunk { chunk_sha_hex } => {
+                assert_eq!(chunk_sha_hex, hex::encode(s_ext));
+            }
+            other => panic!("expected RangeSpansExternalChunk, got {other:?}"),
+        }
+    }
+
+    /// v4.1 (CIRISPersist#142, Cut B) — the V061 SQLite 12-step table
+    /// rebuild MUST preserve existing federation_blobs rows (incl. the
+    /// V053 access-tracking columns), keep every index, and admit
+    /// chunk_dag afterward. Drives the embedded migration chain in two
+    /// passes (target V060, insert a row, then run to HEAD = V061).
+    #[test]
+    fn v061_rebuild_preserves_existing_blob_rows() {
+        // A single in-memory connection held across both runner passes
+        // (the embedded runner's Target lets us stop at V060, insert a
+        // row, then run the rest — V061 — on the same connection).
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+
+        // Pass 1: migrate up to and including V060.
+        embedded::migrations::runner()
+            .set_target(refinery::Target::Version(60))
+            .run(&mut conn)
+            .expect("migrate to V060");
+
+        // Insert an inline blob row directly (pre-V061 schema) with
+        // non-default access-tracking values to prove they survive.
+        {
+            let sha = vec![0x11u8; 32];
+            conn.execute(
+                "INSERT INTO federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, \
+                    media_type, last_accessed_at, access_count\
+                 ) VALUES (?1, 'inline', ?2, NULL, 5, 'text/plain', \
+                    '2026-01-02T03:04:05+00:00', 7)",
+                rusqlite::params![sha, b"hello".to_vec()],
+            )
+            .unwrap();
+        }
+
+        // Pass 2: run the rest of the chain (V061 rebuild).
+        embedded::migrations::runner()
+            .run(&mut conn)
+            .expect("migrate to HEAD (V061)");
+
+        // Verify the row survived with every column intact.
+        let (kind, inline, size, mt, last_acc, acc_count): (
+            String,
+            Vec<u8>,
+            i64,
+            String,
+            String,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT storage_kind, bytes_inline, size_bytes, media_type, \
+                    last_accessed_at, access_count FROM federation_blobs \
+                 WHERE sha256 = ?1",
+                rusqlite::params![vec![0x11u8; 32]],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                },
+            )
+            .expect("blob row survives V061 rebuild");
+        assert_eq!(kind, "inline");
+        assert_eq!(inline, b"hello".to_vec());
+        assert_eq!(size, 5);
+        assert_eq!(mt, "text/plain");
+        assert_eq!(last_acc, "2026-01-02T03:04:05+00:00");
+        assert_eq!(acc_count, 7);
+
+        // All three indexes survived the rebuild.
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' \
+                    AND tbl_name='federation_blobs' AND name IN \
+                    ('federation_blobs_size_bytes','federation_blobs_first_seen_at',\
+                     'federation_blobs_eviction_score')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 3, "all three indexes must survive the rebuild");
+
+        // chunk_dag is now an accepted storage_kind (the CHECK admits it).
+        let dag_sha = vec![0x22u8; 32];
+        conn.execute(
+            "INSERT INTO federation_blobs (\
+                sha256, storage_kind, bytes_inline, external_ref, size_bytes, \
+                media_type, last_accessed_at, access_count\
+             ) VALUES (?1, 'chunk_dag', ?2, NULL, 3, NULL, \
+                '2026-01-01T00:00:00+00:00', 0)",
+            rusqlite::params![dag_sha, b"{}".to_vec()],
+        )
+        .expect("chunk_dag row accepted post-V061");
+
+        // And the cross-column CHECK still rejects a malformed chunk_dag
+        // row (external_ref set when it must be NULL).
+        let bad = conn.execute(
+            "INSERT INTO federation_blobs (\
+                sha256, storage_kind, bytes_inline, external_ref, size_bytes, \
+                media_type, last_accessed_at, access_count\
+             ) VALUES (?1, 'chunk_dag', NULL, 's3://x', 3, NULL, \
+                '2026-01-01T00:00:00+00:00', 0)",
+            rusqlite::params![vec![0x33u8; 32]],
+        );
+        assert!(
+            bad.is_err(),
+            "chunk_dag with external_ref must violate CHECK"
+        );
     }
 
     /// Admission ordering test — trust rejection beats inline-size


### PR DESCRIPTION
**Cut B of the streaming substrate** ([`FSD/V4_1_STREAMING_SUBSTRATE.md`](FSD/V4_1_STREAMING_SUBSTRATE.md) §4.2; #142). Content-addressed chunked blobs — the Merkle-over-chunks layer that satisfies CEG §10.1.1 with SHA-256 (no BLAKE3).

## Adds
- `BlobBody::ChunkDag(ChunkManifest)` — flat one-level Merkle list; manifest (JCS-canonical JSON, sha-of-manifest = row sha) stored in `bytes_inline`; each chunk its own `federation_blobs` row.
- `put_blob_chunks(manifest, chunks)` — atomic multi-row insert; per-chunk + total_size SHA verification before the txn (zero rows on any mismatch).
- `get_blob` chunk_dag arm (returns the parsed manifest) + `get_blob_range` chunk-walk (prefix-sum → covering chunks → re-verify SHA → slice → assemble). A covering `External` chunk → typed `BlobError::RangeSpansExternalChunk` (persist never derefs).
- **V061 migration** — extends the `federation_blobs.storage_kind` CHECK + cross-column CHECK to admit `chunk_dag`. PG `DROP/ADD CONSTRAINT`; **SQLite 12-step table rebuild** (mirrored V035) preserving every column (incl. V053 access-tracking), all 3 indexes, no triggers — with a data-preservation test.
- PyO3: `put_blob_chunks_json` + ChunkDag arms.

## Verification (local, including live postgres)
- **875 tests** pass on `cargo test --features "postgres server pyo3 sqlite" --lib` against a live PG (the new chunk_dag PG tests ran **live**, not skipped) — this is the leg that caught the Cut A `u64` bug; clean here.
- V061 verified applied on live PG (`\d` shows both CHECKs admit `chunk_dag`); data-preservation test confirms the SQLite rebuild keeps every column/index.
- Clean under `-D warnings`: `--no-default-features`, `--features test-panic,pyo3`, the full CI gated combo.
- No `u64` postgres binds (the Cut A gotcha); chunk sizes bound `i64`.

Next: Cut C (live append + per-stream STH + STREAM-nonce AEAD + epoch-DEK v2 cascade) — the CEG-1.0 unblocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)