### PR TITLE
Streaming Cut C3a — V064 key_grant stream/epoch addressing (RC1-1c CHECK migration, #142)

### DIFF
--- a/migrations/postgres/lens/V064__key_grant_stream_epoch_addressing.sql
+++ b/migrations/postgres/lens/V064__key_grant_stream_epoch_addressing.sql
@@ -1,0 +1,96 @@
+-- V064 — key_grant stream/epoch addressing (CIRISPersist#142, Cut C3a;
+-- CEG 0.15 §10.5.3 "RC1-1c — not pure-additive at the Persist
+-- constraint layer"; FSD/V4_1_STREAMING_SUBSTRATE.md §4.4).
+--
+-- V054 landed the content-addressed `key_grant` shape: a
+-- `subject_kind = 'key_grant'` row REQUIRES both `media_content_sha256`
+-- AND `key_grant_recipient_key_id` NOT NULL. That binds a wrapped DEK
+-- to a recipient over a content SHA-256.
+--
+-- The streaming epoch-key cascade (Cut C3b) addresses grants by
+-- `(stream_id, epoch)` instead of by content SHA — a per-stream-epoch
+-- DEK is wrapped to a recipient, with NO content SHA. The V054
+-- constraint REJECTS that shape (it demands media_content_sha256 NOT
+-- NULL for every key_grant). This migration extends the constraint so
+-- the table admits BOTH addressing modes — content-addressed XOR
+-- stream/epoch-addressed — and is therefore NOT pure-additive: the
+-- existing `contributions_key_grant_columns_match_subject_kind`
+-- constraint is dropped and re-added with the wider rule.
+--
+-- This cut is migration-ONLY. The stream-key_grant write path
+-- (epoch-DEK generation + wrapping, payload changes) is Cut C3b. C3a
+-- just makes the schema admit the new shape.
+--
+-- The takedown_notice constraint
+-- (`contributions_takedown_columns_match_subject_kind`) is a SEPARATE
+-- named constraint and is left untouched.
+
+-- 1. New nullable addressing columns. Pure-additive at the column
+--    layer; the constraint swap below is the non-additive part.
+ALTER TABLE cirisnode.contributions
+    ADD COLUMN IF NOT EXISTS key_grant_stream_id TEXT NULL;
+
+ALTER TABLE cirisnode.contributions
+    ADD COLUMN IF NOT EXISTS key_grant_stream_epoch BIGINT NULL;
+
+-- 2. Replace the key_grant cross-column CHECK. Same DROP-IF-EXISTS +
+--    ADD guard pattern V054/V056 use, so re-running the chain is
+--    idempotent. New rule:
+--      subject_kind = 'key_grant'  <=>  recipient NOT NULL AND exactly
+--      one addressing mode holds:
+--        (a) content-addressed:
+--              media_content_sha256 NOT NULL
+--              AND key_grant_stream_id IS NULL
+--              AND key_grant_stream_epoch IS NULL
+--        (b) stream/epoch-addressed:
+--              key_grant_stream_id NOT NULL
+--              AND key_grant_stream_epoch NOT NULL
+--              AND media_content_sha256 IS NULL
+--      subject_kind <> 'key_grant'  =>  recipient, stream_id,
+--      stream_epoch ALL NULL.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_constraint
+        WHERE conname = 'contributions_key_grant_columns_match_subject_kind'
+          AND conrelid = 'cirisnode.contributions'::regclass
+    ) THEN
+        ALTER TABLE cirisnode.contributions
+            DROP CONSTRAINT contributions_key_grant_columns_match_subject_kind;
+    END IF;
+
+    ALTER TABLE cirisnode.contributions
+        ADD CONSTRAINT contributions_key_grant_columns_match_subject_kind
+            CHECK (
+                (subject_kind = 'key_grant'
+                  AND key_grant_recipient_key_id IS NOT NULL
+                  AND (
+                      -- (a) content-addressed
+                      (media_content_sha256 IS NOT NULL
+                          AND key_grant_stream_id IS NULL
+                          AND key_grant_stream_epoch IS NULL)
+                      OR
+                      -- (b) stream/epoch-addressed
+                      (key_grant_stream_id IS NOT NULL
+                          AND key_grant_stream_epoch IS NOT NULL
+                          AND media_content_sha256 IS NULL)
+                  ))
+                OR
+                (subject_kind <> 'key_grant'
+                  AND key_grant_recipient_key_id IS NULL
+                  AND key_grant_stream_id IS NULL
+                  AND key_grant_stream_epoch IS NULL)
+            );
+END$$;
+
+-- 3. Partial index for the later per-stream-epoch grant lookup
+--    (Cut C3b reads grants by (stream_id, epoch)).
+CREATE INDEX IF NOT EXISTS contributions_key_grant_stream_epoch
+    ON cirisnode.contributions (key_grant_stream_id, key_grant_stream_epoch)
+    WHERE key_grant_stream_id IS NOT NULL;
+
+COMMENT ON COLUMN cirisnode.contributions.key_grant_stream_id IS
+    'v4.1 (CIRISPersist#142 Cut C3a) — populated iff subject_kind = ''key_grant'' AND stream/epoch-addressed (media_content_sha256 NULL). The federation_streams stream_id the epoch-DEK is scoped to.';
+
+COMMENT ON COLUMN cirisnode.contributions.key_grant_stream_epoch IS
+    'v4.1 (CIRISPersist#142 Cut C3a) — populated iff subject_kind = ''key_grant'' AND stream/epoch-addressed. The epoch within key_grant_stream_id the wrapped DEK covers.';

--- a/migrations/sqlite/lens/V064__key_grant_stream_epoch_addressing.sql
+++ b/migrations/sqlite/lens/V064__key_grant_stream_epoch_addressing.sql
@@ -1,0 +1,94 @@
+-- V064 — key_grant stream/epoch addressing, SQLite dialect
+-- (CIRISPersist#142, Cut C3a; CEG 0.15 §10.5.3 RC1-1c).
+--
+-- Postgres parity (postgres/lens/V064):
+--   - cirisnode_contributions gains two nullable addressing columns
+--     (key_grant_stream_id, key_grant_stream_epoch).
+--   - The key_grant cross-column rule (enforced here by the V054
+--     BEFORE INSERT/UPDATE triggers, since SQLite has no ALTER TABLE …
+--     ADD/DROP CONSTRAINT) is widened to admit BOTH addressing modes:
+--     content-addressed XOR stream/epoch-addressed.
+--
+-- SQLite can't ALTER a trigger, so we DROP + recreate both key_grant
+-- asymmetry triggers with the extended RAISE(ABORT) condition. The two
+-- new columns are nullable, so `ALTER TABLE … ADD COLUMN` lands them
+-- in place — NO table rebuild needed.
+--
+-- The takedown_notice triggers are a SEPARATE pair and are left
+-- untouched.
+
+-- 1. New nullable addressing columns (no table rebuild — ALTER ADD
+--    COLUMN works for nullable cols).
+ALTER TABLE cirisnode_contributions
+    ADD COLUMN key_grant_stream_id TEXT;
+
+ALTER TABLE cirisnode_contributions
+    ADD COLUMN key_grant_stream_epoch INTEGER;
+
+-- 2. Drop the V054 key_grant asymmetry triggers and recreate them with
+--    the widened rule. The trigger ABORTs when a row VIOLATES the rule
+--    (the inverse of the PG CHECK predicate):
+--      key_grant rows must have recipient NOT NULL AND exactly one
+--      addressing mode (content XOR stream/epoch); non-key_grant rows
+--      must leave recipient + stream_id + stream_epoch all NULL.
+DROP TRIGGER IF EXISTS cirisnode_contributions_key_grant_asymmetry_ins;
+DROP TRIGGER IF EXISTS cirisnode_contributions_key_grant_asymmetry_upd;
+
+CREATE TRIGGER cirisnode_contributions_key_grant_asymmetry_ins
+    BEFORE INSERT ON cirisnode_contributions
+    FOR EACH ROW
+    WHEN (
+        (NEW.subject_kind = 'key_grant'
+            AND NOT (
+                NEW.key_grant_recipient_key_id IS NOT NULL
+                AND (
+                    (NEW.media_content_sha256 IS NOT NULL
+                        AND NEW.key_grant_stream_id IS NULL
+                        AND NEW.key_grant_stream_epoch IS NULL)
+                    OR
+                    (NEW.key_grant_stream_id IS NOT NULL
+                        AND NEW.key_grant_stream_epoch IS NOT NULL
+                        AND NEW.media_content_sha256 IS NULL)
+                )
+            ))
+        OR
+        (NEW.subject_kind <> 'key_grant'
+            AND (NEW.key_grant_recipient_key_id IS NOT NULL
+                 OR NEW.key_grant_stream_id IS NOT NULL
+                 OR NEW.key_grant_stream_epoch IS NOT NULL))
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'cirisnode_contributions: key_grant subject_kind requires key_grant_recipient_key_id + exactly one addressing mode (content-addressed: media_content_sha256; or stream/epoch-addressed: key_grant_stream_id + key_grant_stream_epoch); other subject_kinds must leave key_grant_recipient_key_id, key_grant_stream_id, key_grant_stream_epoch NULL');
+    END;
+
+CREATE TRIGGER cirisnode_contributions_key_grant_asymmetry_upd
+    BEFORE UPDATE ON cirisnode_contributions
+    FOR EACH ROW
+    WHEN (
+        (NEW.subject_kind = 'key_grant'
+            AND NOT (
+                NEW.key_grant_recipient_key_id IS NOT NULL
+                AND (
+                    (NEW.media_content_sha256 IS NOT NULL
+                        AND NEW.key_grant_stream_id IS NULL
+                        AND NEW.key_grant_stream_epoch IS NULL)
+                    OR
+                    (NEW.key_grant_stream_id IS NOT NULL
+                        AND NEW.key_grant_stream_epoch IS NOT NULL
+                        AND NEW.media_content_sha256 IS NULL)
+                )
+            ))
+        OR
+        (NEW.subject_kind <> 'key_grant'
+            AND (NEW.key_grant_recipient_key_id IS NOT NULL
+                 OR NEW.key_grant_stream_id IS NOT NULL
+                 OR NEW.key_grant_stream_epoch IS NOT NULL))
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'cirisnode_contributions: key_grant subject_kind requires key_grant_recipient_key_id + exactly one addressing mode (content-addressed: media_content_sha256; or stream/epoch-addressed: key_grant_stream_id + key_grant_stream_epoch); other subject_kinds must leave key_grant_recipient_key_id, key_grant_stream_id, key_grant_stream_epoch NULL');
+    END;
+
+-- 3. Partial index for the later per-stream-epoch grant lookup.
+CREATE INDEX IF NOT EXISTS contributions_key_grant_stream_epoch
+    ON cirisnode_contributions (key_grant_stream_id, key_grant_stream_epoch)
+    WHERE key_grant_stream_id IS NOT NULL;

--- a/src/cirisnode/postgres.rs
+++ b/src/cirisnode/postgres.rs
@@ -2890,4 +2890,153 @@ mod tests {
             "expected CHECK violation (SQLSTATE 23514); got: {err:?}"
         );
     }
+
+    /// V064 (CIRISPersist#142 Cut C3a) — the widened key_grant CHECK
+    /// admits BOTH addressing modes (content XOR stream/epoch) and
+    /// rejects malformed shapes. Direct bare-SQL inserts exercise the
+    /// constraint at the DB layer (the stream-addressed write path is
+    /// Cut C3b; C3a only makes the schema admit the shape).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn v064_check_admits_both_key_grant_addressing_modes() {
+        use crate::store::backend::Backend;
+        use tokio_postgres::error::SqlState;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let client = backend.pool().get().await.unwrap();
+
+        // Raw key_grant insert helper. Columns beyond the standard
+        // envelope are passed as $2 (sha), $3 (recipient), $4
+        // (stream_id), $5 (stream_epoch).
+        let sql = "INSERT INTO cirisnode.contributions (\
+                contribution_id, contribution_type, domain, language, subject_kind, \
+                author_id, payload, witness_set, submitted_at, \
+                signature, signing_key_id, signature_verified, persist_row_hash, \
+                media_content_sha256, key_grant_recipient_key_id, \
+                key_grant_stream_id, key_grant_stream_epoch\
+             ) VALUES ($1, 'proposal', 'd', 'en', 'key_grant', 'a', '{}'::jsonb, NULL, NOW(), \
+                       'sig', 'a', TRUE, 'h', $2, $3, $4, $5)";
+        let sha = "a".repeat(64);
+        let recipient = "rec-1".to_string();
+        let stream = "stream-xyz".to_string();
+        let epoch: i64 = 7;
+
+        // 1. Existing content-addressed key_grant (sha + recipient,
+        //    stream cols NULL) STILL inserts OK.
+        client
+            .execute(
+                sql,
+                &[
+                    &Uuid::new_v4(),
+                    &Some(sha.clone()),
+                    &Some(recipient.clone()),
+                    &None::<String>,
+                    &None::<i64>,
+                ],
+            )
+            .await
+            .expect("content-addressed key_grant must still insert post-V064");
+
+        // 2. NEW stream/epoch-addressed key_grant (recipient + stream_id
+        //    + stream_epoch, sha NULL) now inserts OK (was rejected
+        //    pre-V064).
+        client
+            .execute(
+                sql,
+                &[
+                    &Uuid::new_v4(),
+                    &None::<String>,
+                    &Some(recipient.clone()),
+                    &Some(stream.clone()),
+                    &Some(epoch),
+                ],
+            )
+            .await
+            .expect("stream/epoch-addressed key_grant must insert post-V064");
+
+        // 3. BOTH addressing modes set → rejected.
+        let err = client
+            .execute(
+                sql,
+                &[
+                    &Uuid::new_v4(),
+                    &Some(sha.clone()),
+                    &Some(recipient.clone()),
+                    &Some(stream.clone()),
+                    &Some(epoch),
+                ],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.as_db_error().map(|d| d.code().clone()),
+            Some(SqlState::CHECK_VIOLATION),
+            "both-addressing-modes key_grant must be rejected; got: {err:?}"
+        );
+
+        // 4. NEITHER addressing mode set (recipient only) → rejected.
+        let err = client
+            .execute(
+                sql,
+                &[
+                    &Uuid::new_v4(),
+                    &None::<String>,
+                    &Some(recipient.clone()),
+                    &None::<String>,
+                    &None::<i64>,
+                ],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.as_db_error().map(|d| d.code().clone()),
+            Some(SqlState::CHECK_VIOLATION),
+            "neither-addressing-mode key_grant must be rejected; got: {err:?}"
+        );
+
+        // 5. stream_id without stream_epoch → rejected (partial
+        //    stream/epoch mode).
+        let err = client
+            .execute(
+                sql,
+                &[
+                    &Uuid::new_v4(),
+                    &None::<String>,
+                    &Some(recipient.clone()),
+                    &Some(stream.clone()),
+                    &None::<i64>,
+                ],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.as_db_error().map(|d| d.code().clone()),
+            Some(SqlState::CHECK_VIOLATION),
+            "stream_id-without-epoch key_grant must be rejected; got: {err:?}"
+        );
+
+        // 6. non-key_grant row with a stream col set → rejected.
+        let err = client
+            .execute(
+                "INSERT INTO cirisnode.contributions (\
+                    contribution_id, contribution_type, domain, language, subject_kind, \
+                    author_id, payload, witness_set, submitted_at, \
+                    signature, signing_key_id, signature_verified, persist_row_hash, \
+                    key_grant_stream_id, key_grant_stream_epoch\
+                 ) VALUES ($1, 'proposal', 'd', 'en', 'arc_question', 'a', '{}'::jsonb, NULL, NOW(), \
+                           'sig', 'a', TRUE, 'h', $2, $3)",
+                &[&Uuid::new_v4(), &Some(stream.clone()), &Some(epoch)],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.as_db_error().map(|d| d.code().clone()),
+            Some(SqlState::CHECK_VIOLATION),
+            "non-key_grant row with stream col set must be rejected; got: {err:?}"
+        );
+    }
 }

--- a/src/cirisnode/sqlite.rs
+++ b/src/cirisnode/sqlite.rs
@@ -3147,4 +3147,103 @@ mod tests {
             "expected trigger violation; got: {detail}"
         );
     }
+
+    /// V064 (CIRISPersist#142 Cut C3a) — the widened key_grant
+    /// asymmetry triggers admit BOTH addressing modes (content XOR
+    /// stream/epoch) and reject malformed shapes. Direct inserts via
+    /// the shared conn handle exercise the triggers at the DB layer
+    /// (the stream-addressed write path is Cut C3b).
+    #[tokio::test]
+    async fn sqlite_v064_trigger_admits_both_key_grant_addressing_modes() {
+        let (backend, _cn) = fresh_backend().await;
+        let conn = backend.conn_handle();
+
+        // (id, sha, recipient, stream_id, stream_epoch) → Result.
+        let insert = |id: &str,
+                      sha: Option<&str>,
+                      recipient: Option<&str>,
+                      stream: Option<&str>,
+                      epoch: Option<i64>|
+         -> rusqlite::Result<usize> {
+            let guard = conn.lock();
+            guard.execute(
+                "INSERT INTO cirisnode_contributions (\
+                    contribution_id, contribution_type, domain, language, subject_kind, \
+                    author_id, payload, witness_set, submitted_at, \
+                    signature, signing_key_id, signature_verified, persist_row_hash, \
+                    media_content_sha256, key_grant_recipient_key_id, \
+                    key_grant_stream_id, key_grant_stream_epoch\
+                 ) VALUES (?1, 'proposal', 'd', 'en', 'key_grant', 'a', '{}', NULL, \
+                           '2026-01-01T00:00:00Z', 'sig', 'a', 1, 'h', ?2, ?3, ?4, ?5)",
+                rusqlite::params![id, sha, recipient, stream, epoch],
+            )
+        };
+        let sha = "a".repeat(64);
+        let recipient = "rec-1";
+        let stream = "stream-xyz";
+        let epoch: i64 = 7;
+
+        // 1. content-addressed (sha + recipient, stream cols NULL) OK.
+        insert("kg-content", Some(&sha), Some(recipient), None, None)
+            .expect("content-addressed key_grant must still insert post-V064");
+
+        // 2. stream/epoch-addressed (recipient + stream_id + epoch, sha
+        //    NULL) now OK (was rejected pre-V064).
+        insert(
+            "kg-stream",
+            None,
+            Some(recipient),
+            Some(stream),
+            Some(epoch),
+        )
+        .expect("stream/epoch-addressed key_grant must insert post-V064");
+
+        // 3. BOTH modes set → rejected.
+        let err = insert(
+            "kg-both",
+            Some(&sha),
+            Some(recipient),
+            Some(stream),
+            Some(epoch),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("key_grant"),
+            "both-addressing-modes must be rejected; got: {err}"
+        );
+
+        // 4. NEITHER mode (recipient only) → rejected.
+        let err = insert("kg-neither", None, Some(recipient), None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("key_grant"),
+            "neither-addressing-mode must be rejected; got: {err}"
+        );
+
+        // 5. stream_id without epoch → rejected.
+        let err = insert("kg-partial", None, Some(recipient), Some(stream), None).unwrap_err();
+        assert!(
+            err.to_string().contains("key_grant"),
+            "stream_id-without-epoch must be rejected; got: {err}"
+        );
+
+        // 6. non-key_grant row with a stream col set → rejected.
+        let err = (|| -> rusqlite::Result<usize> {
+            let guard = conn.lock();
+            guard.execute(
+                "INSERT INTO cirisnode_contributions (\
+                    contribution_id, contribution_type, domain, language, subject_kind, \
+                    author_id, payload, witness_set, submitted_at, \
+                    signature, signing_key_id, signature_verified, persist_row_hash, \
+                    key_grant_stream_id, key_grant_stream_epoch\
+                 ) VALUES ('kg-nonkg', 'proposal', 'd', 'en', 'arc_question', 'a', '{}', NULL, \
+                           '2026-01-01T00:00:00Z', 'sig', 'a', 1, 'h', ?1, ?2)",
+                rusqlite::params![stream, epoch],
+            )
+        })()
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("key_grant"),
+            "non-key_grant row with stream col set must be rejected; got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
**Cut C3a** ([`FSD/V4_1_STREAMING_SUBSTRATE.md`](FSD/V4_1_STREAMING_SUBSTRATE.md) §4.4; CEG 0.15 §10.5.3 RC1-1c). The one explicitly non-additive piece — extends the `key_grant` cross-column constraint to admit **stream/epoch-addressed** grants alongside content-addressed ones. Migration-only enabler; the epoch-DEK write path is C3b.

## V064 (both backends)
- Adds nullable `key_grant_stream_id` / `key_grant_stream_epoch` to `cirisnode_contributions` + a partial index.
- **PG**: `DROP/ADD CONSTRAINT` on `contributions_key_grant_columns_match_subject_kind` (guarded `DO $$`); the takedown constraint is left untouched.
- **SQLite**: `ALTER ADD COLUMN` (nullable — **no table rebuild**) + drop/recreate the `key_grant_asymmetry_{ins,upd}` triggers with the widened condition.
- **Rule**: `key_grant` ⟺ recipient set AND **exactly one** addressing mode (content-addressed `media_content_sha256` XOR stream/epoch `(stream_id, epoch)`); non-key_grant rows null all three.

## Verification (local, live postgres)
- **1005 lib tests** on `cargo test --features "postgres server pyo3 sqlite cirisnode" --lib` against live PG (V064 exercised live; `pg_get_constraintdef` confirms the widened rule).
- Tests: content-addressed still admits; **stream/epoch-addressed now admits (was rejected pre-V064)**; both-modes / neither-mode / partial / non-key_grant-with-stream-col all rejected.
- Clean under `-D warnings`: `--no-default-features`, `--features test-panic,pyo3`, full CI gated combo. No `u64` PG binds.

Next: C3b (epoch-DEK generation + `wrap_algorithm: v2` hybrid-KEM cascade writing these stream/epoch key_grants) — now unblocked by the CEG 0.15 ratification (CIRISRegistry#63); C3c (member-removal rotation + live seal wiring); C4 (delivery receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)