### PR TITLE
Streaming Cut C1a — federation_stream_chunks + put_blob_chunk + seal_stream (#142)

### DIFF
--- a/migrations/postgres/lens/V062__federation_stream_chunks.sql
+++ b/migrations/postgres/lens/V062__federation_stream_chunks.sql
@@ -1,0 +1,90 @@
+-- V062 — federation_stream_chunks live-stream chunk index, Postgres
+-- dialect (CIRISPersist#142, Cut C1a — put_blob_chunk / seal_stream).
+--
+-- Cut C1a adds the LIVE-APPEND substrate on top of Cut B's content-
+-- addressed chunk DAG. A producer appends chunks one at a time
+-- (`put_blob_chunk(stream_id, seq, …)`) while the stream is live; each
+-- chunk lands as a normal `federation_blobs` row (content-addressed by
+-- its own SHA-256) AND a row in THIS table indexing it into the stream
+-- at a monotonic `seq`. `seal_stream(stream_id)` later walks this index
+-- in `seq` order and writes the Cut-B `chunk_dag` manifest row.
+--
+-- # Why a separate index table (vs. a column on federation_blobs)
+--
+-- `federation_blobs` is content-addressed (SHA-256 PK) and write-once;
+-- the same chunk bytes might appear in two streams (or twice in one),
+-- and a stream is an ORDERED sequence, not a set. The stream→(seq→sha)
+-- mapping is therefore its own table. The blob row holds the bytes; this
+-- table holds the position.
+--
+-- # Monotonicity guarantee
+--
+-- PRIMARY KEY (stream_id, seq). A re-used (stream_id, seq) is a PK
+-- conflict → the INSERT fails → put_blob_chunk maps it to
+-- BlobError::InvalidArgument. There is no UPSERT on the index row; the
+-- monotonic seq is the substrate's append-only enforcement.
+--
+-- # Epoch column (stored now, no crypto this cut)
+--
+-- `epoch` is the key-rotation epoch the chunk was sealed under. Cut C1a
+-- stores it but does NO key/crypto work (that is Cut C3 — the epoch-DEK
+-- cascade). The (stream_id, epoch) index is here so the later
+-- per-epoch walk (catch-up / re-key) is index-served from day one.
+--
+-- # No CHECK-rebuild
+--
+-- This is a NEW table — pure additive. (The non-additive RC1-1c
+-- key_grant CHECK migration named in FSD §4.4 is a LATER cut; it is not
+-- part of C1a.)
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_stream_chunks (
+    -- The stream this chunk belongs to. Opaque producer-chosen id
+    -- (CEG §10.5 log_id). Not an FK — streams are not first-class rows
+    -- in this cut; the (stream_id, seq) pair is the only identity.
+    stream_id   TEXT NOT NULL,
+
+    -- Monotonic per-stream sequence number. Together with stream_id this
+    -- is the PK, so a re-used seq is rejected at the driver (the
+    -- monotonicity guarantee). u64 in Rust → bound as i64 (BIGINT);
+    -- tokio_postgres has no ToSql for u64.
+    seq         BIGINT NOT NULL,
+
+    -- Content address of THIS chunk's bytes — a federation_blobs.sha256.
+    -- Exactly 32 bytes. The bytes themselves live in the federation_blobs
+    -- row keyed on this value (put_blob_chunk inserts both atomically).
+    chunk_sha   BYTEA NOT NULL
+        CHECK (octet_length(chunk_sha) = 32),
+
+    -- Key-rotation epoch (CEG §10.5.3). Stored now; the DEK cascade is
+    -- Cut C3. Defaults to 0 for callers that don't rotate.
+    epoch       BIGINT NOT NULL DEFAULT 0,
+
+    -- This chunk's byte length. Sum over the stream (seq order) is the
+    -- sealed manifest's total_size.
+    size_bytes  BIGINT NOT NULL CHECK (size_bytes >= 0),
+
+    -- Wall-clock at append time.
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Set on seal_stream (informational — "when did this stream's index
+    -- get frozen into a manifest"). NULL while the stream is live.
+    sealed_at   TIMESTAMPTZ NULL,
+
+    -- The monotonicity guarantee: a re-used (stream_id, seq) is a PK
+    -- conflict. This index also serves the seq-ordered seal walk.
+    PRIMARY KEY (stream_id, seq)
+);
+
+-- Per-(stream, epoch) index for the later epoch walk (catch-up /
+-- re-key cascade, Cut C3). Cheap to add now; saves a rebuild later.
+CREATE INDEX IF NOT EXISTS federation_stream_chunks_stream_epoch
+    ON cirislens.federation_stream_chunks (stream_id, epoch);
+
+COMMENT ON TABLE cirislens.federation_stream_chunks IS
+    'v4.1 (CIRISPersist#142, Cut C1a) — live-stream chunk index. (stream_id, seq) PK is the monotonicity guarantee; chunk_sha references a federation_blobs row. put_blob_chunk appends; seal_stream walks seq-ordered to build the chunk_dag manifest. epoch stored for the Cut C3 DEK cascade (no crypto this cut).';
+
+COMMENT ON COLUMN cirislens.federation_stream_chunks.seq IS
+    'Monotonic per-stream sequence. Part of the PK — a re-used seq is rejected (append-only enforcement). u64 in Rust, bound i64.';
+
+COMMENT ON COLUMN cirislens.federation_stream_chunks.epoch IS
+    'Key-rotation epoch (CEG §10.5.3). Stored now; the epoch-DEK cascade is Cut C3 (no crypto this cut).';

--- a/migrations/sqlite/lens/V062__federation_stream_chunks.sql
+++ b/migrations/sqlite/lens/V062__federation_stream_chunks.sql
@@ -1,0 +1,45 @@
+-- V062 — federation_stream_chunks live-stream chunk index, SQLite
+-- dialect (CIRISPersist#142, Cut C1a — put_blob_chunk / seal_stream).
+--
+-- Mirrors postgres/lens/V062. NEW table — pure additive, no CHECK
+-- rebuild (this is not the V054-style 12-step rebuild; nothing pre-
+-- existing is touched). See the PG sibling for the full rationale:
+--   * (stream_id, seq) PK = the monotonicity guarantee
+--   * chunk_sha references a federation_blobs row (BLOB, 32 bytes)
+--   * epoch stored now; the DEK cascade is Cut C3 (no crypto this cut)
+--
+-- Type mapping vs. PG: BIGINT→INTEGER, BYTEA→BLOB, TIMESTAMPTZ→TEXT
+-- (RFC3339, like federation_blobs.first_seen_at / V047 SQLite).
+
+CREATE TABLE IF NOT EXISTS federation_stream_chunks (
+    -- Opaque producer-chosen stream id (CEG §10.5 log_id).
+    stream_id   TEXT NOT NULL,
+
+    -- Monotonic per-stream sequence. Part of the PK — a re-used seq is a
+    -- PK conflict (the monotonicity guarantee). u64 in Rust, bound i64.
+    seq         INTEGER NOT NULL,
+
+    -- Content address of this chunk's bytes — a federation_blobs.sha256,
+    -- exactly 32 bytes.
+    chunk_sha   BLOB NOT NULL
+        CHECK (length(chunk_sha) = 32),
+
+    -- Key-rotation epoch (CEG §10.5.3). Stored now; cascade is Cut C3.
+    epoch       INTEGER NOT NULL DEFAULT 0,
+
+    -- This chunk's byte length.
+    size_bytes  INTEGER NOT NULL CHECK (size_bytes >= 0),
+
+    -- Wall-clock at append time (RFC3339).
+    created_at  TEXT NOT NULL DEFAULT (datetime('now', 'subsec')),
+
+    -- Set on seal_stream (informational). NULL while live.
+    sealed_at   TEXT NULL,
+
+    -- The monotonicity guarantee + the seq-ordered seal walk index.
+    PRIMARY KEY (stream_id, seq)
+);
+
+-- Per-(stream, epoch) index for the later epoch walk (Cut C3).
+CREATE INDEX IF NOT EXISTS federation_stream_chunks_stream_epoch
+    ON federation_stream_chunks (stream_id, epoch);

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -466,6 +466,77 @@ pub trait BlobStorage: Send + Sync {
         chunks: Vec<([u8; 32], BlobBody)>,
     ) -> impl Future<Output = Result<(), BlobError>> + Send;
 
+    /// v4.1 (CIRISPersist#142, Cut C1a) — **live append** of one chunk
+    /// to a stream (CEG §10.5.1).
+    ///
+    /// Where [`put_blob_chunks`](BlobStorage::put_blob_chunks) seals a
+    /// known-complete blob in one shot, `put_blob_chunk` appends a
+    /// single chunk to a *live* stream at a monotonic `seq`. In ONE
+    /// transaction it:
+    /// - inserts `body` as a normal `federation_blobs` row, keyed on the
+    ///   chunk's SHA-256 (idempotent / first-write-wins on collision —
+    ///   content-addressed bytes, so a re-PUT of identical bytes is
+    ///   fine), and
+    /// - inserts the `federation_stream_chunks` index row
+    ///   `(stream_id, seq, chunk_sha, epoch, size_bytes)`.
+    ///
+    /// Returns the chunk's SHA-256 (its content address).
+    ///
+    /// # Monotonicity (`seq` collision)
+    ///
+    /// The `(stream_id, seq)` pair is the index table's PRIMARY KEY. A
+    /// re-used `seq` for the same stream is a PK conflict and is
+    /// rejected with [`BlobError::InvalidArgument`] — the substrate's
+    /// append-only enforcement. (The blob row itself is content-
+    /// addressed and idempotent; only the stream-index row is unique per
+    /// `(stream, seq)`.)
+    ///
+    /// # `epoch`
+    ///
+    /// The key-rotation epoch (CEG §10.5.3) is stored on the index row.
+    /// Cut C1a does **no** key/crypto work — the epoch-DEK cascade is
+    /// Cut C3; this cut just records the column.
+    ///
+    /// # Validation
+    ///
+    /// - `Inline` body: hashed on write (SHA-256 == the inserted PK);
+    ///   inline-size-capped, exactly like [`put_blob`].
+    /// - `External` body: SHA trusted (persist has no bytes), as in
+    ///   [`put_blob`].
+    /// - A [`BlobBody::ChunkDag`] body is rejected with
+    ///   [`BlobError::InvalidArgument`] — you cannot chunk a chunk.
+    fn put_blob_chunk(
+        &self,
+        stream_id: &str,
+        seq: u64,
+        body: BlobBody,
+        epoch: u64,
+    ) -> impl Future<Output = Result<[u8; 32], BlobError>> + Send;
+
+    /// v4.1 (CIRISPersist#142, Cut C1a) — **seal** a live stream into a
+    /// content-addressed [`BlobBody::ChunkDag`] (CEG §10.5.1).
+    ///
+    /// Walks every [`federation_stream_chunks`](crate) row for
+    /// `stream_id` in `seq ASC` order, builds the Cut-B
+    /// [`ChunkManifest`] (`total_size` = Σ `size_bytes`, `chunks` in seq
+    /// order), and writes **only** the `chunk_dag` manifest row to
+    /// `federation_blobs` (the chunk rows already exist —
+    /// `put_blob_chunk` inserted them; seal does NOT re-insert them).
+    /// `sealed_at` is stamped on the stream's index rows
+    /// (informational).
+    ///
+    /// Returns the manifest's SHA-256 — the sealed stream's content
+    /// address. After seal, [`get_blob`](BlobStorage::get_blob) /
+    /// [`get_blob_range`](BlobStorage::get_blob_range) over that SHA use
+    /// Cut B's ChunkDag path.
+    ///
+    /// An empty stream (no chunks) is rejected with
+    /// [`BlobError::InvalidArgument`].
+    fn seal_stream(
+        &self,
+        stream_id: &str,
+    ) -> impl Future<Output = Result<[u8; 32], BlobError>> + Send;
+
     /// Read a blob by its SHA-256.
     ///
     /// Returns the [`BlobBody`] variant matching the row's stored
@@ -1319,6 +1390,120 @@ pub(crate) struct PreparedBlobRow {
     pub external_ref: Option<String>,
     /// `size_bytes` column value (already range-checked to fit i64).
     pub size_bytes: i64,
+}
+
+/// v4.1 (CIRISPersist#142, Cut C1a) — validate ONE live-append chunk
+/// (`put_blob_chunk`) and produce the prepared `federation_blobs` row +
+/// the chunk's content SHA-256.
+///
+/// Validation mirrors the per-chunk arm of [`prepare_chunk_rows`]:
+/// nested-DAG reject → inline-size cap → hash-on-write (the SHA is
+/// COMPUTED from the bytes for `Inline`, trusted for `External`) → i64
+/// range. There is no manifest here — a live chunk is one
+/// content-addressed blob row; the stream index row is bound by the
+/// backend alongside it in the same txn.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) fn prepare_stream_chunk_row(
+    body: &BlobBody,
+    inline_bytes_cap: usize,
+) -> Result<PreparedBlobRow, BlobError> {
+    use sha2::{Digest, Sha256};
+
+    let (sha256, storage_kind, bytes_inline, external_ref, size) = match body {
+        BlobBody::Inline(bytes) => {
+            if bytes.len() > inline_bytes_cap {
+                return Err(BlobError::InlineSizeExceeded {
+                    size: bytes.len(),
+                    cap: inline_bytes_cap,
+                });
+            }
+            // Hash-on-write: the chunk's content address is computed from
+            // its bytes (this IS the SHA returned to the caller + the PK).
+            let sha: [u8; 32] = Sha256::digest(bytes).into();
+            (sha, "inline", Some(bytes.clone()), None, bytes.len() as u64)
+        }
+        BlobBody::External(_) => {
+            return Err(BlobError::InvalidArgument(
+                "put_blob_chunk: External chunk body not supported in this cut — \
+                 a live chunk's SHA is computed from its inline bytes (Cut C1a)"
+                    .into(),
+            ));
+        }
+        BlobBody::ChunkDag(_) => {
+            return Err(BlobError::InvalidArgument(
+                "put_blob_chunk: chunk body is itself a ChunkDag — you cannot chunk a chunk".into(),
+            ));
+        }
+    };
+    let size_bytes = i64::try_from(size).map_err(|_| {
+        BlobError::InvalidArgument("put_blob_chunk: chunk size_bytes exceeds i64".into())
+    })?;
+    Ok(PreparedBlobRow {
+        sha256,
+        storage_kind,
+        bytes_inline,
+        external_ref,
+        size_bytes,
+    })
+}
+
+/// v4.1 (CIRISPersist#142, Cut C1a) — from the seq-ordered
+/// `(chunk_sha, size_bytes)` rows read out of `federation_stream_chunks`,
+/// build the sealed [`ChunkManifest`] + the prepared `chunk_dag`
+/// manifest [`PreparedBlobRow`] (its SHA-256 = the sealed stream's
+/// content address). Does NOT touch the chunk rows — they already exist.
+///
+/// Empty input → [`BlobError::InvalidArgument`] (`stream_id` carried by
+/// the caller for the message). `total_size` is Σ `size_bytes`.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) fn prepare_sealed_manifest_row(
+    stream_id: &str,
+    chunk_rows: &[([u8; 32], i64)],
+    inline_bytes_cap: usize,
+) -> Result<(ChunkManifest, PreparedBlobRow), BlobError> {
+    use sha2::{Digest, Sha256};
+
+    if chunk_rows.is_empty() {
+        return Err(BlobError::InvalidArgument(format!(
+            "stream {stream_id} has no chunks"
+        )));
+    }
+    let mut total_size: u64 = 0;
+    let mut chunks = Vec::with_capacity(chunk_rows.len());
+    for (sha, size_i64) in chunk_rows {
+        let size = u32::try_from(*size_i64).map_err(|_| {
+            BlobError::InvalidArgument(format!(
+                "seal_stream: chunk size {size_i64} does not fit u32 (one-chunk cap)"
+            ))
+        })?;
+        total_size = total_size
+            .checked_add(u64::from(size))
+            .ok_or_else(|| BlobError::InvalidArgument("seal_stream: total_size overflow".into()))?;
+        chunks.push(ChunkRef { sha: *sha, size });
+    }
+    let manifest = ChunkManifest {
+        v: CHUNK_MANIFEST_VERSION,
+        total_size,
+        chunks,
+    };
+    let manifest_bytes = manifest.to_jcs_bytes();
+    if manifest_bytes.len() > inline_bytes_cap {
+        return Err(BlobError::InlineSizeExceeded {
+            size: manifest_bytes.len(),
+            cap: inline_bytes_cap,
+        });
+    }
+    let manifest_sha: [u8; 32] = Sha256::digest(&manifest_bytes).into();
+    let manifest_size = i64::try_from(manifest.total_size)
+        .map_err(|_| BlobError::InvalidArgument("seal_stream: total_size exceeds i64".into()))?;
+    let row = PreparedBlobRow {
+        sha256: manifest_sha,
+        storage_kind: "chunk_dag",
+        bytes_inline: Some(manifest_bytes),
+        external_ref: None,
+        size_bytes: manifest_size,
+    };
+    Ok((manifest, row))
 }
 
 /// v4.1 (CIRISPersist#142, Cut B) — validate a `put_blob_chunks`

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4207,6 +4207,102 @@ impl PyEngine {
         })
     }
 
+    /// v4.1 (CIRISPersist#142, Cut C1a) — live-append one chunk to a
+    /// stream. Inserts the chunk's bytes as a content-addressed
+    /// `federation_blobs` row AND the `federation_stream_chunks` index
+    /// row `(stream_id, seq, chunk_sha, epoch, size_bytes)` in ONE
+    /// transaction. Returns the chunk's SHA-256 as a lowercase hex
+    /// string.
+    ///
+    /// `body_b64` is the chunk's inline bytes, base64-standard. A re-used
+    /// `seq` for the same `stream_id` raises `ValueError`
+    /// (`stream … seq … already exists` — the monotonicity guarantee).
+    /// Cut C1a stores `epoch` but does no crypto (the DEK cascade is Cut
+    /// C3).
+    fn put_blob_chunk(
+        &self,
+        py: Python<'_>,
+        stream_id: &str,
+        seq: u64,
+        body_b64: &str,
+        epoch: u64,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            use base64::engine::general_purpose::STANDARD as B64;
+            use base64::Engine as _;
+            let bytes = B64.decode(body_b64).map_err(|e| {
+                PyValueError::new_err(format!("put_blob_chunk body base64 decode: {e}"))
+            })?;
+            let body = crate::federation::BlobBody::Inline(bytes);
+            let runtime = self.runtime.clone();
+            let stream_id = stream_id.to_string();
+            let sha = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_blob_chunk(&stream_id, seq, body, epoch)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_blob_chunk(&stream_id, seq, body, epoch)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            Ok(hex::encode(sha))
+        })
+    }
+
+    /// v4.1 (CIRISPersist#142, Cut C1a) — seal a live stream into a
+    /// content-addressed chunk DAG. Walks the `federation_stream_chunks`
+    /// index in `seq` order, writes the `chunk_dag` manifest row, and
+    /// returns the manifest's SHA-256 (lowercase hex) — the sealed
+    /// stream's address. `get_blob_json` / `get_blob_range` over that SHA
+    /// then resolve via the Cut B ChunkDag path. An empty stream raises
+    /// `ValueError`.
+    fn seal_stream(&self, py: Python<'_>, stream_id: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let stream_id = stream_id.to_string();
+            let sha = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .seal_stream(&stream_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .seal_stream(&stream_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            Ok(hex::encode(sha))
+        })
+    }
+
     /// v3.11.0 (CIRISPersist#143, CIRISVerify FEDERATION_THREAT_MODEL
     /// §3.3.2) — verify-coord R1+Q1 constants as a JSON dict for
     /// consumer code that needs to pin τ_normal / τ_partial /

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3793,6 +3793,178 @@ impl crate::federation::BlobStorage for PostgresBackend {
         Ok(())
     }
 
+    async fn put_blob_chunk(
+        &self,
+        stream_id: &str,
+        seq: u64,
+        body: crate::federation::BlobBody,
+        epoch: u64,
+    ) -> Result<[u8; 32], crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        // Validation + hash-on-write (computes the chunk's content SHA).
+        let row = crate::federation::blobs::prepare_stream_chunk_row(&body, cap)?;
+        // u64 → i64 binds (tokio_postgres has no ToSql for u64).
+        let seq_i64 = i64::try_from(seq).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_blob_chunk: seq exceeds i64 — federation_stream_chunks.seq is BIGINT".into(),
+            )
+        })?;
+        let epoch_i64 = i64::try_from(epoch).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_blob_chunk: epoch exceeds i64 — federation_stream_chunks.epoch is BIGINT"
+                    .into(),
+            )
+        })?;
+
+        let mut client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(format!("begin tx: {e}")))?;
+
+        // 1. The chunk's bytes land as a normal federation_blobs row.
+        //    Content-addressed + idempotent: a re-PUT of identical bytes
+        //    is a no-op (ON CONFLICT DO NOTHING), exactly like
+        //    store_blob_local / the put_blob_chunks chunk rows.
+        let sha_vec = row.sha256.to_vec();
+        let media_type_null: Option<String> = None;
+        tx.execute(
+            "INSERT INTO cirislens.federation_blobs (\
+                sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type\
+             ) VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (sha256) DO NOTHING",
+            &[
+                &sha_vec,
+                &row.storage_kind,
+                &row.bytes_inline,
+                &row.external_ref,
+                &row.size_bytes,
+                &media_type_null,
+            ],
+        )
+        .await
+        .map_err(|e| {
+            crate::federation::BlobError::Backend(format!("put_blob_chunk blob insert: {e}"))
+        })?;
+
+        // 2. The stream-index row. The (stream_id, seq) PK enforces
+        //    monotonicity — a re-used seq is a PK conflict, mapped to
+        //    InvalidArgument (NOT idempotent: the append-only rule).
+        let inserted = tx
+            .execute(
+                "INSERT INTO cirislens.federation_stream_chunks (\
+                    stream_id, seq, chunk_sha, epoch, size_bytes\
+                 ) VALUES ($1, $2, $3, $4, $5) \
+                 ON CONFLICT (stream_id, seq) DO NOTHING",
+                &[&stream_id, &seq_i64, &sha_vec, &epoch_i64, &row.size_bytes],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_blob_chunk index insert: {e}"))
+            })?;
+        if inserted == 0 {
+            // PK conflict on (stream_id, seq) — monotonicity violation.
+            // Roll back the whole txn (the blob row too, if it was new).
+            return Err(crate::federation::BlobError::InvalidArgument(format!(
+                "stream {stream_id} seq {seq} already exists"
+            )));
+        }
+
+        tx.commit().await.map_err(|e| {
+            crate::federation::BlobError::Backend(format!("put_blob_chunk commit: {e}"))
+        })?;
+        Ok(row.sha256)
+    }
+
+    async fn seal_stream(&self, stream_id: &str) -> Result<[u8; 32], crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        let mut client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(format!("begin tx: {e}")))?;
+
+        // 1. Read the seq-ordered chunk index for the stream.
+        let index_rows = tx
+            .query(
+                "SELECT chunk_sha, size_bytes \
+                   FROM cirislens.federation_stream_chunks \
+                  WHERE stream_id = $1 \
+                  ORDER BY seq ASC",
+                &[&stream_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("seal_stream index read: {e}"))
+            })?;
+        let mut chunk_rows: Vec<([u8; 32], i64)> = Vec::with_capacity(index_rows.len());
+        for r in &index_rows {
+            let sha_vec: Vec<u8> =
+                r.safe_get_with("chunk_sha", crate::federation::BlobError::Backend)?;
+            if sha_vec.len() != 32 {
+                return Err(crate::federation::BlobError::Backend(format!(
+                    "seal_stream: chunk_sha is {} bytes, expected 32",
+                    sha_vec.len()
+                )));
+            }
+            let mut sha = [0u8; 32];
+            sha.copy_from_slice(&sha_vec);
+            let size: i64 = r.safe_get_with("size_bytes", crate::federation::BlobError::Backend)?;
+            chunk_rows.push((sha, size));
+        }
+
+        // 2. Build the sealed manifest + the chunk_dag manifest row.
+        //    (Empty stream → InvalidArgument inside the helper.)
+        let (_manifest, manifest_row) =
+            crate::federation::blobs::prepare_sealed_manifest_row(stream_id, &chunk_rows, cap)?;
+
+        // 3. Write ONLY the manifest row (the chunk rows already exist —
+        //    put_blob_chunk inserted them; seal does not re-insert).
+        let manifest_sha_vec = manifest_row.sha256.to_vec();
+        let media_type_null: Option<String> = None;
+        tx.execute(
+            "INSERT INTO cirislens.federation_blobs (\
+                sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type\
+             ) VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (sha256) DO NOTHING",
+            &[
+                &manifest_sha_vec,
+                &manifest_row.storage_kind,
+                &manifest_row.bytes_inline,
+                &manifest_row.external_ref,
+                &manifest_row.size_bytes,
+                &media_type_null,
+            ],
+        )
+        .await
+        .map_err(|e| {
+            crate::federation::BlobError::Backend(format!("seal_stream manifest insert: {e}"))
+        })?;
+
+        // 4. Stamp sealed_at on the stream's index rows (informational).
+        tx.execute(
+            "UPDATE cirislens.federation_stream_chunks \
+                SET sealed_at = NOW() \
+              WHERE stream_id = $1",
+            &[&stream_id],
+        )
+        .await
+        .map_err(|e| {
+            crate::federation::BlobError::Backend(format!("seal_stream sealed_at: {e}"))
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            crate::federation::BlobError::Backend(format!("seal_stream commit: {e}"))
+        })?;
+        Ok(manifest_row.sha256)
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -17352,6 +17524,174 @@ mod tests {
         let _ = backend.delete_blob(&manifest_sha).await;
         let _ = backend.delete_blob(&s0).await;
         let _ = backend.delete_blob(&s_ext).await;
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut C1a) — PG live stream chunks ───
+
+    /// Append 3 chunks, seal, and read the assembled bytes back via
+    /// get_blob_range over the sealed manifest sha — end-to-end with the
+    /// Cut B ChunkDag path, including ranges crossing chunk boundaries.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_stream_append_seal_and_range_round_trip() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobRange, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        // Run-unique chunk bytes (shared test DB → SHAs must not collide).
+        let salt = uuid_like();
+        let c0 = format!("strm-AAAA-{salt}").into_bytes();
+        let c1 = format!("strm-BBBB-{salt}").into_bytes();
+        let c2 = format!("strm-CC-{salt}").into_bytes();
+        let stream = format!("pg-stream-rt-{salt}");
+        let (l0, l1, l2) = (c0.len() as u64, c1.len() as u64, c2.len() as u64);
+        let total = l0 + l1 + l2;
+
+        let s0 = backend
+            .put_blob_chunk(&stream, 0, BlobBody::Inline(c0.clone()), 0)
+            .await
+            .unwrap();
+        let s1 = backend
+            .put_blob_chunk(&stream, 1, BlobBody::Inline(c1.clone()), 0)
+            .await
+            .unwrap();
+        let s2 = backend
+            .put_blob_chunk(&stream, 2, BlobBody::Inline(c2.clone()), 0)
+            .await
+            .unwrap();
+        assert_eq!(s0, pg_sha256_of(&c0));
+        assert_eq!(s1, pg_sha256_of(&c1));
+        assert_eq!(s2, pg_sha256_of(&c2));
+
+        let manifest_sha = backend.seal_stream(&stream).await.unwrap();
+
+        // The sealed sha resolves as a ChunkDag manifest in seq order.
+        match backend.get_blob(&manifest_sha).await.unwrap().unwrap() {
+            BlobBody::ChunkDag(m) => {
+                assert_eq!(m.total_size, total);
+                assert_eq!(m.chunks.len(), 3);
+                assert_eq!(m.chunks[0].sha, s0);
+                assert_eq!(m.chunks[1].sha, s1);
+                assert_eq!(m.chunks[2].sha, s2);
+            }
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+
+        // Assemble the full bytes for the range assertions.
+        let mut full = Vec::new();
+        full.extend_from_slice(&c0);
+        full.extend_from_slice(&c1);
+        full.extend_from_slice(&c2);
+
+        // Full range assembles the whole stream.
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, 0, total - 1)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(full.clone())
+        );
+        // A range crossing the chunk0/chunk1 boundary.
+        let span_start = l0 - 2;
+        let span_end = l0 + 1;
+        let expect: Vec<u8> = full[span_start as usize..=span_end as usize].to_vec();
+        assert_eq!(
+            backend
+                .get_blob_range(&manifest_sha, span_start, span_end)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRange::Inline(expect)
+        );
+
+        // Cleanup (shared DB).
+        let _ = backend.delete_blob(&manifest_sha).await;
+        let _ = backend.delete_blob(&s0).await;
+        let _ = backend.delete_blob(&s1).await;
+        let _ = backend.delete_blob(&s2).await;
+    }
+
+    /// A re-used (stream_id, seq) is rejected (monotonicity guarantee).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_stream_seq_collision_rejected() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let salt = uuid_like();
+        let stream = format!("pg-stream-collide-{salt}");
+        let c0 = format!("first-{salt}").into_bytes();
+        let s0 = backend
+            .put_blob_chunk(&stream, 0, BlobBody::Inline(c0.clone()), 0)
+            .await
+            .unwrap();
+        // Same seq, different bytes → PK conflict → InvalidArgument.
+        let err = backend
+            .put_blob_chunk(
+                &stream,
+                0,
+                BlobBody::Inline(format!("second-{salt}").into_bytes()),
+                0,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        // The stream seals to exactly the first chunk.
+        let manifest_sha = backend.seal_stream(&stream).await.unwrap();
+        match backend.get_blob(&manifest_sha).await.unwrap().unwrap() {
+            BlobBody::ChunkDag(m) => {
+                assert_eq!(m.chunks.len(), 1);
+                assert_eq!(m.chunks[0].sha, s0);
+            }
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+        let _ = backend.delete_blob(&manifest_sha).await;
+        let _ = backend.delete_blob(&s0).await;
+    }
+
+    /// Sealing a stream with no chunks is rejected; a ChunkDag body to
+    /// put_blob_chunk is rejected (can't chunk a chunk).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_stream_seal_empty_and_chunk_dag_body_rejected() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage, ChunkManifest, ChunkRef};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let salt = uuid_like();
+
+        // Empty stream → InvalidArgument.
+        let err = backend
+            .seal_stream(&format!("pg-empty-{salt}"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+
+        // ChunkDag body to put_blob_chunk → InvalidArgument.
+        let nested = ChunkManifest {
+            v: 1,
+            total_size: 4,
+            chunks: vec![ChunkRef {
+                sha: pg_sha256_of(b"AAAA"),
+                size: 4,
+            }],
+        };
+        let err = backend
+            .put_blob_chunk(&format!("pg-nest-{salt}"), 0, BlobBody::ChunkDag(nested), 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
     }
 
     // ─── v3.4.0 (CIRISPersist#123) — PG sweeper parity ─────────────

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3523,6 +3523,186 @@ impl crate::federation::BlobStorage for SqliteBackend {
         Ok(())
     }
 
+    async fn put_blob_chunk(
+        &self,
+        stream_id: &str,
+        seq: u64,
+        body: crate::federation::BlobBody,
+        epoch: u64,
+    ) -> Result<[u8; 32], crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        // Validation + hash-on-write (computes the chunk's content SHA).
+        let row = crate::federation::blobs::prepare_stream_chunk_row(&body, cap)?;
+        // u64 → i64 binds (rusqlite has no native u64 path either; keep
+        // parity with the PG side's typed-overflow errors).
+        let seq_i64 = i64::try_from(seq).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_blob_chunk: seq exceeds i64 — federation_stream_chunks.seq is INTEGER".into(),
+            )
+        })?;
+        let epoch_i64 = i64::try_from(epoch).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_blob_chunk: epoch exceeds i64 — federation_stream_chunks.epoch is INTEGER"
+                    .into(),
+            )
+        })?;
+
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let stream_id_owned = stream_id.to_string();
+        let conn = self.conn.clone();
+        let chunk_sha = row.sha256;
+        // Returns Ok(true) on successful append, Ok(false) on a
+        // (stream_id, seq) PK conflict (monotonicity violation), Err on a
+        // real backend error.
+        let appended = (move || -> Result<bool, rusqlite::Error> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction()?;
+            // 1. The chunk's bytes as a normal federation_blobs row
+            //    (content-addressed + idempotent).
+            let sha_vec = row.sha256.to_vec();
+            tx.execute(
+                "INSERT INTO federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type, \
+                    last_accessed_at, access_count\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, 0) \
+                 ON CONFLICT (sha256) DO NOTHING",
+                rusqlite::params![
+                    sha_vec,
+                    row.storage_kind,
+                    row.bytes_inline,
+                    row.external_ref,
+                    row.size_bytes,
+                    now_iso,
+                ],
+            )?;
+            // 2. The stream-index row. (stream_id, seq) PK = monotonicity.
+            let inserted = tx.execute(
+                "INSERT INTO federation_stream_chunks (\
+                    stream_id, seq, chunk_sha, epoch, size_bytes, created_at\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT (stream_id, seq) DO NOTHING",
+                rusqlite::params![
+                    stream_id_owned,
+                    seq_i64,
+                    sha_vec,
+                    epoch_i64,
+                    row.size_bytes,
+                    now_iso,
+                ],
+            )?;
+            if inserted == 0 {
+                // PK conflict → roll back (drop the tx without commit).
+                return Ok(false);
+            }
+            tx.commit()?;
+            Ok(true)
+        })()
+        .map_err(|e| crate::federation::BlobError::Backend(format!("put_blob_chunk tx: {e}")))?;
+        if !appended {
+            return Err(crate::federation::BlobError::InvalidArgument(format!(
+                "stream {stream_id} seq {seq} already exists"
+            )));
+        }
+        Ok(chunk_sha)
+    }
+
+    async fn seal_stream(&self, stream_id: &str) -> Result<[u8; 32], crate::federation::BlobError> {
+        let cap = self.inline_bytes_cap();
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let stream_id_owned = stream_id.to_string();
+        let conn = self.conn.clone();
+        // All DB work inside one closure / one txn.
+        let manifest_sha = (move || -> Result<[u8; 32], crate::federation::BlobError> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction().map_err(|e| {
+                crate::federation::BlobError::Backend(format!("seal_stream tx: {e}"))
+            })?;
+
+            // 1. Read the seq-ordered chunk index.
+            let chunk_rows: Vec<([u8; 32], i64)> = {
+                let mut stmt = tx
+                    .prepare(
+                        "SELECT chunk_sha, size_bytes \
+                           FROM federation_stream_chunks \
+                          WHERE stream_id = ?1 \
+                          ORDER BY seq ASC",
+                    )
+                    .map_err(|e| {
+                        crate::federation::BlobError::Backend(format!("seal_stream prepare: {e}"))
+                    })?;
+                let rows = stmt
+                    .query_map(rusqlite::params![stream_id_owned], |r| {
+                        let sha_vec: Vec<u8> = r.get(0)?;
+                        let size: i64 = r.get(1)?;
+                        Ok((sha_vec, size))
+                    })
+                    .map_err(|e| {
+                        crate::federation::BlobError::Backend(format!("seal_stream query: {e}"))
+                    })?;
+                let mut out = Vec::new();
+                for r in rows {
+                    let (sha_vec, size) = r.map_err(|e| {
+                        crate::federation::BlobError::Backend(format!("seal_stream row: {e}"))
+                    })?;
+                    if sha_vec.len() != 32 {
+                        return Err(crate::federation::BlobError::Backend(format!(
+                            "seal_stream: chunk_sha is {} bytes, expected 32",
+                            sha_vec.len()
+                        )));
+                    }
+                    let mut sha = [0u8; 32];
+                    sha.copy_from_slice(&sha_vec);
+                    out.push((sha, size));
+                }
+                out
+            };
+
+            // 2. Build the sealed manifest + chunk_dag manifest row
+            //    (empty stream → InvalidArgument inside the helper).
+            let (_manifest, manifest_row) = crate::federation::blobs::prepare_sealed_manifest_row(
+                &stream_id_owned,
+                &chunk_rows,
+                cap,
+            )?;
+
+            // 3. Write ONLY the manifest row (chunk rows already exist).
+            let manifest_sha_vec = manifest_row.sha256.to_vec();
+            tx.execute(
+                "INSERT INTO federation_blobs (\
+                    sha256, storage_kind, bytes_inline, external_ref, size_bytes, media_type, \
+                    last_accessed_at, access_count\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, 0) \
+                 ON CONFLICT (sha256) DO NOTHING",
+                rusqlite::params![
+                    manifest_sha_vec,
+                    manifest_row.storage_kind,
+                    manifest_row.bytes_inline,
+                    manifest_row.external_ref,
+                    manifest_row.size_bytes,
+                    now_iso,
+                ],
+            )
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("seal_stream manifest insert: {e}"))
+            })?;
+
+            // 4. Stamp sealed_at on the index rows (informational).
+            tx.execute(
+                "UPDATE federation_stream_chunks SET sealed_at = ?2 WHERE stream_id = ?1",
+                rusqlite::params![stream_id_owned, now_iso],
+            )
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("seal_stream sealed_at: {e}"))
+            })?;
+
+            tx.commit().map_err(|e| {
+                crate::federation::BlobError::Backend(format!("seal_stream commit: {e}"))
+            })?;
+            Ok(manifest_row.sha256)
+        })()?;
+        Ok(manifest_sha)
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -16997,6 +17177,152 @@ mod tests {
             }
             other => panic!("expected RangeSpansExternalChunk, got {other:?}"),
         }
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut C1a) — live stream chunks ──────
+
+    /// Append 3 chunks to a stream, seal, and read the assembled bytes
+    /// back via get_blob_range over the sealed manifest sha — end-to-end
+    /// with the Cut B ChunkDag path, including a range that crosses a
+    /// chunk boundary.
+    #[tokio::test]
+    async fn stream_append_seal_and_range_round_trip() {
+        let backend = blob_test_backend().await;
+        let stream = "stream-rt";
+        // 3 chunks: "AAAA"(0..=3) "BBBB"(4..=7) "CC"(8..=9), total 10.
+        let s0 = backend
+            .put_blob_chunk(stream, 0, BlobBody::Inline(b"AAAA".to_vec()), 0)
+            .await
+            .unwrap();
+        let s1 = backend
+            .put_blob_chunk(stream, 1, BlobBody::Inline(b"BBBB".to_vec()), 0)
+            .await
+            .unwrap();
+        let s2 = backend
+            .put_blob_chunk(stream, 2, BlobBody::Inline(b"CC".to_vec()), 0)
+            .await
+            .unwrap();
+        assert_eq!(s0, sha256_of(b"AAAA"));
+        assert_eq!(s1, sha256_of(b"BBBB"));
+        assert_eq!(s2, sha256_of(b"CC"));
+        // Each chunk landed as its own federation_blobs row.
+        assert!(backend.has_blob(&s0).await.unwrap());
+        assert!(backend.has_blob(&s1).await.unwrap());
+        assert!(backend.has_blob(&s2).await.unwrap());
+
+        let manifest_sha = backend.seal_stream(stream).await.unwrap();
+
+        // The sealed sha resolves as a ChunkDag manifest in seq order.
+        match backend.get_blob(&manifest_sha).await.unwrap().unwrap() {
+            BlobBody::ChunkDag(m) => {
+                assert_eq!(m.v, crate::federation::CHUNK_MANIFEST_VERSION);
+                assert_eq!(m.total_size, 10);
+                assert_eq!(m.chunks.len(), 3);
+                assert_eq!(m.chunks[0].sha, s0);
+                assert_eq!(m.chunks[1].sha, s1);
+                assert_eq!(m.chunks[2].sha, s2);
+            }
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+
+        // Full range assembles the whole stream.
+        let full = backend
+            .get_blob_range(&manifest_sha, 0, 9)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(full, BlobRange::Inline(b"AAAABBBBCC".to_vec()));
+        // A range across the chunk0/chunk1 boundary: "AABB".
+        let span = backend
+            .get_blob_range(&manifest_sha, 2, 5)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(span, BlobRange::Inline(b"AABB".to_vec()));
+        // A range crossing all three chunks: "ABBBBC".
+        let across = backend
+            .get_blob_range(&manifest_sha, 3, 8)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(across, BlobRange::Inline(b"ABBBBC".to_vec()));
+    }
+
+    /// A re-used (stream_id, seq) is rejected (monotonicity guarantee).
+    #[tokio::test]
+    async fn stream_seq_collision_rejected() {
+        let backend = blob_test_backend().await;
+        let stream = "stream-collide";
+        backend
+            .put_blob_chunk(stream, 0, BlobBody::Inline(b"first".to_vec()), 0)
+            .await
+            .unwrap();
+        // Same seq, different bytes → PK conflict → InvalidArgument.
+        let err = backend
+            .put_blob_chunk(stream, 0, BlobBody::Inline(b"second".to_vec()), 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        // The second chunk's bytes did NOT get indexed: a fresh seq still
+        // works and the stream seals to exactly the first chunk.
+        let manifest_sha = backend.seal_stream(stream).await.unwrap();
+        match backend.get_blob(&manifest_sha).await.unwrap().unwrap() {
+            BlobBody::ChunkDag(m) => {
+                assert_eq!(m.chunks.len(), 1);
+                assert_eq!(m.chunks[0].sha, sha256_of(b"first"));
+            }
+            other => panic!("expected ChunkDag, got {other:?}"),
+        }
+    }
+
+    /// Sealing a stream with no chunks is rejected.
+    #[tokio::test]
+    async fn stream_seal_empty_rejected() {
+        let backend = blob_test_backend().await;
+        let err = backend.seal_stream("nonexistent-stream").await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    /// A ChunkDag body to put_blob_chunk is rejected (can't chunk a chunk).
+    #[tokio::test]
+    async fn stream_chunk_dag_body_rejected() {
+        let backend = blob_test_backend().await;
+        let nested = crate::federation::ChunkManifest {
+            v: 1,
+            total_size: 4,
+            chunks: vec![crate::federation::ChunkRef {
+                sha: sha256_of(b"AAAA"),
+                size: 4,
+            }],
+        };
+        let err = backend
+            .put_blob_chunk("s", 0, BlobBody::ChunkDag(nested), 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    /// epoch is stored on the index row (no crypto this cut, but the
+    /// column round-trips).
+    #[tokio::test]
+    async fn stream_epoch_stored_on_index() {
+        let backend = blob_test_backend().await;
+        let stream = "stream-epoch";
+        backend
+            .put_blob_chunk(stream, 0, BlobBody::Inline(b"AAAA".to_vec()), 7)
+            .await
+            .unwrap();
+        let epoch: i64 = {
+            let conn = backend.conn.clone();
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT epoch FROM federation_stream_chunks WHERE stream_id = ?1 AND seq = 0",
+                rusqlite::params![stream],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(epoch, 7);
     }
 
     /// v4.1 (CIRISPersist#142, Cut B) — the V061 SQLite 12-step table


### PR DESCRIPTION
**Cut C1a of the streaming substrate** ([`FSD/V4_1_STREAMING_SUBSTRATE.md`](FSD/V4_1_STREAMING_SUBSTRATE.md) §4.3; #142). The live-stream chunk index — pure substrate, no crypto (that's C2/C3). Builds on Cut A (`get_blob_range`) + Cut B (`ChunkDag`).

## Adds
- **V062** `federation_stream_chunks (stream_id, seq) → chunk_sha, epoch, size` — NEW table, `PRIMARY KEY (stream_id, seq)` IS the monotonicity guarantee; `(stream_id, epoch)` index for the later epoch walk. Pure-additive (no CHECK rebuild).
- `put_blob_chunk(stream_id, seq, body, epoch) → sha` — atomic: content-addressed chunk blob + index row in one txn; seq collision → rejected (monotonicity); `epoch` stored for the later cascade.
- `seal_stream(stream_id) → manifest_sha` — reads the index by seq, builds a Cut-B `ChunkManifest`, writes only the `chunk_dag` manifest row (chunks already exist); after seal, `get_blob_range` over the sealed sha reassembles via Cut B end-to-end.
- PyO3: thin `put_blob_chunk` + `seal_stream`.

## Verification (local, incl. live postgres)
- **883 tests** pass on `cargo test --features "postgres server pyo3 sqlite" --lib` against live PG (the 3 `pg_stream_*` tests ran live); V062 applied clean on real PG + fresh sqlite.
- Clean under `-D warnings`: `--no-default-features`, `--features test-panic,pyo3`, full CI gated combo. No `u64` PG binds.
- End-to-end test: append 3 chunks → seal → range-read across chunk boundaries.

Next: C1b (per-stream transparency log / producer-signed STH), then C2 (STREAM-nonce AEAD), C3 (epoch-DEK PQC cascade + RC1-1c migration), C4 (delivery receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)