### PR TITLE
Streaming Cut C1b — per-stream transparency log (producer-signed STH + RFC 6962 proofs, #142)

### DIFF
--- a/migrations/postgres/lens/V063__federation_stream_sth.sql
+++ b/migrations/postgres/lens/V063__federation_stream_sth.sql
@@ -1,0 +1,103 @@
+-- V063 — federation_stream_sth per-stream transparency log, Postgres
+-- dialect (CIRISPersist#142, Cut C1b — producer-signed STH + RFC 6962
+-- inclusion/consistency proofs over a stream's chunks; CEG 0.10
+-- §10.5.1).
+--
+-- Cut C1b makes each live stream (Cut C1a) its OWN RFC 6962
+-- transparency log. The log's `log_id` is `stream:<stream_id>`; its
+-- LEAVES are the chunk hashes already stored in
+-- `federation_stream_chunks` (Cut C1a) — this table does NOT duplicate
+-- leaf storage. What it stores is the **Signed Tree Head**: a
+-- producer-signed snapshot of the log at a given `tree_size`.
+--
+-- # The anti-equivocation gate (why this is security-critical)
+--
+-- `put_stream_sth` is the integrity gate. Before a row lands here,
+-- persist:
+--   1. recomputes the Merkle root from ITS OWN stored chunks
+--      (federation_stream_chunks, seq ASC, first `tree_size` of them)
+--      via the CIRISVerify RFC 6962 store, and asserts it equals the
+--      STH's claimed `root_hash` — a producer cannot register a root
+--      inconsistent with the chunks persist holds; and
+--   2. verifies the producer's hybrid signature over the STH's
+--      canonical signing bytes, with the producer's public key resolved
+--      from `federation_keys` (NOT from the bytes embedded in the
+--      signature).
+-- Only then is the row inserted. Persist does NOT sign stream STHs
+-- (unlike the audit log's `merkle_sth_log`) — the producer signs; this
+-- is the best-effort tier (CEG §10.5.1: producer-signed only, no
+-- witness-cosign quorum enforcement THIS cut).
+--
+-- # Append-only / monotonic
+--
+-- PRIMARY KEY (stream_id, tree_size): one STH per (stream, size). A
+-- second STH at the same (stream_id, tree_size) with a DIFFERENT root
+-- is an equivocation attempt → rejected by `put_stream_sth` (it reads
+-- the existing row's root and compares); an identical re-PUT is
+-- idempotent. `tree_size` is u64 in Rust → bound as i64 (BIGINT);
+-- tokio_postgres has no ToSql for u64.
+--
+-- # No CHECK-rebuild
+--
+-- NEW table — pure additive.
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_stream_sth (
+    -- The stream this STH describes. The log_id baked into the STH is
+    -- `stream:<stream_id>` (CEG §10.5.1 log_id); this column is the
+    -- parsed `<stream_id>` and joins to federation_stream_chunks.
+    stream_id           TEXT NOT NULL,
+
+    -- Number of leaves (chunks) the STH covers — the RFC 6962 tree
+    -- size. u64 in Rust → bound i64 (BIGINT). Part of the PK.
+    tree_size           BIGINT NOT NULL,
+
+    -- Key-rotation epoch (CEG §10.5.3). Stored now; no crypto cascade
+    -- this cut (that is Cut C3). u64 in Rust → bound i64.
+    epoch               BIGINT NOT NULL DEFAULT 0,
+
+    -- The Merkle root the STH claims for `tree_size` leaves. Persist
+    -- recomputes this from its own chunks and asserts equality BEFORE
+    -- insert (the anti-equivocation gate). Exactly 32 bytes.
+    root_hash           BYTEA NOT NULL
+        CHECK (octet_length(root_hash) = 32),
+
+    -- Wall-clock the producer signed the STH (the STH's `timestamp`,
+    -- part of the signed canonical bytes).
+    signed_at           TIMESTAMPTZ NOT NULL,
+
+    -- The federation_keys key that signed this STH. The producer's
+    -- public key is resolved from federation_keys via this id for the
+    -- signature-verification gate.
+    producer_key_id     TEXT NOT NULL,
+
+    -- Serialized `ciris_crypto::HybridSignature` (Ed25519 + ML-DSA-65)
+    -- over the STH's canonical signing bytes. JSON-as-bytes, mirroring
+    -- merkle_store's `serialize_signature` so PG and SQLite share the
+    -- exact same encoding.
+    signature_blob      BYTEA NOT NULL,
+
+    -- Serialized witness cosignatures (CEG §10.5.1). Stored as-provided
+    -- (default empty) — Cut C1b does NOT enforce a cosign quorum
+    -- (best-effort tier = producer-signed only). Mirrors merkle_store's
+    -- witness serialization. JSONB so the column is queryable later.
+    witness_signatures  JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+    -- One STH per (stream, size); append-only, monotonic tree_size.
+    PRIMARY KEY (stream_id, tree_size)
+);
+
+-- Serve the `latest_stream_sth` query (highest tree_size for a stream).
+CREATE INDEX IF NOT EXISTS federation_stream_sth_stream_size
+    ON cirislens.federation_stream_sth (stream_id, tree_size DESC);
+
+COMMENT ON TABLE cirislens.federation_stream_sth IS
+    'v4.1 (CIRISPersist#142, Cut C1b, CEG §10.5.1) — per-stream transparency log: producer-signed Signed Tree Heads over a stream''s chunk hashes (leaves live in federation_stream_chunks). put_stream_sth recomputes the root from persist''s own chunks + asserts equality with the claimed root (anti-equivocation gate), then verifies the producer''s hybrid signature against federation_keys, then inserts. (stream_id, tree_size) PK = append-only/monotonic; a same-size different-root STH is an equivocation attempt and is rejected. Persist does NOT sign stream STHs.';
+
+COMMENT ON COLUMN cirislens.federation_stream_sth.tree_size IS
+    'RFC 6962 tree size (leaf count). u64 in Rust, bound i64 (BIGINT). Part of the PK.';
+
+COMMENT ON COLUMN cirislens.federation_stream_sth.root_hash IS
+    'Merkle root the STH claims. Recomputed from federation_stream_chunks and asserted equal BEFORE insert (anti-equivocation gate). 32 bytes.';
+
+COMMENT ON COLUMN cirislens.federation_stream_sth.signature_blob IS
+    'Serialized ciris_crypto::HybridSignature (JSON-as-bytes) over the STH signing bytes; verified against the federation_keys row named by producer_key_id.';

--- a/migrations/sqlite/lens/V063__federation_stream_sth.sql
+++ b/migrations/sqlite/lens/V063__federation_stream_sth.sql
@@ -1,0 +1,60 @@
+-- V063 — federation_stream_sth per-stream transparency log, SQLite
+-- dialect (CIRISPersist#142, Cut C1b — producer-signed STH + RFC 6962
+-- inclusion/consistency proofs over a stream's chunks; CEG 0.10
+-- §10.5.1).
+--
+-- Mirrors postgres/lens/V063. NEW table — pure additive. See the PG
+-- sibling for the full rationale:
+--   * each live stream is its own RFC 6962 log; leaves are the chunk
+--     hashes in federation_stream_chunks (NOT duplicated here)
+--   * (stream_id, tree_size) PK = append-only / monotonic; a same-size
+--     different-root STH is an equivocation attempt → rejected by
+--     put_stream_sth
+--   * put_stream_sth recomputes the root from persist's own chunks +
+--     asserts equality (anti-equivocation gate), then verifies the
+--     producer's hybrid signature against federation_keys, then inserts
+--   * persist does NOT sign stream STHs (producer-signed best-effort
+--     tier; no witness-cosign quorum enforcement this cut)
+--
+-- Type mapping vs. PG: BIGINT→INTEGER, BYTEA→BLOB, TIMESTAMPTZ→TEXT
+-- (RFC3339), JSONB→TEXT. tree_size/epoch are u64 in Rust → bound i64.
+
+CREATE TABLE IF NOT EXISTS federation_stream_sth (
+    -- Parsed `<stream_id>` from the STH's `stream:<id>` log_id (CEG
+    -- §10.5.1). Joins to federation_stream_chunks.
+    stream_id           TEXT NOT NULL,
+
+    -- RFC 6962 tree size (leaf/chunk count). u64 in Rust, bound i64.
+    -- Part of the PK.
+    tree_size           INTEGER NOT NULL,
+
+    -- Key-rotation epoch (CEG §10.5.3). Stored now; cascade is Cut C3.
+    epoch               INTEGER NOT NULL DEFAULT 0,
+
+    -- Merkle root the STH claims. Recomputed from persist's own chunks
+    -- and asserted equal BEFORE insert (anti-equivocation gate). 32 B.
+    root_hash           BLOB NOT NULL
+        CHECK (length(root_hash) = 32),
+
+    -- Wall-clock the producer signed the STH (RFC3339).
+    signed_at           TEXT NOT NULL,
+
+    -- The federation_keys key that signed; the producer pubkey is
+    -- resolved from federation_keys via this id for the sig gate.
+    producer_key_id     TEXT NOT NULL,
+
+    -- Serialized ciris_crypto::HybridSignature (JSON-as-bytes), mirror
+    -- of merkle_store's serialize_signature (same encoding PG/SQLite).
+    signature_blob      BLOB NOT NULL,
+
+    -- Serialized witness cosignatures (CEG §10.5.1). Stored as-provided
+    -- (default empty); no cosign quorum enforcement this cut.
+    witness_signatures  TEXT NOT NULL DEFAULT '[]',
+
+    -- One STH per (stream, size); append-only, monotonic tree_size.
+    PRIMARY KEY (stream_id, tree_size)
+);
+
+-- Serve latest_stream_sth (highest tree_size for a stream).
+CREATE INDEX IF NOT EXISTS federation_stream_sth_stream_size
+    ON federation_stream_sth (stream_id, tree_size DESC);

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -537,6 +537,78 @@ pub trait BlobStorage: Send + Sync {
         stream_id: &str,
     ) -> impl Future<Output = Result<[u8; 32], BlobError>> + Send;
 
+    /// v4.1 (CIRISPersist#142, Cut C1b) — store a **producer-signed**
+    /// Signed Tree Head for a stream's transparency log (CEG §10.5.1).
+    ///
+    /// A stream is its own RFC 6962 log (`log_id = stream:<id>`) whose
+    /// leaves are the chunk hashes in `federation_stream_chunks`. The
+    /// PRODUCER signs the STH; persist's job is integrity-gating, in
+    /// **EXACTLY this order** (the anti-equivocation gate):
+    ///
+    /// 1. Parse `stream_id` from `sth.log_id` (must be `stream:<id>`,
+    ///    else [`BlobError::InvalidArgument`]).
+    /// 2. Load the first `sth.tree_size` chunk hashes for the stream
+    ///    (`seq ASC`). Fewer than `tree_size` exist →
+    ///    [`BlobError::InvalidArgument`] (the STH claims more leaves than
+    ///    persist holds).
+    /// 3. Recompute the Merkle root over those leaves via CIRISVerify's
+    ///    [`InMemoryTransparencyStore`](ciris_verify_core::transparency::InMemoryTransparencyStore)
+    ///    (RFC 6962 — **not** reimplemented here).
+    /// 4. Assert the recomputed root equals `sth.root_hash`; mismatch →
+    ///    [`BlobError::InvalidArgument`]. **Not optional.**
+    /// 5. Verify the producer's hybrid signature over
+    ///    `sth.signing_bytes_of()`, resolving the producer's public key
+    ///    from `federation_keys` via `producer_key_id`. Bad signature →
+    ///    [`BlobError::InvalidArgument`].
+    /// 6. INSERT. A `(stream_id, tree_size)` PK conflict with a DIFFERENT
+    ///    root → [`BlobError::InvalidArgument`] (equivocation attempt);
+    ///    an identical re-PUT is idempotent (`Ok`).
+    ///
+    /// Persist does NOT sign stream STHs (unlike the audit log). Witness
+    /// cosignatures are stored as-provided (default empty); Cut C1b does
+    /// NOT enforce a cosign quorum (best-effort tier — CEG §10.5.1).
+    fn put_stream_sth(
+        &self,
+        sth: ciris_verify_core::transparency::SignedTreeHead,
+        producer_key_id: &str,
+    ) -> impl Future<Output = Result<(), BlobError>> + Send;
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — the most recent STH (highest
+    /// `tree_size`) stored for `stream_id`, or `None` if no STH exists.
+    fn latest_stream_sth(
+        &self,
+        stream_id: &str,
+    ) -> impl Future<
+        Output = Result<Option<ciris_verify_core::transparency::SignedTreeHead>, BlobError>,
+    > + Send;
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — RFC 6962 inclusion proof for
+    /// the chunk at `leaf_index` against a `tree_size`-leaf tree, built
+    /// from the stream's stored chunk hashes via
+    /// [`InMemoryTransparencyStore`](ciris_verify_core::transparency::InMemoryTransparencyStore).
+    /// `None` if the stream has fewer than `tree_size` chunks or
+    /// `leaf_index >= tree_size`.
+    fn stream_inclusion_proof(
+        &self,
+        stream_id: &str,
+        leaf_index: u64,
+        tree_size: u64,
+    ) -> impl Future<Output = Result<Option<ciris_verify_core::transparency::MerkleProof>, BlobError>>
+           + Send;
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — RFC 6962 §2.1.2 consistency
+    /// proof between `from_size` and `to_size`, built from the stream's
+    /// stored chunk hashes. `None` if the stream has fewer than
+    /// `to_size` chunks.
+    fn stream_consistency_proof(
+        &self,
+        stream_id: &str,
+        from_size: u64,
+        to_size: u64,
+    ) -> impl Future<
+        Output = Result<Option<ciris_verify_core::transparency::ConsistencyProof>, BlobError>,
+    > + Send;
+
     /// Read a blob by its SHA-256.
     ///
     /// Returns the [`BlobBody`] variant matching the row's stored
@@ -1504,6 +1576,53 @@ pub(crate) fn prepare_sealed_manifest_row(
         size_bytes: manifest_size,
     };
     Ok((manifest, row))
+}
+
+/// v4.1 (CIRISPersist#142, Cut C1b) — **step 5 of the `put_stream_sth`
+/// gate**: verify the producer's hybrid signature over the STH's
+/// canonical signing bytes, resolving the producer's PINNED public key
+/// from `federation_keys` via `producer_key_id`.
+///
+/// The producer's keys come from the directory, **not** from the
+/// pubkeys embedded in the STH's `HybridSignature` — a forged STH
+/// carrying its own keypair cannot self-certify. Uses
+/// [`HybridPolicy::Strict`](crate::verify::HybridPolicy::Strict): a
+/// stream STH must carry both signature components (no hybrid-pending
+/// acceptance for transparency heads). Any verification failure —
+/// unknown key, bad signature, missing PQC — maps to
+/// [`BlobError::InvalidArgument`] so the gate rejects fast.
+///
+/// Mirrors the `verify_hybrid_via_directory` usage at
+/// `src/server/secrets.rs`.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) async fn verify_stream_sth_signature<F>(
+    directory: &F,
+    sth: &ciris_verify_core::transparency::SignedTreeHead,
+    producer_key_id: &str,
+) -> Result<(), BlobError>
+where
+    F: crate::federation::FederationDirectory,
+{
+    let (ed25519_sig_b64, ml_dsa_65_sig_b64) =
+        crate::federation::stream_sth::signature_b64_parts(sth);
+    let signing_bytes = sth.signing_bytes_of();
+    crate::verify::verify_hybrid_via_directory(
+        directory,
+        &signing_bytes,
+        producer_key_id,
+        &ed25519_sig_b64,
+        ml_dsa_65_sig_b64.as_deref(),
+        crate::verify::HybridPolicy::Strict,
+        None,
+    )
+    .await
+    .map(|_outcome| ())
+    .map_err(|e| {
+        BlobError::InvalidArgument(format!(
+            "put_stream_sth: producer signature verification failed for \
+             key_id={producer_key_id}: {e}"
+        ))
+    })
 }
 
 /// v4.1 (CIRISPersist#142, Cut B) — validate a `put_blob_chunks`

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -50,6 +50,7 @@ pub mod rooting;
 pub mod schema_resolver;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_open;
+pub mod stream_sth;
 pub mod topology;
 pub mod trust_grant;
 pub mod types;
@@ -114,6 +115,10 @@ pub use schema_resolver::{
 };
 #[cfg(feature = "sqlite")]
 pub use sqlite_open::FederationDirectorySqlite;
+pub use stream_sth::{
+    log_id_for_stream, parse_stream_id, recompute_and_assert_root, StreamChunkLeaf,
+    STREAM_LOG_ID_PREFIX,
+};
 pub use topology::{
     build_delegation_graph, build_trust_topology, AuditChainEntry, AuditChainProof, DelegationEdge,
     DelegationGraph, EdgeType, FederationDirectoryFilter, TrustEdge, TrustNode, TrustTopology,

--- a/src/federation/stream_sth.rs
+++ b/src/federation/stream_sth.rs
@@ -1,0 +1,440 @@
+//! v4.1 (CIRISPersist#142, Cut C1b) — per-stream transparency log
+//! (CEG 0.10 §10.5.1).
+//!
+//! Each live stream (Cut C1a) is its own RFC 6962 transparency log:
+//! its `log_id` is `stream:<stream_id>`, and its **leaves are the chunk
+//! hashes** already stored in `federation_stream_chunks` (Cut C1a). This
+//! module does NOT duplicate leaf storage; it stores producer-signed
+//! [`SignedTreeHead`]s in `federation_stream_sth` (V063) and computes
+//! RFC 6962 inclusion / consistency proofs **over those chunk hashes**.
+//!
+//! # RFC 6962 is NOT reimplemented here
+//!
+//! Every root / proof computation delegates to CIRISVerify's
+//! [`InMemoryTransparencyStore`] — the same store the audit
+//! `merkle_store` uses (see `src/audit/merkle_store.rs`). We build the
+//! store from the stream's chunk-hash leaves and call its
+//! `root` / `inclusion_proof` / `consistency_proof`. Reimplementing the
+//! tree math would subtly break proof compatibility with every other
+//! CIRIS transparency consumer.
+//!
+//! # The anti-equivocation gate (`put_stream_sth`)
+//!
+//! Persist does NOT sign stream STHs (unlike the audit log). The
+//! producer signs; persist's job is integrity-gating, in EXACTLY this
+//! order:
+//!
+//! 1. Parse `stream_id` from `sth.log_id` (must be `stream:<id>`).
+//! 2. Load the first `sth.tree_size` chunk hashes from
+//!    `federation_stream_chunks` (seq ASC). Fewer than `tree_size`
+//!    exist → reject ([`BlobError::InvalidArgument`]): the STH claims
+//!    more leaves than persist holds.
+//! 3. Build an [`InMemoryTransparencyStore`] from those leaves; compute
+//!    its root.
+//! 4. Assert `computed_root == sth.root_hash` — mismatch → reject. This
+//!    is the anti-equivocation integrity gate; it is NOT optional.
+//! 5. Verify the producer's hybrid signature over `sth.signing_bytes_of()`
+//!    using the producer's public key resolved from `federation_keys`
+//!    (the `producer_key_id`) — NOT the pubkeys embedded in the
+//!    signature. Reject on a bad signature.
+//! 6. Only then INSERT. A `(stream_id, tree_size)` PK conflict with a
+//!    DIFFERENT root → reject (equivocation attempt); identical →
+//!    idempotent OK.
+//!
+//! Steps 1–4 (pure, no I/O) live in this module
+//! ([`parse_stream_id`], [`recompute_and_assert_root`]); steps 5–6 live
+//! in the backend `BlobStorage` impls (they own the SQL + the
+//! `FederationDirectory` the signature check resolves against).
+
+use ciris_verify_core::transparency::{
+    ConsistencyProof, InMemoryTransparencyStore, MerkleProof, SignedTreeHead, TransparencyError,
+    TransparencyLeaf, TransparencyStore, WitnessSignature,
+};
+
+use super::BlobError;
+
+/// The `log_id` prefix for a per-stream transparency log
+/// (CEG §10.5.1). The full log_id is `stream:<stream_id>`.
+pub const STREAM_LOG_ID_PREFIX: &str = "stream:";
+
+/// v4.1 (Cut C1b) — the `log_id` for a stream's transparency log.
+/// Mirrors `merkle_store::log_id_for_tenant` (`tenant:<id>`).
+#[must_use]
+pub fn log_id_for_stream(stream_id: &str) -> String {
+    format!("{STREAM_LOG_ID_PREFIX}{stream_id}")
+}
+
+/// v4.1 (Cut C1b) — a [`TransparencyLeaf`] wrapping one stream chunk's
+/// 32-byte SHA-256 (a `federation_stream_chunks.chunk_sha`).
+///
+/// Its [`canonical_bytes`](TransparencyLeaf::canonical_bytes) are the
+/// 32 raw chunk-sha bytes — the leaf DATA. The CIRISVerify store
+/// applies the RFC 6962 §2.1 `0x00` leaf-hash prefix on top. This
+/// mirrors how [`AuditLeaf`](crate::audit) implements `TransparencyLeaf`
+/// (the leaf returns its canonical content; the store does the hashing).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StreamChunkLeaf {
+    /// The chunk's content address (SHA-256), the leaf data.
+    pub chunk_sha: [u8; 32],
+}
+
+impl StreamChunkLeaf {
+    /// Wrap a chunk SHA as a transparency leaf.
+    #[must_use]
+    pub fn new(chunk_sha: [u8; 32]) -> Self {
+        Self { chunk_sha }
+    }
+}
+
+impl TransparencyLeaf for StreamChunkLeaf {
+    fn canonical_bytes(&self) -> Result<Vec<u8>, TransparencyError> {
+        // The leaf data is the 32-byte chunk sha. The crate applies the
+        // RFC 6962 0x00 leaf-hash prefix — we do NOT prefix here.
+        Ok(self.chunk_sha.to_vec())
+    }
+}
+
+/// v4.1 (Cut C1b) — parse the `stream_id` out of an STH `log_id`.
+///
+/// The log_id must be `stream:<stream_id>` (CEG §10.5.1); anything else
+/// is rejected — a stream STH cannot describe a non-stream log.
+///
+/// # Errors
+///
+/// [`BlobError::InvalidArgument`] if `log_id` lacks the `stream:`
+/// prefix or the `<stream_id>` is empty.
+pub fn parse_stream_id(log_id: &str) -> Result<&str, BlobError> {
+    let id = log_id.strip_prefix(STREAM_LOG_ID_PREFIX).ok_or_else(|| {
+        BlobError::InvalidArgument(format!(
+            "put_stream_sth: log_id {log_id:?} is not a stream log \
+             (expected `stream:<id>`)"
+        ))
+    })?;
+    if id.is_empty() {
+        return Err(BlobError::InvalidArgument(
+            "put_stream_sth: empty stream_id in log_id".into(),
+        ));
+    }
+    Ok(id)
+}
+
+/// v4.1 (Cut C1b) — build an [`InMemoryTransparencyStore`] over a
+/// stream's chunk-hash leaves.
+///
+/// The single place this module constructs the RFC 6962 store. The
+/// `chunk_hashes` are the `federation_stream_chunks.chunk_sha` values in
+/// `seq ASC` order; each becomes a [`StreamChunkLeaf`].
+fn build_store(
+    chunk_hashes: &[[u8; 32]],
+) -> Result<InMemoryTransparencyStore<StreamChunkLeaf>, BlobError> {
+    let store: InMemoryTransparencyStore<StreamChunkLeaf> = InMemoryTransparencyStore::new(None);
+    for sha in chunk_hashes {
+        store
+            .append(StreamChunkLeaf::new(*sha))
+            .map_err(|e| BlobError::Backend(format!("stream-sth append leaf: {e}")))?;
+    }
+    Ok(store)
+}
+
+/// v4.1 (Cut C1b) — **the anti-equivocation gate** (steps 2–4).
+///
+/// `chunk_hashes` MUST be the first `tree_size` chunk hashes of the
+/// stream in seq order (the backend loads exactly that). This:
+///
+/// - rejects if `chunk_hashes.len() < tree_size` (the STH claims more
+///   leaves than persist holds);
+/// - builds the RFC 6962 store from the (first `tree_size`) leaves and
+///   recomputes the root via [`InMemoryTransparencyStore`]; and
+/// - asserts the recomputed root equals `sth.root_hash`.
+///
+/// Returns `Ok(())` only when persist's own chunks reproduce the STH's
+/// claimed root. NO signature work here — that is step 5, in the backend.
+///
+/// # Errors
+///
+/// [`BlobError::InvalidArgument`] on an over-claimed `tree_size` or a
+/// root mismatch.
+pub fn recompute_and_assert_root(
+    sth: &SignedTreeHead,
+    chunk_hashes: &[[u8; 32]],
+) -> Result<(), BlobError> {
+    let tree_size = usize::try_from(sth.tree_size).map_err(|_| {
+        BlobError::InvalidArgument("put_stream_sth: tree_size exceeds usize".into())
+    })?;
+
+    // Step 2: persist must hold at least `tree_size` chunks.
+    if chunk_hashes.len() < tree_size {
+        return Err(BlobError::InvalidArgument(format!(
+            "put_stream_sth: STH claims tree_size {tree_size} but persist \
+             holds only {} chunks for the stream",
+            chunk_hashes.len()
+        )));
+    }
+
+    // Step 3: build the RFC 6962 store over EXACTLY the first
+    // `tree_size` leaves and recompute the root.
+    let store = build_store(&chunk_hashes[..tree_size])?;
+    let computed_root = store
+        .root()
+        .map_err(|e| BlobError::Backend(format!("stream-sth root: {e}")))?;
+
+    // Step 4: the assertion. A producer-claimed root that does not match
+    // persist's own chunks is an equivocation attempt → reject.
+    if computed_root != sth.root_hash {
+        return Err(BlobError::InvalidArgument(format!(
+            "put_stream_sth: root mismatch — STH claims {} but persist's \
+             {tree_size} chunks reproduce {} (anti-equivocation gate)",
+            hex::encode(sth.root_hash),
+            hex::encode(computed_root),
+        )));
+    }
+    Ok(())
+}
+
+/// v4.1 (Cut C1b) — extract the base64 Ed25519 + optional ML-DSA-65
+/// signature components from a stored/parsed [`SignedTreeHead`]'s
+/// [`HybridSignature`](ciris_crypto::HybridSignature), for handing to
+/// [`verify_hybrid_via_directory`](crate::verify::verify_hybrid_via_directory).
+///
+/// The directory path resolves the producer's PINNED public keys from
+/// `federation_keys` (it does NOT trust the pubkeys embedded in the
+/// signature), so a forged STH carrying its own keypair cannot
+/// self-certify. ML-DSA-65 is returned `None` only for a
+/// classical-only signature mode (the hybrid-pending window); a normal
+/// hybrid STH returns `Some`.
+#[must_use]
+pub fn signature_b64_parts(sth: &SignedTreeHead) -> (String, Option<String>) {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    let ed25519_sig_b64 = B64.encode(&sth.signature.classical.signature);
+    let pqc_sig_b64 = match sth.signature.mode {
+        ciris_crypto::SignatureMode::ClassicalOnly => None,
+        _ => Some(B64.encode(&sth.signature.pqc.signature)),
+    };
+    (ed25519_sig_b64, pqc_sig_b64)
+}
+
+/// v4.1 (Cut C1b) — RFC 6962 inclusion proof for `leaf_index` against a
+/// tree of `tree_size` leaves, built from the stream's chunk hashes.
+///
+/// `chunk_hashes` is the stream's seq-ordered chunk hashes (the backend
+/// loads up to `tree_size`). Returns `Ok(None)` if the stream has fewer
+/// than `tree_size` chunks or `leaf_index >= tree_size`. Delegates the
+/// proof math to [`InMemoryTransparencyStore`] — no reimpl.
+pub fn inclusion_proof(
+    chunk_hashes: &[[u8; 32]],
+    leaf_index: u64,
+    tree_size: u64,
+) -> Result<Option<MerkleProof>, BlobError> {
+    let size = usize::try_from(tree_size).map_err(|_| {
+        BlobError::InvalidArgument("inclusion_proof: tree_size exceeds usize".into())
+    })?;
+    if chunk_hashes.len() < size || leaf_index >= tree_size {
+        return Ok(None);
+    }
+    let store = build_store(&chunk_hashes[..size])?;
+    let proof = store
+        .inclusion_proof(leaf_index)
+        .map_err(|e| BlobError::Backend(format!("stream inclusion_proof: {e}")))?;
+    Ok(Some(proof))
+}
+
+/// v4.1 (Cut C1b) — RFC 6962 §2.1.2 consistency proof between
+/// `from_size` and `to_size`, built from the stream's chunk hashes.
+///
+/// `chunk_hashes` is the stream's seq-ordered chunk hashes (the backend
+/// loads up to `to_size`). Returns `Ok(None)` if the stream has fewer
+/// than `to_size` chunks. The crate validates the `0 < from <= to`
+/// range. Delegates to [`InMemoryTransparencyStore`] — no reimpl.
+pub fn consistency_proof(
+    chunk_hashes: &[[u8; 32]],
+    from_size: u64,
+    to_size: u64,
+) -> Result<Option<ConsistencyProof>, BlobError> {
+    let to = usize::try_from(to_size).map_err(|_| {
+        BlobError::InvalidArgument("consistency_proof: to_size exceeds usize".into())
+    })?;
+    if chunk_hashes.len() < to {
+        return Ok(None);
+    }
+    let store = build_store(&chunk_hashes[..to])?;
+    let proof = store
+        .consistency_proof(from_size, to_size)
+        .map_err(|e| BlobError::Backend(format!("stream consistency_proof: {e}")))?;
+    Ok(Some(proof))
+}
+
+// ────────────────────────────────────────────────────────────────────
+// SignedTreeHead <-> row column helpers (dialect-independent)
+//
+// Mirror merkle_store's serialize_signature / serialize_witness_signatures
+// so the audit log and the stream log share the exact same on-disk
+// signature encoding (JSON-as-bytes for the signature, JSON text for the
+// witness list).
+// ────────────────────────────────────────────────────────────────────
+
+/// JSON-serialize the producer's `HybridSignature` for the
+/// `signature_blob` column. JSON-as-bytes so PG (BYTEA) and SQLite
+/// (BLOB) share the exact same encoding. Mirrors
+/// `merkle_store::serialize_signature`.
+pub fn serialize_signature(sig: &ciris_crypto::HybridSignature) -> Result<Vec<u8>, BlobError> {
+    serde_json::to_vec(sig)
+        .map_err(|e| BlobError::Backend(format!("stream-sth signature serialize: {e}")))
+}
+
+/// Inverse of [`serialize_signature`].
+pub fn deserialize_signature(bytes: &[u8]) -> Result<ciris_crypto::HybridSignature, BlobError> {
+    serde_json::from_slice(bytes)
+        .map_err(|e| BlobError::Backend(format!("stream-sth signature deserialize: {e}")))
+}
+
+/// JSON-serialize the witness cosignatures for the `witness_signatures`
+/// column (PG JSONB / SQLite TEXT). Stored as-provided — Cut C1b does
+/// NOT enforce a cosign quorum. Mirrors
+/// `merkle_store::serialize_witness_signatures`.
+pub fn serialize_witness_signatures(witnesses: &[WitnessSignature]) -> Result<String, BlobError> {
+    serde_json::to_string(witnesses)
+        .map_err(|e| BlobError::Backend(format!("stream-sth witness sigs serialize: {e}")))
+}
+
+/// Inverse of [`serialize_witness_signatures`].
+pub fn deserialize_witness_signatures(raw: &str) -> Result<Vec<WitnessSignature>, BlobError> {
+    serde_json::from_str(raw)
+        .map_err(|e| BlobError::Backend(format!("stream-sth witness sigs deserialize: {e}")))
+}
+
+/// Coerce a row's `root_hash` bytes into a fixed array.
+pub fn root_hash_from_bytes(raw: &[u8]) -> Result<[u8; 32], BlobError> {
+    raw.try_into().map_err(|_| {
+        BlobError::Backend(format!(
+            "stream-sth root_hash column expected 32 bytes, got {}",
+            raw.len()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_verify_core::transparency::verify_inclusion;
+    use sha2::{Digest, Sha256};
+
+    fn sha(seed: u8) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update([seed]);
+        h.finalize().into()
+    }
+
+    #[test]
+    fn leaf_canonical_bytes_are_the_raw_sha() {
+        let leaf = StreamChunkLeaf::new(sha(7));
+        assert_eq!(leaf.canonical_bytes().unwrap(), sha(7).to_vec());
+    }
+
+    #[test]
+    fn log_id_round_trip() {
+        let id = log_id_for_stream("abc");
+        assert_eq!(id, "stream:abc");
+        assert_eq!(parse_stream_id(&id).unwrap(), "abc");
+    }
+
+    #[test]
+    fn parse_rejects_non_stream_log_id() {
+        assert!(parse_stream_id("tenant:abc").is_err());
+        assert!(parse_stream_id("stream:").is_err());
+    }
+
+    #[test]
+    fn recomputed_root_matches_inmemory_store() {
+        // Build the same store the production path builds and confirm
+        // recompute_and_assert_root accepts the store's own root.
+        let hashes = [sha(1), sha(2), sha(3)];
+        let store = build_store(&hashes).unwrap();
+        let root = store.root().unwrap();
+        let sth = SignedTreeHead {
+            log_id: log_id_for_stream("s1"),
+            tree_size: 3,
+            root_hash: root,
+            timestamp: chrono::Utc::now(),
+            signature: dummy_sig(),
+            witness_signatures: Vec::new(),
+        };
+        recompute_and_assert_root(&sth, &hashes).unwrap();
+    }
+
+    #[test]
+    fn root_mismatch_is_rejected() {
+        let hashes = [sha(1), sha(2), sha(3)];
+        let sth = SignedTreeHead {
+            log_id: log_id_for_stream("s1"),
+            tree_size: 3,
+            root_hash: [0xFF; 32], // wrong root
+            timestamp: chrono::Utc::now(),
+            signature: dummy_sig(),
+            witness_signatures: Vec::new(),
+        };
+        assert!(recompute_and_assert_root(&sth, &hashes).is_err());
+    }
+
+    #[test]
+    fn over_claimed_tree_size_is_rejected() {
+        let hashes = [sha(1), sha(2)];
+        let store = build_store(&hashes).unwrap();
+        let sth = SignedTreeHead {
+            log_id: log_id_for_stream("s1"),
+            tree_size: 5, // more than the 2 chunks held
+            root_hash: store.root().unwrap(),
+            timestamp: chrono::Utc::now(),
+            signature: dummy_sig(),
+            witness_signatures: Vec::new(),
+        };
+        assert!(recompute_and_assert_root(&sth, &hashes).is_err());
+    }
+
+    #[test]
+    fn inclusion_proof_verifies() {
+        let hashes = [sha(1), sha(2), sha(3), sha(4)];
+        let proof = inclusion_proof(&hashes, 2, 4).unwrap().unwrap();
+        assert!(verify_inclusion(&proof));
+        // Out-of-range index → None.
+        assert!(inclusion_proof(&hashes, 4, 4).unwrap().is_none());
+    }
+
+    #[test]
+    fn consistency_proof_built() {
+        let hashes = [sha(1), sha(2), sha(3), sha(4)];
+        let proof = consistency_proof(&hashes, 2, 4).unwrap().unwrap();
+        assert_eq!(proof.old_tree_size, 2);
+        assert_eq!(proof.new_tree_size, 4);
+        // to_size beyond held chunks → None.
+        assert!(consistency_proof(&hashes, 2, 9).unwrap().is_none());
+    }
+
+    #[test]
+    fn signature_round_trips_through_columns() {
+        let sig = dummy_sig();
+        let blob = serialize_signature(&sig).unwrap();
+        let back = deserialize_signature(&blob).unwrap();
+        assert_eq!(back.classical.signature, sig.classical.signature);
+        let raw = serialize_witness_signatures(&[]).unwrap();
+        assert_eq!(raw, "[]");
+        assert!(deserialize_witness_signatures(&raw).unwrap().is_empty());
+    }
+
+    fn dummy_sig() -> ciris_crypto::HybridSignature {
+        ciris_crypto::HybridSignature {
+            crypto_kind: ciris_crypto::CRYPTO_KIND_CIRIS_V1,
+            classical: ciris_crypto::TaggedClassicalSignature {
+                algorithm: ciris_crypto::ClassicalAlgorithm::Ed25519,
+                signature: vec![0u8; 64],
+                public_key: vec![0u8; 32],
+            },
+            pqc: ciris_crypto::TaggedPqcSignature {
+                algorithm: ciris_crypto::PqcAlgorithm::MlDsa65,
+                signature: vec![0u8; 3309],
+                public_key: vec![0u8; 1952],
+            },
+            mode: ciris_crypto::SignatureMode::HybridRequired,
+        }
+    }
+}

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4303,6 +4303,202 @@ impl PyEngine {
         })
     }
 
+    /// v4.1 (CIRISPersist#142, Cut C1b) — store a producer-signed Signed
+    /// Tree Head for a stream's transparency log (CEG §10.5.1).
+    ///
+    /// `sth_json` is a serialized `SignedTreeHead`
+    /// (`{log_id, tree_size, root_hash, timestamp, signature,
+    /// witness_signatures}`). Persist runs the anti-equivocation gate:
+    /// it recomputes the Merkle root from its OWN stored chunks and
+    /// asserts equality with the STH's claimed root, then verifies the
+    /// producer's hybrid signature against the `producer_key_id` row in
+    /// `federation_keys`, then inserts. A root mismatch, a bad
+    /// signature, an over-claimed `tree_size`, or a same-size
+    /// different-root equivocation all raise `ValueError`. An identical
+    /// re-PUT is idempotent.
+    fn put_stream_sth(
+        &self,
+        py: Python<'_>,
+        sth_json: &str,
+        producer_key_id: &str,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let sth: ciris_verify_core::transparency::SignedTreeHead =
+                serde_json::from_str(sth_json).map_err(|e| {
+                    PyValueError::new_err(format!("put_stream_sth: sth_json parse: {e}"))
+                })?;
+            let runtime = self.runtime.clone();
+            let producer_key_id = producer_key_id.to_string();
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_stream_sth(sth, &producer_key_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_stream_sth(sth, &producer_key_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — the latest STH (highest
+    /// `tree_size`) stored for `stream_id`, as a serialized
+    /// `SignedTreeHead` JSON string, or `None` if no STH exists.
+    fn latest_stream_sth(&self, py: Python<'_>, stream_id: &str) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let stream_id = stream_id.to_string();
+            let sth_opt = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .latest_stream_sth(&stream_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .latest_stream_sth(&stream_id)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            match sth_opt {
+                None => Ok(None),
+                Some(sth) => {
+                    let json = serde_json::to_string(&sth).map_err(|e| {
+                        PyValueError::new_err(format!("latest_stream_sth: serialize: {e}"))
+                    })?;
+                    Ok(Some(json))
+                }
+            }
+        })
+    }
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — RFC 6962 inclusion proof for
+    /// the chunk at `leaf_index` against a `tree_size`-leaf tree, as a
+    /// serialized `MerkleProof` JSON string. `None` if the stream holds
+    /// fewer than `tree_size` chunks or `leaf_index >= tree_size`.
+    fn stream_inclusion_proof(
+        &self,
+        py: Python<'_>,
+        stream_id: &str,
+        leaf_index: u64,
+        tree_size: u64,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let stream_id = stream_id.to_string();
+            let proof_opt = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .stream_inclusion_proof(&stream_id, leaf_index, tree_size)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .stream_inclusion_proof(&stream_id, leaf_index, tree_size)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            match proof_opt {
+                None => Ok(None),
+                Some(proof) => {
+                    let json = serde_json::to_string(&proof).map_err(|e| {
+                        PyValueError::new_err(format!("stream_inclusion_proof: serialize: {e}"))
+                    })?;
+                    Ok(Some(json))
+                }
+            }
+        })
+    }
+
+    /// v4.1 (CIRISPersist#142, Cut C1b) — RFC 6962 §2.1.2 consistency
+    /// proof between `from_size` and `to_size`, as a serialized
+    /// `ConsistencyProof` JSON string. `None` if the stream holds fewer
+    /// than `to_size` chunks.
+    fn stream_consistency_proof(
+        &self,
+        py: Python<'_>,
+        stream_id: &str,
+        from_size: u64,
+        to_size: u64,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let stream_id = stream_id.to_string();
+            let proof_opt = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .stream_consistency_proof(&stream_id, from_size, to_size)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .stream_consistency_proof(&stream_id, from_size, to_size)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            match proof_opt {
+                None => Ok(None),
+                Some(proof) => {
+                    let json = serde_json::to_string(&proof).map_err(|e| {
+                        PyValueError::new_err(format!("stream_consistency_proof: serialize: {e}"))
+                    })?;
+                    Ok(Some(json))
+                }
+            }
+        })
+    }
+
     /// v3.11.0 (CIRISPersist#143, CIRISVerify FEDERATION_THREAT_MODEL
     /// §3.3.2) — verify-coord R1+Q1 constants as a JSON dict for
     /// consumer code that needs to pin τ_normal / τ_partial /

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3965,6 +3965,190 @@ impl crate::federation::BlobStorage for PostgresBackend {
         Ok(manifest_row.sha256)
     }
 
+    async fn put_stream_sth(
+        &self,
+        sth: ciris_verify_core::transparency::SignedTreeHead,
+        producer_key_id: &str,
+    ) -> Result<(), crate::federation::BlobError> {
+        use crate::federation::stream_sth;
+        // Step 1: parse stream_id (must be `stream:<id>`).
+        let stream_id = stream_sth::parse_stream_id(&sth.log_id)?.to_string();
+
+        // Step 2: load the seq-ordered chunk hashes for the stream
+        // (the first `tree_size` are what the gate compares against; we
+        // load all and let recompute_and_assert_root slice + check the
+        // count).
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let chunk_hashes = pg_load_stream_chunk_hashes(&client, &stream_id).await?;
+
+        // Steps 3–4: recompute the RFC 6962 root from persist's own
+        // chunks and assert it equals the STH's claimed root (the
+        // anti-equivocation gate; rejects over-claimed tree_size too).
+        stream_sth::recompute_and_assert_root(&sth, &chunk_hashes)?;
+
+        // Step 5: verify the producer's hybrid signature, resolving the
+        // pinned key from federation_keys via producer_key_id.
+        crate::federation::blobs::verify_stream_sth_signature(self, &sth, producer_key_id).await?;
+
+        // Step 6: INSERT. A (stream_id, tree_size) PK conflict with a
+        // DIFFERENT root is an equivocation attempt → reject; identical
+        // → idempotent. We read any existing row's root first.
+        let tree_size_i64 = i64::try_from(sth.tree_size).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_stream_sth: tree_size exceeds i64 — federation_stream_sth.tree_size is BIGINT"
+                    .into(),
+            )
+        })?;
+        let epoch_i64 = i64::try_from(0u64).expect("0 fits i64");
+        let root_vec = sth.root_hash.to_vec();
+        let signed_at = sth.timestamp;
+        let signature_blob = stream_sth::serialize_signature(&sth.signature)?;
+        let witness_json = stream_sth::serialize_witness_signatures(&sth.witness_signatures)?;
+        let witness_value: serde_json::Value =
+            serde_json::from_str(&witness_json).map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_stream_sth witness json: {e}"))
+            })?;
+
+        // Idempotent/equivocation: only insert when absent.
+        let inserted = client
+            .execute(
+                "INSERT INTO cirislens.federation_stream_sth (\
+                    stream_id, tree_size, epoch, root_hash, signed_at, \
+                    producer_key_id, signature_blob, witness_signatures\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+                 ON CONFLICT (stream_id, tree_size) DO NOTHING",
+                &[
+                    &stream_id,
+                    &tree_size_i64,
+                    &epoch_i64,
+                    &root_vec,
+                    &signed_at,
+                    &producer_key_id,
+                    &signature_blob,
+                    &witness_value,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_stream_sth insert: {e}"))
+            })?;
+
+        if inserted == 0 {
+            // A row already exists at (stream_id, tree_size). Equivocation
+            // iff its stored root differs from the new STH's root.
+            let existing_root: Vec<u8> = client
+                .query_one(
+                    "SELECT root_hash FROM cirislens.federation_stream_sth \
+                      WHERE stream_id = $1 AND tree_size = $2",
+                    &[&stream_id, &tree_size_i64],
+                )
+                .await
+                .map_err(|e| {
+                    crate::federation::BlobError::Backend(format!(
+                        "put_stream_sth conflict re-read: {e}"
+                    ))
+                })?
+                .get(0);
+            if existing_root != root_vec {
+                return Err(crate::federation::BlobError::InvalidArgument(format!(
+                    "put_stream_sth: equivocation — an STH at stream={stream_id} \
+                     tree_size={} already exists with a different root",
+                    sth.tree_size
+                )));
+            }
+            // Identical re-PUT → idempotent OK.
+        }
+        Ok(())
+    }
+
+    async fn latest_stream_sth(
+        &self,
+        stream_id: &str,
+    ) -> Result<Option<ciris_verify_core::transparency::SignedTreeHead>, crate::federation::BlobError>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let row_opt = client
+            .query_opt(
+                "SELECT tree_size, root_hash, signed_at, signature_blob, witness_signatures \
+                   FROM cirislens.federation_stream_sth \
+                  WHERE stream_id = $1 \
+                  ORDER BY tree_size DESC \
+                  LIMIT 1",
+                &[&stream_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("latest_stream_sth select: {e}"))
+            })?;
+        let Some(row) = row_opt else {
+            return Ok(None);
+        };
+        let tree_size_i64: i64 =
+            row.safe_get_with("tree_size", crate::federation::BlobError::Backend)?;
+        let tree_size = u64::try_from(tree_size_i64).map_err(|_| {
+            crate::federation::BlobError::Backend("latest_stream_sth: negative tree_size".into())
+        })?;
+        let root_vec: Vec<u8> =
+            row.safe_get_with("root_hash", crate::federation::BlobError::Backend)?;
+        let root_hash = crate::federation::stream_sth::root_hash_from_bytes(&root_vec)?;
+        let signed_at: chrono::DateTime<chrono::Utc> =
+            row.safe_get_with("signed_at", crate::federation::BlobError::Backend)?;
+        let signature_blob: Vec<u8> =
+            row.safe_get_with("signature_blob", crate::federation::BlobError::Backend)?;
+        let signature = crate::federation::stream_sth::deserialize_signature(&signature_blob)?;
+        let witness_value: serde_json::Value =
+            row.safe_get_with("witness_signatures", crate::federation::BlobError::Backend)?;
+        let witness_signatures = crate::federation::stream_sth::deserialize_witness_signatures(
+            &witness_value.to_string(),
+        )?;
+        Ok(Some(ciris_verify_core::transparency::SignedTreeHead {
+            log_id: crate::federation::stream_sth::log_id_for_stream(stream_id),
+            tree_size,
+            root_hash,
+            timestamp: signed_at,
+            signature,
+            witness_signatures,
+        }))
+    }
+
+    async fn stream_inclusion_proof(
+        &self,
+        stream_id: &str,
+        leaf_index: u64,
+        tree_size: u64,
+    ) -> Result<Option<ciris_verify_core::transparency::MerkleProof>, crate::federation::BlobError>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let chunk_hashes = pg_load_stream_chunk_hashes(&client, stream_id).await?;
+        crate::federation::stream_sth::inclusion_proof(&chunk_hashes, leaf_index, tree_size)
+    }
+
+    async fn stream_consistency_proof(
+        &self,
+        stream_id: &str,
+        from_size: u64,
+        to_size: u64,
+    ) -> Result<
+        Option<ciris_verify_core::transparency::ConsistencyProof>,
+        crate::federation::BlobError,
+    > {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(e.to_string()))?;
+        let chunk_hashes = pg_load_stream_chunk_hashes(&client, stream_id).await?;
+        crate::federation::stream_sth::consistency_proof(&chunk_hashes, from_size, to_size)
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -4545,6 +4729,34 @@ impl crate::federation::BlobStorage for PostgresBackend {
         }
         Ok(report)
     }
+}
+
+/// v4.1 (CIRISPersist#142, Cut C1b) — load a stream's chunk hashes in
+/// `seq ASC` order (the leaves of the stream's RFC 6962 log). Shared by
+/// `put_stream_sth` (the anti-equivocation gate) and the proof methods.
+async fn pg_load_stream_chunk_hashes(
+    client: &deadpool_postgres::Object,
+    stream_id: &str,
+) -> Result<Vec<[u8; 32]>, crate::federation::BlobError> {
+    let rows = client
+        .query(
+            "SELECT chunk_sha FROM cirislens.federation_stream_chunks \
+              WHERE stream_id = $1 ORDER BY seq ASC",
+            &[&stream_id],
+        )
+        .await
+        .map_err(|e| {
+            crate::federation::BlobError::Backend(format!("load stream chunk hashes: {e}"))
+        })?;
+    let mut out = Vec::with_capacity(rows.len());
+    for r in &rows {
+        let sha_vec: Vec<u8> =
+            r.safe_get_with("chunk_sha", crate::federation::BlobError::Backend)?;
+        out.push(crate::federation::stream_sth::root_hash_from_bytes(
+            &sha_vec,
+        )?);
+    }
+    Ok(out)
 }
 
 // ─── Eviction sweeper helpers (v3.4.0, CIRISPersist#123) ───────────
@@ -17692,6 +17904,290 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, BlobError::InvalidArgument(_)));
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut C1b) — PG per-stream transparency
+    //     log: producer-signed STH + RFC 6962 proofs ─────────────────
+
+    /// Register a real hybrid producer key in federation_keys (PG).
+    async fn pg_register_hybrid_producer(
+        backend: &PostgresBackend,
+        key_id: &str,
+    ) -> ciris_crypto::HybridSigner<ciris_crypto::Ed25519Signer, ciris_crypto::MlDsa65Signer> {
+        use crate::federation::FederationDirectory as _;
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        let ed = ciris_crypto::Ed25519Signer::from_seed(&[0x41; 32]).unwrap();
+        let mldsa = ciris_crypto::MlDsa65Signer::from_seed(&[0x42; 32]).unwrap();
+        let ed_pub_b64 = {
+            use ciris_crypto::ClassicalSigner as _;
+            B64.encode(ed.public_key().unwrap())
+        };
+        let mldsa_pub_b64 = {
+            use ciris_crypto::PqcSigner as _;
+            B64.encode(mldsa.public_key().unwrap())
+        };
+        let mut record = fix_section_i_key(key_id, key_id, chrono::Utc::now(), true);
+        record.pubkey_ed25519_base64 = ed_pub_b64;
+        record.pubkey_ml_dsa_65_base64 = Some(mldsa_pub_b64);
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord { record })
+            .await
+            .unwrap();
+        ciris_crypto::HybridSigner::new(ed, mldsa).unwrap()
+    }
+
+    fn pg_sign_stream_sth(
+        signer: &ciris_crypto::HybridSigner<
+            ciris_crypto::Ed25519Signer,
+            ciris_crypto::MlDsa65Signer,
+        >,
+        stream_id: &str,
+        chunk_hashes: &[[u8; 32]],
+        tree_size: u64,
+    ) -> ciris_verify_core::transparency::SignedTreeHead {
+        use crate::federation::stream_sth::StreamChunkLeaf;
+        use ciris_verify_core::transparency::{InMemoryTransparencyStore, TransparencyStore};
+        let store: InMemoryTransparencyStore<StreamChunkLeaf> =
+            InMemoryTransparencyStore::new(None);
+        for sha in &chunk_hashes[..tree_size as usize] {
+            store.append(StreamChunkLeaf::new(*sha)).unwrap();
+        }
+        let root_hash = store.root().unwrap();
+        let log_id = crate::federation::stream_sth::log_id_for_stream(stream_id);
+        let timestamp = chrono::Utc::now();
+        let signing_bytes = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &log_id, tree_size, &root_hash, timestamp,
+        );
+        let signature = signer.sign(&signing_bytes).unwrap();
+        ciris_verify_core::transparency::SignedTreeHead {
+            log_id,
+            tree_size,
+            root_hash,
+            timestamp,
+            signature,
+            witness_signatures: Vec::new(),
+        }
+    }
+
+    /// Run an async PG-STH test body on a dedicated thread with a large
+    /// stack. The ML-DSA-65 hybrid sign/verify is stack-heavy in debug
+    /// builds; combined with tokio-postgres/deadpool frames it overflows
+    /// the default test-thread stack. A 32 MiB std::thread + a
+    /// current-thread runtime keeps the body self-contained (no
+    /// RUST_MIN_STACK dependency).
+    fn pg_run_big_stack<F, Fut>(f: F)
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()>,
+    {
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                rt.block_on(f());
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    #[test]
+    #[serial_test::serial(postgres)]
+    fn pg_sth_round_trip_and_proofs_verify() {
+        pg_run_big_stack(pg_sth_round_trip_and_proofs_verify_inner);
+    }
+
+    async fn pg_sth_round_trip_and_proofs_verify_inner() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobStorage};
+        use ciris_verify_core::transparency::{verify_consistency, verify_inclusion};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let salt = uuid_like();
+        let key_id = format!("pg-producer-{salt}");
+        let signer = pg_register_hybrid_producer(&backend, &key_id).await;
+        let stream = format!("pg-sth-rt-{salt}");
+
+        let mut hashes = Vec::new();
+        let mut shas = Vec::new();
+        for (seq, tag) in ["AAAA", "BBBB", "CC", "DDDD"].iter().enumerate() {
+            let body = format!("sth-{tag}-{salt}").into_bytes();
+            let sha = backend
+                .put_blob_chunk(&stream, seq as u64, BlobBody::Inline(body), 0)
+                .await
+                .unwrap();
+            hashes.push(sha);
+            shas.push(sha);
+        }
+
+        let sth = pg_sign_stream_sth(&signer, &stream, &hashes, 4);
+        backend.put_stream_sth(sth.clone(), &key_id).await.unwrap();
+
+        let stored = backend.latest_stream_sth(&stream).await.unwrap().unwrap();
+        assert_eq!(stored.tree_size, 4);
+        assert_eq!(stored.root_hash, sth.root_hash);
+        assert_eq!(stored.log_id, sth.log_id);
+
+        let proof = backend
+            .stream_inclusion_proof(&stream, 2, 4)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(verify_inclusion(&proof));
+        assert_eq!(proof.root, sth.root_hash);
+
+        let sth2 = pg_sign_stream_sth(&signer, &stream, &hashes, 2);
+        let cproof = backend
+            .stream_consistency_proof(&stream, 2, 4)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(verify_consistency(&sth2.root_hash, 2, &sth.root_hash, 4, &cproof).unwrap());
+
+        // Idempotent re-PUT.
+        backend.put_stream_sth(sth, &key_id).await.unwrap();
+
+        // Cleanup (shared DB).
+        let client = backend.get_client().await.unwrap();
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_stream_sth WHERE stream_id = $1",
+                &[&stream],
+            )
+            .await;
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_stream_chunks WHERE stream_id = $1",
+                &[&stream],
+            )
+            .await;
+        for sha in &shas {
+            let _ = backend.delete_blob(sha).await;
+        }
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_keys WHERE key_id = $1",
+                &[&key_id],
+            )
+            .await;
+    }
+
+    #[test]
+    #[serial_test::serial(postgres)]
+    fn pg_sth_security_gate_negatives() {
+        pg_run_big_stack(pg_sth_security_gate_negatives_inner);
+    }
+
+    async fn pg_sth_security_gate_negatives_inner() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::{BlobBody, BlobError, BlobStorage};
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let salt = uuid_like();
+        let key_id = format!("pg-producer-neg-{salt}");
+        let signer = pg_register_hybrid_producer(&backend, &key_id).await;
+        let stream = format!("pg-sth-neg-{salt}");
+
+        let mut hashes = Vec::new();
+        let mut shas = Vec::new();
+        for (seq, tag) in ["AAAA", "BBBB"].iter().enumerate() {
+            let body = format!("neg-{tag}-{salt}").into_bytes();
+            let sha = backend
+                .put_blob_chunk(&stream, seq as u64, BlobBody::Inline(body), 0)
+                .await
+                .unwrap();
+            hashes.push(sha);
+            shas.push(sha);
+        }
+
+        // (a) root mismatch (re-signed so the SIG is valid but the root
+        //     does not match persist's chunks).
+        let mut bad_root = pg_sign_stream_sth(&signer, &stream, &hashes, 2);
+        bad_root.root_hash = [0xAB; 32];
+        let sb = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &bad_root.log_id,
+            2,
+            &bad_root.root_hash,
+            bad_root.timestamp,
+        );
+        bad_root.signature = signer.sign(&sb).unwrap();
+        let err = backend.put_stream_sth(bad_root, &key_id).await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        assert!(format!("{err}").contains("root mismatch"));
+
+        // (b) bad/forged producer signature (root matches).
+        let mut bad_sig = pg_sign_stream_sth(&signer, &stream, &hashes, 2);
+        for b in &mut bad_sig.signature.classical.signature {
+            *b ^= 0xFF;
+        }
+        let err = backend.put_stream_sth(bad_sig, &key_id).await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        assert!(format!("{err}").contains("signature verification failed"));
+
+        // (c) over-claimed tree_size (> stored chunks).
+        let mut over = pg_sign_stream_sth(&signer, &stream, &hashes, 2);
+        over.tree_size = 5;
+        let sb = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &over.log_id,
+            5,
+            &over.root_hash,
+            over.timestamp,
+        );
+        over.signature = signer.sign(&sb).unwrap();
+        let err = backend.put_stream_sth(over, &key_id).await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        assert!(format!("{err}").contains("only 2 chunks"));
+
+        // (d) equivocation: a valid STH lands, then the stored root is
+        //     tampered and the correct STH is re-PUT → different root at
+        //     the same (stream, tree_size) → reject.
+        let good = pg_sign_stream_sth(&signer, &stream, &hashes, 2);
+        backend.put_stream_sth(good.clone(), &key_id).await.unwrap();
+        let client = backend.get_client().await.unwrap();
+        client
+            .execute(
+                "UPDATE cirislens.federation_stream_sth SET root_hash = $1 \
+                   WHERE stream_id = $2 AND tree_size = 2",
+                &[&vec![0xCDu8; 32], &stream],
+            )
+            .await
+            .unwrap();
+        let err = backend.put_stream_sth(good, &key_id).await.unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)));
+        assert!(format!("{err}").contains("equivocation"));
+
+        // Cleanup.
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_stream_sth WHERE stream_id = $1",
+                &[&stream],
+            )
+            .await;
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_stream_chunks WHERE stream_id = $1",
+                &[&stream],
+            )
+            .await;
+        for sha in &shas {
+            let _ = backend.delete_blob(sha).await;
+        }
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_keys WHERE key_id = $1",
+                &[&key_id],
+            )
+            .await;
     }
 
     // ─── v3.4.0 (CIRISPersist#123) — PG sweeper parity ─────────────

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3703,6 +3703,178 @@ impl crate::federation::BlobStorage for SqliteBackend {
         Ok(manifest_sha)
     }
 
+    async fn put_stream_sth(
+        &self,
+        sth: ciris_verify_core::transparency::SignedTreeHead,
+        producer_key_id: &str,
+    ) -> Result<(), crate::federation::BlobError> {
+        use crate::federation::stream_sth;
+        // Step 1: parse stream_id (must be `stream:<id>`).
+        let stream_id = stream_sth::parse_stream_id(&sth.log_id)?.to_string();
+
+        // Step 2: load the seq-ordered chunk hashes for the stream.
+        let chunk_hashes = sqlite_load_stream_chunk_hashes(&self.conn, &stream_id)?;
+
+        // Steps 3–4: recompute the RFC 6962 root from persist's own
+        // chunks + assert equality (anti-equivocation gate; also rejects
+        // an over-claimed tree_size).
+        stream_sth::recompute_and_assert_root(&sth, &chunk_hashes)?;
+
+        // Step 5: verify the producer's hybrid signature (pinned key
+        // resolved from federation_keys via producer_key_id).
+        crate::federation::blobs::verify_stream_sth_signature(self, &sth, producer_key_id).await?;
+
+        // Step 6: INSERT. (stream_id, tree_size) PK conflict with a
+        // DIFFERENT root → equivocation reject; identical → idempotent.
+        let tree_size_i64 = i64::try_from(sth.tree_size).map_err(|_| {
+            crate::federation::BlobError::InvalidArgument(
+                "put_stream_sth: tree_size exceeds i64 — federation_stream_sth.tree_size is INTEGER"
+                    .into(),
+            )
+        })?;
+        let root_vec = sth.root_hash.to_vec();
+        let signed_at_iso = sth.timestamp.to_rfc3339();
+        let signature_blob = stream_sth::serialize_signature(&sth.signature)?;
+        let witness_json = stream_sth::serialize_witness_signatures(&sth.witness_signatures)?;
+        let stream_id_owned = stream_id.clone();
+        let producer_key_id_owned = producer_key_id.to_string();
+        let root_for_closure = root_vec.clone();
+        let conn = self.conn.clone();
+        let tree_size_for_err = sth.tree_size;
+
+        let result = (move || -> Result<(), crate::federation::BlobError> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction().map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_stream_sth tx: {e}"))
+            })?;
+            let inserted = tx
+                .execute(
+                    "INSERT INTO federation_stream_sth (\
+                        stream_id, tree_size, epoch, root_hash, signed_at, \
+                        producer_key_id, signature_blob, witness_signatures\
+                     ) VALUES (?1, ?2, 0, ?3, ?4, ?5, ?6, ?7) \
+                     ON CONFLICT (stream_id, tree_size) DO NOTHING",
+                    rusqlite::params![
+                        stream_id_owned,
+                        tree_size_i64,
+                        root_for_closure,
+                        signed_at_iso,
+                        producer_key_id_owned,
+                        signature_blob,
+                        witness_json,
+                    ],
+                )
+                .map_err(|e| {
+                    crate::federation::BlobError::Backend(format!("put_stream_sth insert: {e}"))
+                })?;
+            if inserted == 0 {
+                // Row exists at (stream_id, tree_size). Equivocation iff
+                // the stored root differs.
+                let existing_root: Vec<u8> = tx
+                    .query_row(
+                        "SELECT root_hash FROM federation_stream_sth \
+                          WHERE stream_id = ?1 AND tree_size = ?2",
+                        rusqlite::params![stream_id_owned, tree_size_i64],
+                        |r| r.get(0),
+                    )
+                    .map_err(|e| {
+                        crate::federation::BlobError::Backend(format!(
+                            "put_stream_sth conflict re-read: {e}"
+                        ))
+                    })?;
+                if existing_root != root_vec {
+                    return Err(crate::federation::BlobError::InvalidArgument(format!(
+                        "put_stream_sth: equivocation — an STH at stream={stream_id_owned} \
+                         tree_size={tree_size_for_err} already exists with a different root"
+                    )));
+                }
+                // Identical re-PUT → idempotent OK; nothing to commit.
+                return Ok(());
+            }
+            tx.commit().map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_stream_sth commit: {e}"))
+            })?;
+            Ok(())
+        })();
+        result
+    }
+
+    async fn latest_stream_sth(
+        &self,
+        stream_id: &str,
+    ) -> Result<Option<ciris_verify_core::transparency::SignedTreeHead>, crate::federation::BlobError>
+    {
+        let stream_id_owned = stream_id.to_string();
+        let conn = self.conn.clone();
+        type SthRow = (i64, Vec<u8>, String, Vec<u8>, String);
+        let row_opt = (move || -> Result<Option<SthRow>, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT tree_size, root_hash, signed_at, signature_blob, witness_signatures \
+                   FROM federation_stream_sth \
+                  WHERE stream_id = ?1 \
+                  ORDER BY tree_size DESC \
+                  LIMIT 1",
+                rusqlite::params![stream_id_owned],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+            )
+            .optional()
+        })()
+        .map_err(|e| {
+            crate::federation::BlobError::Backend(format!("latest_stream_sth query: {e}"))
+        })?;
+        let Some((tree_size_i64, root_vec, signed_at_iso, signature_blob, witness_json)) = row_opt
+        else {
+            return Ok(None);
+        };
+        let tree_size = u64::try_from(tree_size_i64).map_err(|_| {
+            crate::federation::BlobError::Backend("latest_stream_sth: negative tree_size".into())
+        })?;
+        let root_hash = crate::federation::stream_sth::root_hash_from_bytes(&root_vec)?;
+        let timestamp = chrono::DateTime::parse_from_rfc3339(&signed_at_iso)
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!(
+                    "latest_stream_sth signed_at parse: {e}"
+                ))
+            })?
+            .with_timezone(&chrono::Utc);
+        let signature = crate::federation::stream_sth::deserialize_signature(&signature_blob)?;
+        let witness_signatures =
+            crate::federation::stream_sth::deserialize_witness_signatures(&witness_json)?;
+        Ok(Some(ciris_verify_core::transparency::SignedTreeHead {
+            log_id: crate::federation::stream_sth::log_id_for_stream(stream_id),
+            tree_size,
+            root_hash,
+            timestamp,
+            signature,
+            witness_signatures,
+        }))
+    }
+
+    async fn stream_inclusion_proof(
+        &self,
+        stream_id: &str,
+        leaf_index: u64,
+        tree_size: u64,
+    ) -> Result<Option<ciris_verify_core::transparency::MerkleProof>, crate::federation::BlobError>
+    {
+        let chunk_hashes = sqlite_load_stream_chunk_hashes(&self.conn, stream_id)?;
+        crate::federation::stream_sth::inclusion_proof(&chunk_hashes, leaf_index, tree_size)
+    }
+
+    async fn stream_consistency_proof(
+        &self,
+        stream_id: &str,
+        from_size: u64,
+        to_size: u64,
+    ) -> Result<
+        Option<ciris_verify_core::transparency::ConsistencyProof>,
+        crate::federation::BlobError,
+    > {
+        let chunk_hashes = sqlite_load_stream_chunk_hashes(&self.conn, stream_id)?;
+        crate::federation::stream_sth::consistency_proof(&chunk_hashes, from_size, to_size)
+    }
+
     async fn get_blob(
         &self,
         sha256: &[u8; 32],
@@ -4367,6 +4539,40 @@ impl crate::federation::BlobStorage for SqliteBackend {
         }
         Ok(report)
     }
+}
+
+/// v4.1 (CIRISPersist#142, Cut C1b) — load a stream's chunk hashes in
+/// `seq ASC` order (the leaves of the stream's RFC 6962 log). Shared by
+/// `put_stream_sth` (the anti-equivocation gate) and the proof methods.
+fn sqlite_load_stream_chunk_hashes(
+    conn: &Arc<Mutex<Connection>>,
+    stream_id: &str,
+) -> Result<Vec<[u8; 32]>, crate::federation::BlobError> {
+    let stream_id_owned = stream_id.to_string();
+    let conn = conn.clone();
+    let raw = (move || -> Result<Vec<Vec<u8>>, rusqlite::Error> {
+        let conn = conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT chunk_sha FROM federation_stream_chunks \
+              WHERE stream_id = ?1 ORDER BY seq ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![stream_id_owned], |r| {
+            r.get::<_, Vec<u8>>(0)
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    })()
+    .map_err(|e| crate::federation::BlobError::Backend(format!("load stream chunk hashes: {e}")))?;
+    let mut out = Vec::with_capacity(raw.len());
+    for sha_vec in &raw {
+        out.push(crate::federation::stream_sth::root_hash_from_bytes(
+            sha_vec,
+        )?);
+    }
+    Ok(out)
 }
 
 // ─── Eviction sweeper helpers (v3.4.0, CIRISPersist#123) ───────────
@@ -17323,6 +17529,273 @@ mod tests {
             .unwrap()
         };
         assert_eq!(epoch, 7);
+    }
+
+    // ─── v4.1 (CIRISPersist#142, Cut C1b) — per-stream transparency
+    //     log: producer-signed STH + RFC 6962 proofs ─────────────────
+
+    /// Build a real hybrid producer signer (Ed25519 + ML-DSA-65 from
+    /// deterministic seeds), register its pubkeys in `federation_keys`
+    /// under `key_id`, and return the signer for producing STHs the
+    /// gate will accept.
+    async fn register_hybrid_producer(
+        backend: &SqliteBackend,
+        key_id: &str,
+    ) -> ciris_crypto::HybridSigner<ciris_crypto::Ed25519Signer, ciris_crypto::MlDsa65Signer> {
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        let ed = ciris_crypto::Ed25519Signer::from_seed(&[0x31; 32]).unwrap();
+        let mldsa = ciris_crypto::MlDsa65Signer::from_seed(&[0x32; 32]).unwrap();
+        let ed_pub_b64 = {
+            use ciris_crypto::ClassicalSigner as _;
+            B64.encode(ed.public_key().unwrap())
+        };
+        let mldsa_pub_b64 = {
+            use ciris_crypto::PqcSigner as _;
+            B64.encode(mldsa.public_key().unwrap())
+        };
+        let mut record = fed_key(key_id, key_id, key_id);
+        record.pubkey_ed25519_base64 = ed_pub_b64;
+        record.pubkey_ml_dsa_65_base64 = Some(mldsa_pub_b64);
+        backend
+            .put_public_key(SignedKeyRecord { record })
+            .await
+            .unwrap();
+        ciris_crypto::HybridSigner::new(ed, mldsa).unwrap()
+    }
+
+    /// Produce a producer-signed STH over a stream's recomputed root for
+    /// `tree_size` leaves, signed by `signer`.
+    fn sign_stream_sth(
+        signer: &ciris_crypto::HybridSigner<
+            ciris_crypto::Ed25519Signer,
+            ciris_crypto::MlDsa65Signer,
+        >,
+        stream_id: &str,
+        chunk_hashes: &[[u8; 32]],
+        tree_size: u64,
+    ) -> ciris_verify_core::transparency::SignedTreeHead {
+        use crate::federation::stream_sth::StreamChunkLeaf;
+        use ciris_verify_core::transparency::{InMemoryTransparencyStore, TransparencyStore};
+        let store: InMemoryTransparencyStore<StreamChunkLeaf> =
+            InMemoryTransparencyStore::new(None);
+        for sha in &chunk_hashes[..tree_size as usize] {
+            store.append(StreamChunkLeaf::new(*sha)).unwrap();
+        }
+        let root_hash = store.root().unwrap();
+        let log_id = crate::federation::stream_sth::log_id_for_stream(stream_id);
+        let timestamp = chrono::Utc::now();
+        let signing_bytes = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &log_id, tree_size, &root_hash, timestamp,
+        );
+        let signature = signer.sign(&signing_bytes).unwrap();
+        ciris_verify_core::transparency::SignedTreeHead {
+            log_id,
+            tree_size,
+            root_hash,
+            timestamp,
+            signature,
+            witness_signatures: Vec::new(),
+        }
+    }
+
+    /// Append chunks, return their seq-ordered hashes.
+    async fn append_chunks(
+        backend: &SqliteBackend,
+        stream: &str,
+        bodies: &[&[u8]],
+    ) -> Vec<[u8; 32]> {
+        let mut out = Vec::new();
+        for (seq, body) in bodies.iter().enumerate() {
+            let sha = backend
+                .put_blob_chunk(stream, seq as u64, BlobBody::Inline(body.to_vec()), 0)
+                .await
+                .unwrap();
+            out.push(sha);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn sth_round_trip_and_proofs_verify() {
+        use ciris_verify_core::transparency::{verify_consistency, verify_inclusion};
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-rt";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB", b"CC", b"DDDD"]).await;
+
+        // Producer signs an STH over the real root for all 4 chunks.
+        let sth = sign_stream_sth(&signer, stream, &hashes, 4);
+        backend
+            .put_stream_sth(sth.clone(), "producer-key")
+            .await
+            .unwrap();
+
+        // latest_stream_sth round-trips.
+        let stored = backend.latest_stream_sth(stream).await.unwrap().unwrap();
+        assert_eq!(stored.log_id, sth.log_id);
+        assert_eq!(stored.tree_size, 4);
+        assert_eq!(stored.root_hash, sth.root_hash);
+
+        // Inclusion proof for a chunk verifies against the crate verifier.
+        let proof = backend
+            .stream_inclusion_proof(stream, 2, 4)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(verify_inclusion(&proof));
+        assert_eq!(proof.root, sth.root_hash);
+
+        // Consistency proof between two sizes verifies.
+        let sth2 = sign_stream_sth(&signer, stream, &hashes, 2);
+        let cproof = backend
+            .stream_consistency_proof(stream, 2, 4)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(verify_consistency(&sth2.root_hash, 2, &sth.root_hash, 4, &cproof).unwrap());
+    }
+
+    #[tokio::test]
+    async fn sth_idempotent_reput() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-idem";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB"]).await;
+        let sth = sign_stream_sth(&signer, stream, &hashes, 2);
+        backend
+            .put_stream_sth(sth.clone(), "producer-key")
+            .await
+            .unwrap();
+        // Identical re-PUT → idempotent OK.
+        backend.put_stream_sth(sth, "producer-key").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sth_root_mismatch_rejected() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-root-mismatch";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB"]).await;
+        let mut sth = sign_stream_sth(&signer, stream, &hashes, 2);
+        // Tamper the claimed root, re-sign so the SIGNATURE is valid but
+        // the root does NOT match persist's chunks → root-gate rejects
+        // (and would reject before sig anyway).
+        sth.root_hash = [0xAB; 32];
+        let signing_bytes = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &sth.log_id,
+            sth.tree_size,
+            &sth.root_hash,
+            sth.timestamp,
+        );
+        sth.signature = signer.sign(&signing_bytes).unwrap();
+        let err = backend
+            .put_stream_sth(sth, "producer-key")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)), "got {err:?}");
+        assert!(format!("{err}").contains("root mismatch"));
+    }
+
+    #[tokio::test]
+    async fn sth_bad_signature_rejected() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-badsig";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB"]).await;
+        let mut sth = sign_stream_sth(&signer, stream, &hashes, 2);
+        // Forge the signature bytes (root still matches persist's chunks,
+        // so the gate passes the root check then rejects on the sig).
+        for b in &mut sth.signature.classical.signature {
+            *b ^= 0xFF;
+        }
+        let err = backend
+            .put_stream_sth(sth, "producer-key")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)), "got {err:?}");
+        assert!(format!("{err}").contains("signature verification failed"));
+    }
+
+    #[tokio::test]
+    async fn sth_over_claimed_tree_size_rejected() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-overclaim";
+        // Persist holds only 2 chunks.
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB"]).await;
+        // Build an STH whose root is over 2 chunks but claims tree_size=5.
+        let mut sth = sign_stream_sth(&signer, stream, &hashes, 2);
+        sth.tree_size = 5;
+        let signing_bytes = ciris_verify_core::transparency::SignedTreeHead::signing_bytes(
+            &sth.log_id,
+            5,
+            &sth.root_hash,
+            sth.timestamp,
+        );
+        sth.signature = signer.sign(&signing_bytes).unwrap();
+        let err = backend
+            .put_stream_sth(sth, "producer-key")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)), "got {err:?}");
+        assert!(format!("{err}").contains("only 2 chunks"));
+    }
+
+    #[tokio::test]
+    async fn sth_equivocation_same_size_diff_root_rejected() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-equiv";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA", b"BBBB"]).await;
+        let sth = sign_stream_sth(&signer, stream, &hashes, 2);
+        backend.put_stream_sth(sth, "producer-key").await.unwrap();
+
+        // A second producer appends a divergent chunk set to a DIFFERENT
+        // stream so we can craft a same-(stream,size) different-root STH.
+        // Simulate equivocation: write a row directly with a different
+        // root at the same (stream, tree_size), then put a new STH whose
+        // root differs but which passes its own gate against the SAME
+        // chunks — we craft this by forcing a different valid root via a
+        // direct row. Simpler: directly assert the DB-level conflict by
+        // attempting to store an STH whose root we tamper to a value that
+        // still matches a different chunk set is not feasible; instead we
+        // insert a conflicting row and re-PUT the original to confirm the
+        // equivocation branch fires.
+        {
+            let conn = backend.conn.clone();
+            let conn = conn.lock();
+            conn.execute(
+                "UPDATE federation_stream_sth SET root_hash = ?1 \
+                   WHERE stream_id = ?2 AND tree_size = 2",
+                rusqlite::params![vec![0xCDu8; 32], stream],
+            )
+            .unwrap();
+        }
+        // Re-PUT the original (correct-root) STH → its root differs from
+        // the now-tampered stored row → equivocation reject.
+        let sth_again = sign_stream_sth(&signer, stream, &hashes, 2);
+        let err = backend
+            .put_stream_sth(sth_again, "producer-key")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)), "got {err:?}");
+        assert!(format!("{err}").contains("equivocation"));
+    }
+
+    #[tokio::test]
+    async fn sth_non_stream_log_id_rejected() {
+        let backend = blob_test_backend().await;
+        let signer = register_hybrid_producer(&backend, "producer-key").await;
+        let stream = "sth-logid";
+        let hashes = append_chunks(&backend, stream, &[b"AAAA"]).await;
+        let mut sth = sign_stream_sth(&signer, stream, &hashes, 1);
+        sth.log_id = "tenant:not-a-stream".into();
+        let err = backend
+            .put_stream_sth(sth, "producer-key")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BlobError::InvalidArgument(_)), "got {err:?}");
     }
 
     /// v4.1 (CIRISPersist#142, Cut B) — the V061 SQLite 12-step table


### PR DESCRIPTION
**Cut C1b** ([`FSD/V4_1_STREAMING_SUBSTRATE.md`](FSD/V4_1_STREAMING_SUBSTRATE.md) §4.3; CEG 0.10 §10.5.1). The per-stream transparency log — the security bridge between the C1a substrate and the C2/C3 crypto core.

## Model (CEG §10.5.1)
Each stream is its own RFC 6962 log (`log_id = stream:<id>`); its leaves are the `federation_stream_chunks` hashes (C1a). The **producer signs the STH**; persist's job is the integrity gate, not signing.

## Adds
- `StreamChunkLeaf : TransparencyLeaf` + **V063** `federation_stream_sth (stream_id, tree_size) → root, producer_key_id, signature_blob, witness_signatures`.
- `put_stream_sth(sth, producer_key_id)` — the **security gate**, in order: parse `stream:<id>` → load chunks → **recompute the RFC 6962 root from persist's own chunks and assert == STH root** (anti-equivocation) → **verify the producer's hybrid signature over `signing_bytes_of()` against the pinned `federation_keys` key** (`verify_hybrid_via_directory`, `Strict`; ignores keys embedded in the sig) → insert (`(stream_id,tree_size)` conflict with a different root → rejected as equivocation).
- `latest_stream_sth` + `stream_inclusion_proof` + `stream_consistency_proof` — all via the audited `InMemoryTransparencyStore` (**no RFC 6962 reimplementation**).
- PyO3: STH put/get + proofs (JSON).

## Verification (local, incl. live postgres)
- **901 tests** on `cargo test --features "postgres server pyo3 sqlite" --lib` against live PG (19 STH tests, the PG ones ran live).
- **Negative/security tests all reject:** root-mismatch, forged producer signature, over-claimed `tree_size`, and same-size-different-root equivocation.
- Clean under `-D warnings`: `--no-default-features`, `--features test-panic,pyo3`, full gated combo. No `u64` PG binds.

Best-effort tier only (producer-signed STH); witness-cosign quorum is stored-not-enforced this cut (CEG §10.5.1). Next: C2 (STREAM-nonce AEAD), C3 (epoch-DEK PQC cascade + RC1-1c), C4 (delivery receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)