### PR TITLE
Streaming Cut C3b — epoch-DEK key_grant cascade + wrap_algorithm v2 (#142, CEG §10.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.3.0] — 2026-06-07
+
+**Streaming substrate Cut C3b — epoch-DEK `key_grant` cascade + `wrap_algorithm: v2` (PQC) + CIRISVerify 4.10.0 re-pin (CIRISPersist#142, CEG 0.15 §10.5.3).**
+
+The streaming epoch-key cascade. A per-`(stream_id, epoch)` DEK is wrapped to each roster recipient as a stream/epoch-addressed `key_grant` Contribution. **Persist's role is validate / record / list, NOT wrap** (the producer/sender wraps and submits; the storage path stores the wrapped DEK opaquely; MISSION §1.7). Unblocked by CIRISVerify#58 closing.
+
+### Dependency
+- **CIRISVerify `v4.8.1` → `v4.10.0`** across all deps + `[target.*]` tables. Picks up `ciris-crypto::key_grant`'s **`wrap_algorithm: v2`** API (`KEY_GRANT_ALGORITHM_V2`, `wrap_dek_for_recipient_v2`/`unwrap_dek_v2`/`KeyGrantWrapV2`; #58) — gated `ml-kem`, which persist already pulls via `hybrid-kex`, so no feature change. (4.9.0 moved `random` into default features — additive.) 1028 lib tests green on live PG against 4.10.0.
+
+### Added — the cascade
+- **Stream/epoch-addressed `key_grant`** — `KeyGrantPayload` gains optional `stream_id` / `stream_epoch` (and `content_sha256` becomes optional); `WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256` (v2); `KeyGrantScope::StreamEpoch`. Projected onto the V064 (`Cut C3a`) `key_grant_stream_id` / `key_grant_stream_epoch` columns, both backends.
+- **`list_key_grants_for_stream_epoch(stream_id, epoch)`** on the NodeCore service + both backends + PyO3 (`cirisnode_list_key_grants_for_stream_epoch_json`) — the catch-up / delivery read the cascade serves. Persist returns the grants; the consumer (LensCore) applies its own **P4 catch-up depth cap** (a LensCore knob, NOT a substrate constant — CEG §10.5.3). `history_on_join` (a producer envelope field) is likewise not a persist concern.
+- **Wheel FFI v2 helpers** — `wrap_dek_for_recipient_v2_b64` / `unwrap_dek_v2_b64` (the only place persist *calls* the v2 wrap; for Python users of the crate). Real-hybrid round-trip tested.
+- **`MAX_CHUNKS_PER_EPOCH = 2²⁴`** — a nonce-safety **substrate constant** (the STREAM nonce's 32-bit `counter_be` must never wrap). `put_blob_chunk` refuses an append that would push a `(stream_id, epoch)` past it (force epoch roll), both backends.
+
+### Enforced at ingest — the normative reject-v1
+- A **streaming epoch grant carrying `wrap_algorithm: v1` is rejected at `put_contribution`** (CEG §10.5.3: "a Consumer MUST reject a streaming epoch grant carrying `wrap_algorithm: v1`"). The extractor enforces **exactly-one addressing mode** (content XOR stream/epoch, mirroring the V064 CHECK) and `scope=stream_epoch` for streaming grants. Content-addressed v1 grants are unaffected (backward-compatible).
+
+### Pending ratification
+- The **v2 payload wire string** `x25519_mlkem768_aes256_gcm_hkdf_sha256` is **proposed pending CIRISRegistry#64**. CEG §10.5.3 mandates `wrap_algorithm: v2` but does not yet pin the payload enum string (unlike v1's §5.6.8.4-pinned string); shipped via the propose-then-ratify path (same as the STREAM-nonce epoch encoding, #63). Only the serde rename changes if the registry pins a different string.
+
+### Tests
+Both backends (live PG + in-memory SQLite): stream/epoch grant round-trip + `(stream_id, epoch)` filtering, ingest reject-v1, addressing-XOR + scope validators, the `MAX_CHUNKS_PER_EPOCH` boundary, and a real v2 hybrid wrap/unwrap round-trip through the wheel FFI.
+
 ## [4.2.0] — 2026-06-07
 
 **Streaming substrate Cut C4 — signed delivery receipts (CIRISPersist#142, CEG 0.15 §10.5.4).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -721,10 +721,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -735,7 +735,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.1", version = "4", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/src/cirisnode/media_sharing.rs
+++ b/src/cirisnode/media_sharing.rs
@@ -465,13 +465,34 @@ pub struct KeyGrantPayload {
     pub recipient_key_id: String,
 
     /// SHA-256 of the content body the granted key encrypts, hex-encoded.
-    pub content_sha256: String,
+    /// Present iff the grant is **content-addressed**; `None` for a
+    /// **stream/epoch-addressed** streaming grant (see [`Self::stream_id`]
+    /// / [`Self::stream_epoch`]). Exactly one addressing mode holds —
+    /// enforced by [`extract_key_grant_payload`] (mirrors the V064
+    /// `cirisnode.contributions` XOR CHECK; CEG 0.15 §10.5.3 RC1-1c).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_sha256: Option<String>,
+
+    /// `federation_streams` stream id the epoch-DEK is scoped to.
+    /// Present iff the grant is **stream/epoch-addressed** (the §10.5.3
+    /// streaming cascade); `None` for a content-addressed grant.
+    /// Projected onto `key_grant_stream_id` (V064) for indexed reads.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<String>,
+
+    /// Key-rotation epoch within [`Self::stream_id`] the wrapped DEK
+    /// covers. Present iff stream/epoch-addressed. Projected onto
+    /// `key_grant_stream_epoch` (V064).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_epoch: Option<u64>,
 
     /// Base64-encoded wrapped DEK. The wrap algorithm is named below.
     pub wrapped_dek_base64: String,
 
-    /// Wrap algorithm identifier. v1 ships with a single variant —
-    /// see [`WrapAlgorithm`].
+    /// Wrap algorithm identifier. Content grants use v1; **stream/epoch
+    /// grants MUST use v2** (PQC hybrid — see [`WrapAlgorithm`] and CEG
+    /// §10.5.3: "a Consumer MUST reject a streaming epoch grant carrying
+    /// `wrap_algorithm: v1`", enforced at ingest).
     pub wrap_algorithm: WrapAlgorithm,
 
     /// Symmetric-ratchet version the key was wrapped under.
@@ -496,28 +517,47 @@ pub struct KeyGrantPayload {
     pub rotation_chain: Vec<String>,
 }
 
-/// Closed-set wrap algorithm vocabulary. v1 ships a single variant;
-/// adding a second is a coordinated registry rev.
+/// Closed-set wrap algorithm vocabulary.
 ///
-/// # CEG 0.3 §5.6.8.4 — HPKE RFC 9180 base mode, KEM X25519, AEAD AES-128-GCM
+/// # v1 — CEG 0.3 §5.6.8.4 — HPKE RFC 9180 base mode, KEM X25519, AEAD AES-128-GCM
 ///
 /// Locked by CEG 0.3 (Registry commit a7d95cd, closes CIRISRegistry#38).
-/// Wire string: `"hpke_rfc9180_base_x25519_aes_gcm"`. Adding a v2
-/// variant (e.g. ML-KEM hybrid) is a coordinated registry rev.
+/// Wire string: `"hpke_rfc9180_base_x25519_aes_gcm"`.
+///
+/// # v2 — CEG 0.15 §10.5.3 — X25519 + ML-KEM-768 hybrid (FIPS 203), PQC at rest
+///
+/// **MANDATORY for streaming epoch-DEK grants** (the §10.5.3 cascade);
+/// a content grant may stay v1, but a stream/epoch grant carrying v1 is
+/// rejected at ingest. Wraps with the `ciris-crypto::key_grant`
+/// `wrap_dek_for_recipient_v2` construction (`KEY_GRANT_ALGORITHM_V2 =
+/// "x25519-mlkem768-aes256-gcm-hkdf-sha256"`, v4.10.0). The payload wire
+/// string `"x25519_mlkem768_aes256_gcm_hkdf_sha256"` names that
+/// construction; **pending CIRISRegistry ratification (CIRISRegistry#64)**
+/// — the CEG mandates `wrap_algorithm: v2` but does not yet pin the
+/// payload enum string (unlike v1's §5.6.8.4-pinned string), so this is
+/// proposed via the same propose-then-ratify path as the STREAM-nonce
+/// epoch encoding (CIRISRegistry#63). If the registry ratifies a
+/// different string, only this serde rename changes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WrapAlgorithm {
     /// HPKE RFC 9180 base mode, KEM X25519, AEAD AES-128-GCM. Locked
-    /// by CEG 0.3 §5.6.8.4.
+    /// by CEG 0.3 §5.6.8.4. The content-addressed-grant default.
     #[serde(rename = "hpke_rfc9180_base_x25519_aes_gcm")]
     HpkeRfc9180BaseX25519AesGcm,
+
+    /// X25519 + ML-KEM-768 hybrid DEK wrap (FIPS 203), AES-256-GCM +
+    /// HKDF-SHA-256. CEG 0.15 §10.5.3; mandatory for streaming epoch
+    /// grants. Maps to `ciris-crypto`'s `KEY_GRANT_ALGORITHM_V2`.
+    #[serde(rename = "x25519_mlkem768_aes256_gcm_hkdf_sha256")]
+    X25519MlKem768Aes256GcmHkdfSha256,
 }
 
 impl WrapAlgorithm {
-    /// Wire-shaped string — matches the CEG 0.3 §5.6.8.4 locked
-    /// vocabulary.
+    /// Wire-shaped string — matches the locked vocabulary.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::HpkeRfc9180BaseX25519AesGcm => "hpke_rfc9180_base_x25519_aes_gcm",
+            Self::X25519MlKem768Aes256GcmHkdfSha256 => "x25519_mlkem768_aes256_gcm_hkdf_sha256",
         }
     }
 
@@ -526,8 +566,17 @@ impl WrapAlgorithm {
     pub fn from_wire_str(s: &str) -> Option<Self> {
         match s {
             "hpke_rfc9180_base_x25519_aes_gcm" => Some(Self::HpkeRfc9180BaseX25519AesGcm),
+            "x25519_mlkem768_aes256_gcm_hkdf_sha256" => {
+                Some(Self::X25519MlKem768Aes256GcmHkdfSha256)
+            }
             _ => None,
         }
+    }
+
+    /// Whether this is the PQC-hybrid v2 wrap (the only algorithm a
+    /// streaming epoch-DEK grant may carry; CEG §10.5.3).
+    pub fn is_streaming_pqc_v2(self) -> bool {
+        matches!(self, Self::X25519MlKem768Aes256GcmHkdfSha256)
     }
 }
 
@@ -544,6 +593,10 @@ pub enum KeyGrantScope {
     SingleContent,
     GroupMember,
     SubscriptionTier,
+    /// One grant per `(stream_id, epoch)` — the streaming epoch-DEK
+    /// cascade (CEG 0.15 §10.5.3). `scope_id` is the `stream_id`. The
+    /// only scope a stream/epoch-addressed grant may carry.
+    StreamEpoch,
 }
 
 impl KeyGrantScope {
@@ -553,6 +606,7 @@ impl KeyGrantScope {
             Self::SingleContent => "single_content",
             Self::GroupMember => "group_member",
             Self::SubscriptionTier => "subscription_tier",
+            Self::StreamEpoch => "stream_epoch",
         }
     }
 }
@@ -638,11 +692,21 @@ pub fn extract_takedown_notice_payload(
 /// Decode + validate a `key_grant` payload from the JSONB column.
 /// Returns `Ok(None)` for non-grant rows.
 ///
-/// Validation:
-///   - `content_sha256` is hex-64 lowercase.
+/// Validation (common):
 ///   - `recipient_key_id` / `scope_id` non-empty.
 ///   - `wrapped_dek_base64` is valid base64.
 ///   - `key_validity_window.not_after > not_before`.
+///
+/// Addressing — **exactly one mode** (mirrors the V064
+/// `cirisnode.contributions` XOR CHECK; CEG 0.15 §10.5.3 RC1-1c):
+///   - **content-addressed**: `content_sha256` is `Some` hex-64
+///     lowercase; `stream_id` / `stream_epoch` are `None`.
+///   - **stream/epoch-addressed**: `stream_id` is `Some` non-empty AND
+///     `stream_epoch` is `Some`; `content_sha256` is `None`. The grant
+///     **MUST** carry `wrap_algorithm: v2` (PQC hybrid) — a v1 wrap on a
+///     streaming epoch grant is rejected here (CEG §10.5.3: "a Consumer
+///     MUST reject a streaming epoch grant carrying `wrap_algorithm:
+///     v1`"). `scope` must be [`KeyGrantScope::StreamEpoch`].
 pub fn extract_key_grant_payload(
     subject_kind: &str,
     payload: &serde_json::Value,
@@ -652,7 +716,6 @@ pub fn extract_key_grant_payload(
     }
     let typed: KeyGrantPayload = serde_json::from_value(payload.clone())
         .map_err(|e| Error::InvalidArgument(format!("key_grant payload shape: {e}")))?;
-    validate_hex_64("content_sha256", &typed.content_sha256)?;
     validate_non_empty("recipient_key_id", &typed.recipient_key_id)?;
     validate_non_empty("scope_id", &typed.scope_id)?;
     validate_base64("wrapped_dek_base64", &typed.wrapped_dek_base64)?;
@@ -660,6 +723,57 @@ pub fn extract_key_grant_payload(
         return Err(Error::InvalidArgument(
             "key_grant: key_validity_window.not_after must be after not_before".into(),
         ));
+    }
+
+    // Exactly-one addressing mode (XOR), matching the V064 constraint.
+    let content_addressed = typed.content_sha256.is_some();
+    let stream_addressed = typed.stream_id.is_some() || typed.stream_epoch.is_some();
+    match (content_addressed, stream_addressed) {
+        (true, true) => {
+            return Err(Error::InvalidArgument(
+                "key_grant: content_sha256 and stream_id/stream_epoch are mutually exclusive \
+                 (exactly one addressing mode; CEG §10.5.3 RC1-1c)"
+                    .into(),
+            ));
+        }
+        (false, false) => {
+            return Err(Error::InvalidArgument(
+                "key_grant: must be addressed — set content_sha256 (content) OR \
+                 stream_id + stream_epoch (streaming epoch)"
+                    .into(),
+            ));
+        }
+        (true, false) => {
+            // Content-addressed: hex-64 sha, no stream fields.
+            let sha = typed
+                .content_sha256
+                .as_deref()
+                .expect("content_addressed => Some");
+            validate_hex_64("content_sha256", sha)?;
+        }
+        (false, true) => {
+            // Stream/epoch-addressed: both fields present, v2 wrap required.
+            validate_non_empty("stream_id", typed.stream_id.as_deref().unwrap_or_default())?;
+            if typed.stream_epoch.is_none() {
+                return Err(Error::InvalidArgument(
+                    "key_grant: stream/epoch-addressed grant requires stream_epoch".into(),
+                ));
+            }
+            if !typed.wrap_algorithm.is_streaming_pqc_v2() {
+                return Err(Error::InvalidArgument(format!(
+                    "key_grant: streaming epoch grant MUST use wrap_algorithm v2 \
+                     (x25519_mlkem768_aes256_gcm_hkdf_sha256), got {} — CEG §10.5.3 \
+                     rejects wrap_algorithm: v1 on a streaming epoch grant",
+                    typed.wrap_algorithm.as_str()
+                )));
+            }
+            if typed.scope != KeyGrantScope::StreamEpoch {
+                return Err(Error::InvalidArgument(format!(
+                    "key_grant: stream/epoch-addressed grant requires scope=stream_epoch, got {}",
+                    typed.scope.as_str()
+                )));
+            }
+        }
     }
     Ok(Some(typed))
 }
@@ -696,7 +810,9 @@ mod tests {
     fn fixture_key_grant() -> KeyGrantPayload {
         KeyGrantPayload {
             recipient_key_id: "recipient-1".into(),
-            content_sha256: fixture_sha256(),
+            content_sha256: Some(fixture_sha256()),
+            stream_id: None,
+            stream_epoch: None,
             wrapped_dek_base64: base64::engine::general_purpose::STANDARD.encode([0u8; 48]),
             wrap_algorithm: WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm,
             ratchet_version: 1,
@@ -987,6 +1103,121 @@ mod tests {
         let value = serde_json::to_value(&typed).unwrap();
         let err = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value).unwrap_err();
         assert!(matches!(err, Error::InvalidArgument(_)));
+    }
+
+    // ── Cut C3b: stream/epoch addressing (CEG §10.5.3) ──────────────
+
+    /// A valid stream/epoch-addressed grant: no content_sha256, stream
+    /// fields set, v2 wrap, StreamEpoch scope.
+    fn fixture_stream_grant() -> KeyGrantPayload {
+        KeyGrantPayload {
+            recipient_key_id: "recipient-1".into(),
+            content_sha256: None,
+            stream_id: Some("stream-abc".into()),
+            stream_epoch: Some(7),
+            wrapped_dek_base64: base64::engine::general_purpose::STANDARD.encode([0u8; 48]),
+            wrap_algorithm: WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256,
+            ratchet_version: 1,
+            key_validity_window: KeyValidityWindow {
+                not_before: DateTime::parse_from_rfc3339("2026-05-29T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                not_after: DateTime::parse_from_rfc3339("2027-05-29T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            },
+            scope: KeyGrantScope::StreamEpoch,
+            scope_id: "stream-abc".into(),
+            rotation_chain: vec![],
+        }
+    }
+
+    #[test]
+    fn extract_stream_epoch_grant_validates() {
+        let typed = fixture_stream_grant();
+        let value = serde_json::to_value(&typed).unwrap();
+        let parsed = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value)
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed, typed);
+        assert!(parsed.wrap_algorithm.is_streaming_pqc_v2());
+    }
+
+    #[test]
+    fn stream_grant_with_v1_wrap_is_rejected() {
+        // The normative §10.5.3 check: a streaming epoch grant carrying
+        // wrap_algorithm v1 MUST be rejected.
+        let mut typed = fixture_stream_grant();
+        typed.wrap_algorithm = WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm;
+        let value = serde_json::to_value(&typed).unwrap();
+        let err = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value).unwrap_err();
+        match err {
+            Error::InvalidArgument(m) => assert!(
+                m.contains("wrap_algorithm v2") && m.contains("v1"),
+                "expected reject-v1 message, got: {m}"
+            ),
+            other => panic!("expected InvalidArgument, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn grant_with_both_addressing_modes_is_rejected() {
+        let mut typed = fixture_stream_grant();
+        typed.content_sha256 = Some("a".repeat(64)); // now BOTH set
+        let value = serde_json::to_value(&typed).unwrap();
+        let err = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(ref m) if m.contains("mutually exclusive")));
+    }
+
+    #[test]
+    fn grant_with_no_addressing_is_rejected() {
+        let mut typed = fixture_stream_grant();
+        typed.stream_id = None;
+        typed.stream_epoch = None; // neither content nor stream
+        let value = serde_json::to_value(&typed).unwrap();
+        let err = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(ref m) if m.contains("must be addressed")));
+    }
+
+    #[test]
+    fn stream_grant_requires_stream_epoch_scope() {
+        let mut typed = fixture_stream_grant();
+        typed.scope = KeyGrantScope::GroupMember; // wrong scope
+        let value = serde_json::to_value(&typed).unwrap();
+        let err = extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value).unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(ref m) if m.contains("scope=stream_epoch")));
+    }
+
+    #[test]
+    fn content_grant_still_accepts_v1() {
+        // Backward compat: a content-addressed grant with v1 wrap is
+        // unaffected by the streaming reject-v1 rule.
+        let typed = fixture_key_grant();
+        assert_eq!(
+            typed.wrap_algorithm,
+            WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm
+        );
+        let value = serde_json::to_value(&typed).unwrap();
+        assert!(extract_key_grant_payload(KEY_GRANT_SUBJECT_KIND, &value)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn wrap_algorithm_v2_wire_round_trip() {
+        assert_eq!(
+            WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256.as_str(),
+            "x25519_mlkem768_aes256_gcm_hkdf_sha256"
+        );
+        assert_eq!(
+            WrapAlgorithm::from_wire_str("x25519_mlkem768_aes256_gcm_hkdf_sha256"),
+            Some(WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256)
+        );
+        // serde rename matches the wire string.
+        assert_eq!(
+            serde_json::to_string(&WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256).unwrap(),
+            r#""x25519_mlkem768_aes256_gcm_hkdf_sha256""#
+        );
     }
 
     #[test]

--- a/src/cirisnode/postgres.rs
+++ b/src/cirisnode/postgres.rs
@@ -151,11 +151,27 @@ impl NodeCoreService for PostgresBackend {
         let media_content_sha256: Option<String> = takedown
             .as_ref()
             .map(|p| p.content_sha256.clone())
-            .or_else(|| key_grant.as_ref().map(|p| p.content_sha256.clone()));
+            .or_else(|| key_grant.as_ref().and_then(|p| p.content_sha256.clone()));
         let takedown_legal_basis: Option<&'static str> =
             takedown.as_ref().map(|p| p.legal_basis.as_str());
         let key_grant_recipient_key_id: Option<String> =
             key_grant.as_ref().map(|p| p.recipient_key_id.clone());
+        // v4.x (CIRISPersist#142 Cut C3b) — stream/epoch addressing
+        // projection (V064 columns). XOR with media_content_sha256 is
+        // guaranteed by extract_key_grant_payload. stream_epoch is u64
+        // in Rust → bound i64 (BIGINT); tokio_postgres has no ToSql u64.
+        let key_grant_stream_id: Option<String> =
+            key_grant.as_ref().and_then(|p| p.stream_id.clone());
+        let key_grant_stream_epoch: Option<i64> =
+            match key_grant.as_ref().and_then(|p| p.stream_epoch) {
+                None => None,
+                Some(e) => Some(i64::try_from(e).map_err(|_| {
+                    Error::InvalidArgument(
+                        "key_grant: stream_epoch exceeds i64 — key_grant_stream_epoch is BIGINT"
+                            .into(),
+                    )
+                })?),
+            };
 
         let client = self
             .pool()
@@ -173,9 +189,10 @@ impl NodeCoreService for PostgresBackend {
                     author_id, payload, witness_set, submitted_at, \
                     signature, signing_key_id, signature_verified, persist_row_hash, \
                     announcement_priority, announcement_authority_class, \
-                    media_content_sha256, key_grant_recipient_key_id, takedown_legal_basis\
+                    media_content_sha256, key_grant_recipient_key_id, takedown_legal_basis, \
+                    key_grant_stream_id, key_grant_stream_epoch\
                  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, TRUE, $12, $13, $14, \
-                           $15, $16, $17)",
+                           $15, $16, $17, $18, $19)",
                 &[
                     &id,
                     &contribution_type_str(env.contribution_type),
@@ -194,6 +211,8 @@ impl NodeCoreService for PostgresBackend {
                     &media_content_sha256,
                     &key_grant_recipient_key_id,
                     &takedown_legal_basis,
+                    &key_grant_stream_id,
+                    &key_grant_stream_epoch,
                 ],
             )
             .await
@@ -1176,6 +1195,36 @@ impl NodeCoreService for PostgresBackend {
         rows.into_iter().map(row_to_contribution).collect()
     }
 
+    async fn list_key_grants_for_stream_epoch(
+        &self,
+        stream_id: &str,
+        epoch: u64,
+    ) -> Result<Vec<ContributionEnvelope>, Error> {
+        // u64 epoch → bound i64 (BIGINT); tokio_postgres has no ToSql u64.
+        let epoch_i64 = i64::try_from(epoch).map_err(|_| {
+            Error::InvalidArgument("list_key_grants_for_stream_epoch: epoch exceeds i64".into())
+        })?;
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| Error::Backend(format!("pool: {e}")))?;
+        let rows = client
+            .query(
+                "SELECT contribution_id::text, contribution_type, domain, language, subject_kind, \
+                        author_id, payload, witness_set, submitted_at, signature \
+                 FROM cirisnode.contributions \
+                 WHERE subject_kind = 'key_grant' \
+                   AND key_grant_stream_id = $1 \
+                   AND key_grant_stream_epoch = $2 \
+                 ORDER BY submitted_at DESC, contribution_id DESC",
+                &[&stream_id, &epoch_i64],
+            )
+            .await
+            .map_err(|e| map_pg_error(e, "list_key_grants_for_stream_epoch"))?;
+        rows.into_iter().map(row_to_contribution).collect()
+    }
+
     async fn retire_key_grants(
         &self,
         actor_key_id: &str,
@@ -1317,8 +1366,12 @@ async fn emit_key_grant_supersession(
     let supersession_payload = super::media_sharing::KeyGrantPayload {
         recipient_key_id: prior.recipient_key_id.clone(),
         content_sha256: prior.content_sha256.clone(),
+        // Carry the prior grant's addressing + wrap algorithm so a
+        // stream/epoch-grant supersession stays stream-addressed + v2.
+        stream_id: prior.stream_id.clone(),
+        stream_epoch: prior.stream_epoch,
         wrapped_dek_base64: revocation_dek,
-        wrap_algorithm: super::media_sharing::WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm,
+        wrap_algorithm: prior.wrap_algorithm,
         ratchet_version: prior.ratchet_version,
         key_validity_window: super::media_sharing::KeyValidityWindow {
             // The supersession grant's validity window is bounded by
@@ -2454,7 +2507,9 @@ mod tests {
         let author = pubkey_b64(author_key);
         let payload = crate::cirisnode::KeyGrantPayload {
             recipient_key_id: recipient_key_id.to_owned(),
-            content_sha256: sha_hex.to_owned(),
+            content_sha256: Some(sha_hex.to_owned()),
+            stream_id: None,
+            stream_epoch: None,
             wrapped_dek_base64: {
                 use base64::Engine as _;
                 base64::engine::general_purpose::STANDARD.encode([0u8; 48])
@@ -2489,6 +2544,120 @@ mod tests {
         };
         env.signature = sign_envelope(&env, author_key);
         env
+    }
+
+    // ── Cut C3b: stream/epoch-addressed grant cascade (CEG §10.5.3) ──
+
+    fn build_stream_key_grant(
+        author_key: &ed25519_dalek::SigningKey,
+        stream_id: &str,
+        epoch: u64,
+        recipient_key_id: &str,
+    ) -> ContributionEnvelope {
+        let author = pubkey_b64(author_key);
+        let payload = crate::cirisnode::KeyGrantPayload {
+            recipient_key_id: recipient_key_id.to_owned(),
+            content_sha256: None,
+            stream_id: Some(stream_id.to_owned()),
+            stream_epoch: Some(epoch),
+            wrapped_dek_base64: {
+                use base64::Engine as _;
+                base64::engine::general_purpose::STANDARD.encode([0u8; 48])
+            },
+            wrap_algorithm: crate::cirisnode::WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256,
+            ratchet_version: 1,
+            key_validity_window: crate::cirisnode::KeyValidityWindow {
+                not_before: Utc::now(),
+                not_after: Utc::now() + chrono::Duration::days(30),
+            },
+            scope: crate::cirisnode::KeyGrantScope::StreamEpoch,
+            scope_id: stream_id.to_owned(),
+            rotation_chain: vec![],
+        };
+        let mut env = ContributionEnvelope {
+            contribution_id: Uuid::new_v4().to_string(),
+            contribution_type: ContributionType::Proposal,
+            author_id: author,
+            subject: Cell {
+                domain: format!("stream-{}", Uuid::new_v4()),
+                language: "en".into(),
+                subject: Some(crate::cirisnode::KEY_GRANT_SUBJECT_KIND.into()),
+            },
+            payload: serde_json::to_value(&payload).unwrap(),
+            witness_set: None,
+            signature: HybridSignature {
+                ed25519: String::new(),
+                ml_dsa_65: None,
+                signed_at: Utc::now(),
+            },
+            submitted_at: Utc::now(),
+        };
+        env.signature = sign_envelope(&env, author_key);
+        env
+    }
+
+    /// PG parity for the stream/epoch grant cascade: v2 grant admitted,
+    /// projected onto the V064 BIGINT/text columns, served by
+    /// list_key_grants_for_stream_epoch filtered on (stream_id, epoch);
+    /// and a v1-wrapped streaming grant is rejected at ingest.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_stream_epoch_grant_round_trip_and_v1_reject() {
+        use crate::store::backend::Backend;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let author_key = ed25519_dalek::SigningKey::from_bytes(&[0xC5; 32]);
+        let stream = format!("stream-{}", Uuid::new_v4());
+        let other_stream = format!("stream-{}", Uuid::new_v4());
+        let recip = format!("rec-{}", Uuid::new_v4());
+
+        backend
+            .put_contribution(build_stream_key_grant(&author_key, &stream, 1, &recip))
+            .await
+            .unwrap();
+        backend
+            .put_contribution(build_stream_key_grant(&author_key, &stream, 2, &recip))
+            .await
+            .unwrap();
+        backend
+            .put_contribution(build_stream_key_grant(
+                &author_key,
+                &other_stream,
+                1,
+                &recip,
+            ))
+            .await
+            .unwrap();
+
+        let rows = backend
+            .list_key_grants_for_stream_epoch(&stream, 1)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "exactly the (stream, epoch=1) grant");
+        let rows2 = backend
+            .list_key_grants_for_stream_epoch(&stream, 2)
+            .await
+            .unwrap();
+        assert_eq!(rows2.len(), 1);
+        let none = backend
+            .list_key_grants_for_stream_epoch(&stream, 99)
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+
+        // v1 wrap on a streaming grant is rejected at ingest.
+        let mut env = build_stream_key_grant(&author_key, &stream, 3, &recip);
+        let mut payload: crate::cirisnode::KeyGrantPayload =
+            serde_json::from_value(env.payload.clone()).unwrap();
+        payload.wrap_algorithm = crate::cirisnode::WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm;
+        env.payload = serde_json::to_value(&payload).unwrap();
+        env.signature = sign_envelope(&env, &author_key);
+        let err = backend.put_contribution(env).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "got: {err:?}");
     }
 
     #[tokio::test]

--- a/src/cirisnode/service.rs
+++ b/src/cirisnode/service.rs
@@ -286,6 +286,20 @@ pub trait NodeCoreService: Send + Sync {
         recipient_key_id: &str,
     ) -> impl Future<Output = Result<Vec<ContributionEnvelope>, Error>> + Send;
 
+    /// v4.x (CIRISPersist#142 Cut C3b, CEG §10.5.3) — list every
+    /// **stream/epoch-addressed** `key_grant` Contribution for
+    /// `(stream_id, epoch)`, newest-first. This is the catch-up /
+    /// delivery read the epoch-DEK cascade serves; persist returns the
+    /// grants and the consumer (LensCore) applies its own P4 catch-up
+    /// depth cap (the cap is a LensCore knob, NOT a substrate constant —
+    /// §10.5.3). Indexed via the V064 partial index
+    /// `contributions_key_grant_stream_epoch`.
+    fn list_key_grants_for_stream_epoch(
+        &self,
+        stream_id: &str,
+        epoch: u64,
+    ) -> impl Future<Output = Result<Vec<ContributionEnvelope>, Error>> + Send;
+
     /// v3.6.0 (CIRISPersist#134) — emit a supersession `key_grant`
     /// Contribution against every prior `key_grant` Contribution
     /// issued by `actor_key_id`. Used when an actor's keying material

--- a/src/cirisnode/sqlite.rs
+++ b/src/cirisnode/sqlite.rs
@@ -267,11 +267,27 @@ impl NodeCoreService for SqliteNodeCoreBackend {
         let media_content_sha256: Option<String> = takedown
             .as_ref()
             .map(|p| p.content_sha256.clone())
-            .or_else(|| key_grant.as_ref().map(|p| p.content_sha256.clone()));
+            .or_else(|| key_grant.as_ref().and_then(|p| p.content_sha256.clone()));
         let takedown_legal_basis: Option<String> =
             takedown.as_ref().map(|p| p.legal_basis.as_str().to_owned());
         let key_grant_recipient_key_id: Option<String> =
             key_grant.as_ref().map(|p| p.recipient_key_id.clone());
+        // v4.x (CIRISPersist#142 Cut C3b) — stream/epoch addressing
+        // projection (V064 columns). Populated iff the grant is
+        // stream/epoch-addressed; the extractor guarantees the XOR with
+        // media_content_sha256.
+        let key_grant_stream_id: Option<String> =
+            key_grant.as_ref().and_then(|p| p.stream_id.clone());
+        let key_grant_stream_epoch: Option<i64> =
+            match key_grant.as_ref().and_then(|p| p.stream_epoch) {
+                None => None,
+                Some(e) => Some(i64::try_from(e).map_err(|_| {
+                    Error::InvalidArgument(
+                        "key_grant: stream_epoch exceeds i64 — key_grant_stream_epoch is INTEGER"
+                            .into(),
+                    )
+                })?),
+            };
 
         let id_str = id.to_string();
         let ct_str = contribution_type_str(env.contribution_type).to_owned();
@@ -299,9 +315,10 @@ impl NodeCoreService for SqliteNodeCoreBackend {
                         author_id, payload, witness_set, submitted_at, \
                         signature, signing_key_id, signature_verified, persist_row_hash, \
                         announcement_priority, announcement_authority_class, \
-                        media_content_sha256, key_grant_recipient_key_id, takedown_legal_basis\
+                        media_content_sha256, key_grant_recipient_key_id, takedown_legal_basis, \
+                        key_grant_stream_id, key_grant_stream_epoch\
                      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 1, ?12, ?13, ?14, \
-                               ?15, ?16, ?17)",
+                               ?15, ?16, ?17, ?18, ?19)",
                     params![
                         id_str,
                         ct_str,
@@ -320,6 +337,8 @@ impl NodeCoreService for SqliteNodeCoreBackend {
                         media_content_sha256,
                         key_grant_recipient_key_id,
                         takedown_legal_basis,
+                        key_grant_stream_id,
+                        key_grant_stream_epoch,
                     ],
                 )
                 .map_err(|e| map_sqlite_error(e, "put_contribution"))?;
@@ -1527,6 +1546,39 @@ impl NodeCoreService for SqliteNodeCoreBackend {
         rows.into_iter().map(materialize_contribution).collect()
     }
 
+    async fn list_key_grants_for_stream_epoch(
+        &self,
+        stream_id: &str,
+        epoch: u64,
+    ) -> Result<Vec<ContributionEnvelope>, Error> {
+        let stream = stream_id.to_owned();
+        // u64 epoch → bound i64; key_grant_stream_epoch is INTEGER.
+        let epoch_i64 = i64::try_from(epoch).map_err(|_| {
+            Error::InvalidArgument("list_key_grants_for_stream_epoch: epoch exceeds i64".into())
+        })?;
+        let conn = self.conn.clone();
+        let rows = (move || -> Result<Vec<ContributionRow>, Error> {
+            let guard = conn.lock();
+            let mut stmt = guard
+                .prepare(
+                    "SELECT contribution_id, contribution_type, domain, language, subject_kind, \
+                            author_id, payload, witness_set, submitted_at, signature \
+                     FROM cirisnode_contributions \
+                     WHERE subject_kind = 'key_grant' \
+                       AND key_grant_stream_id = ?1 \
+                       AND key_grant_stream_epoch = ?2 \
+                     ORDER BY submitted_at DESC, contribution_id DESC",
+                )
+                .map_err(|e| map_sqlite_error(e, "list_key_grants_for_stream_epoch prepare"))?;
+            let rows = stmt
+                .query_map(params![stream, epoch_i64], read_contribution_row)
+                .map_err(|e| map_sqlite_error(e, "list_key_grants_for_stream_epoch query"))?;
+            let out: Result<Vec<_>, _> = rows.collect();
+            out.map_err(|e| map_sqlite_error(e, "list_key_grants_for_stream_epoch collect"))
+        })()?;
+        rows.into_iter().map(materialize_contribution).collect()
+    }
+
     async fn retire_key_grants(
         &self,
         actor_key_id: &str,
@@ -1709,8 +1761,13 @@ async fn emit_key_grant_supersession_sqlite(
     let supersession_payload = super::media_sharing::KeyGrantPayload {
         recipient_key_id: prior.recipient_key_id.clone(),
         content_sha256: prior.content_sha256.clone(),
+        // Carry the prior grant's addressing + wrap algorithm so a
+        // stream/epoch-grant supersession stays stream-addressed + v2
+        // (the extractor rejects a v1 streaming grant).
+        stream_id: prior.stream_id.clone(),
+        stream_epoch: prior.stream_epoch,
         wrapped_dek_base64: revocation_dek,
-        wrap_algorithm: super::media_sharing::WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm,
+        wrap_algorithm: prior.wrap_algorithm,
         ratchet_version: prior.ratchet_version,
         key_validity_window: super::media_sharing::KeyValidityWindow {
             not_before: now,
@@ -2808,7 +2865,9 @@ mod tests {
         let author = pubkey_b64(author_key);
         let payload = crate::cirisnode::KeyGrantPayload {
             recipient_key_id: recipient_key_id.to_owned(),
-            content_sha256: sha_hex.to_owned(),
+            content_sha256: Some(sha_hex.to_owned()),
+            stream_id: None,
+            stream_epoch: None,
             wrapped_dek_base64: {
                 use base64::Engine as _;
                 base64::engine::general_purpose::STANDARD.encode([0u8; 48])
@@ -2987,6 +3046,132 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(rows.len(), 1);
+    }
+
+    // ── Cut C3b: stream/epoch-addressed grant cascade (CEG §10.5.3) ──
+
+    fn build_stream_key_grant_sqlite(
+        author_key: &ed25519_dalek::SigningKey,
+        stream_id: &str,
+        epoch: u64,
+        recipient_key_id: &str,
+    ) -> ContributionEnvelope {
+        let author = pubkey_b64(author_key);
+        let payload = crate::cirisnode::KeyGrantPayload {
+            recipient_key_id: recipient_key_id.to_owned(),
+            content_sha256: None,
+            stream_id: Some(stream_id.to_owned()),
+            stream_epoch: Some(epoch),
+            wrapped_dek_base64: {
+                use base64::Engine as _;
+                base64::engine::general_purpose::STANDARD.encode([0u8; 48])
+            },
+            wrap_algorithm: crate::cirisnode::WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256,
+            ratchet_version: 1,
+            key_validity_window: crate::cirisnode::KeyValidityWindow {
+                not_before: Utc::now(),
+                not_after: Utc::now() + chrono::Duration::days(30),
+            },
+            scope: crate::cirisnode::KeyGrantScope::StreamEpoch,
+            scope_id: stream_id.to_owned(),
+            rotation_chain: vec![],
+        };
+        let mut env = ContributionEnvelope {
+            contribution_id: Uuid::new_v4().to_string(),
+            contribution_type: ContributionType::Proposal,
+            author_id: author,
+            subject: Cell {
+                domain: format!("stream-{}", Uuid::new_v4()),
+                language: "en".into(),
+                subject: Some(crate::cirisnode::KEY_GRANT_SUBJECT_KIND.into()),
+            },
+            payload: serde_json::to_value(&payload).unwrap(),
+            witness_set: None,
+            signature: HybridSignature {
+                ed25519: String::new(),
+                ml_dsa_65: None,
+                signed_at: Utc::now(),
+            },
+            submitted_at: Utc::now(),
+        };
+        env.signature = sign_envelope(&env, author_key);
+        env
+    }
+
+    /// A v2 stream/epoch grant is admitted, projected onto the V064
+    /// columns, and served by list_key_grants_for_stream_epoch filtered
+    /// on (stream_id, epoch) — and only that pair.
+    #[tokio::test]
+    async fn sqlite_stream_epoch_grant_round_trip_and_filter() {
+        let (_b, cn) = fresh_backend().await;
+        let author_key = ed25519_dalek::SigningKey::from_bytes(&[0xC3; 32]);
+        let stream = format!("stream-{}", Uuid::new_v4());
+        let other_stream = format!("stream-{}", Uuid::new_v4());
+        let recip = format!("rec-{}", Uuid::new_v4());
+
+        // Two epochs of the target stream + one of another stream.
+        cn.put_contribution(build_stream_key_grant_sqlite(
+            &author_key,
+            &stream,
+            1,
+            &recip,
+        ))
+        .await
+        .unwrap();
+        cn.put_contribution(build_stream_key_grant_sqlite(
+            &author_key,
+            &stream,
+            2,
+            &recip,
+        ))
+        .await
+        .unwrap();
+        cn.put_contribution(build_stream_key_grant_sqlite(
+            &author_key,
+            &other_stream,
+            1,
+            &recip,
+        ))
+        .await
+        .unwrap();
+
+        // (stream, epoch 1) returns exactly the one grant.
+        let rows = cn
+            .list_key_grants_for_stream_epoch(&stream, 1)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "exactly the (stream, epoch=1) grant");
+        // A different epoch of the same stream is a distinct authorization.
+        let rows2 = cn
+            .list_key_grants_for_stream_epoch(&stream, 2)
+            .await
+            .unwrap();
+        assert_eq!(rows2.len(), 1);
+        // An epoch with no grant is empty (LensCore sees this and pulls).
+        let none = cn
+            .list_key_grants_for_stream_epoch(&stream, 99)
+            .await
+            .unwrap();
+        assert!(none.is_empty());
+    }
+
+    /// A streaming epoch grant carrying wrap_algorithm v1 is rejected at
+    /// ingest (the normative §10.5.3 consumer-MUST-reject-v1, enforced
+    /// substrate-side).
+    #[tokio::test]
+    async fn sqlite_stream_grant_v1_wrap_rejected_at_ingest() {
+        let (_b, cn) = fresh_backend().await;
+        let author_key = ed25519_dalek::SigningKey::from_bytes(&[0xC4; 32]);
+        let mut env = build_stream_key_grant_sqlite(&author_key, "stream-v1-reject", 1, "rec-1");
+        // Downgrade the wrap to v1 and re-sign.
+        let mut payload: crate::cirisnode::KeyGrantPayload =
+            serde_json::from_value(env.payload.clone()).unwrap();
+        payload.wrap_algorithm = crate::cirisnode::WrapAlgorithm::HpkeRfc9180BaseX25519AesGcm;
+        env.payload = serde_json::to_value(&payload).unwrap();
+        env.signature = sign_envelope(&env, &author_key);
+
+        let err = cn.put_contribution(env).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "got: {err:?}");
     }
 
     /// CEG 0.3 §5.6.8.4 — option (b) supersession: retire_key_grants

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -187,6 +187,28 @@ pub struct ChunkManifest {
 /// version.
 pub const CHUNK_MANIFEST_VERSION: u32 = 1;
 
+/// v4.x (CIRISPersist#142, Cut C3b) — operational cap on chunks per
+/// `(stream_id, epoch)`: a **nonce-safety substrate constant** (CEG 0.15
+/// §10.5.2 / §10.5.3, FSD §5). The STREAM nonce's `counter_be` is a
+/// 32-bit per-epoch chunk index; the substrate forces an epoch roll well
+/// before `2^32 - 1` so a `(DEK, nonce)` pair is never reused
+/// (GCM-catastrophic). `2^24` (~16.7M chunks/epoch) leaves an 8-bit
+/// safety margin. `put_blob_chunk` rejects an append that would push a
+/// `(stream_id, epoch)` past this count — the producer MUST roll the
+/// epoch. Unlike the P4 catch-up cap (a LensCore policy knob, §10.5.3),
+/// this is genuinely the substrate's to enforce.
+pub const MAX_CHUNKS_PER_EPOCH: u64 = 1 << 24;
+
+/// Whether a `(stream_id, epoch)` that already holds
+/// `existing_chunk_count` chunks has reached [`MAX_CHUNKS_PER_EPOCH`] —
+/// i.e. the next `put_blob_chunk` append must be REFUSED (the producer
+/// rolls the epoch). The single boundary both backends call, so the
+/// nonce-counter-exhaustion rule is defined once and unit-testable
+/// without materializing 2^24 rows.
+pub fn epoch_chunk_cap_reached(existing_chunk_count: u64) -> bool {
+    existing_chunk_count >= MAX_CHUNKS_PER_EPOCH
+}
+
 impl ChunkManifest {
     /// Serialize to **JCS-canonical JSON bytes** (CEG §0.9).
     ///
@@ -1768,6 +1790,18 @@ pub(crate) fn prepare_chunk_rows(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn epoch_chunk_cap_boundary() {
+        // Below the cap → append allowed.
+        assert!(!epoch_chunk_cap_reached(0));
+        assert!(!epoch_chunk_cap_reached(MAX_CHUNKS_PER_EPOCH - 1));
+        // At/over the cap → next append refused (roll the epoch).
+        assert!(epoch_chunk_cap_reached(MAX_CHUNKS_PER_EPOCH));
+        assert!(epoch_chunk_cap_reached(MAX_CHUNKS_PER_EPOCH + 1));
+        // 2^24, the 32-bit-counter safety margin.
+        assert_eq!(MAX_CHUNKS_PER_EPOCH, 16_777_216);
+    }
 
     #[test]
     fn holds_bytes_prefix_shape() {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -11310,6 +11310,53 @@ impl PyEngine {
         })
     }
 
+    /// v4.x (CIRISPersist#142 Cut C3b, CEG §10.5.3) — list every
+    /// stream/epoch-addressed key_grant Contribution for
+    /// `(stream_id, epoch)`, newest-first. JSON array of
+    /// [`ContributionEnvelope`](crate::cirisnode::ContributionEnvelope).
+    /// The consumer (LensCore) applies its own P4 catch-up depth cap.
+    #[cfg(feature = "cirisnode")]
+    fn cirisnode_list_key_grants_for_stream_epoch_json(
+        &self,
+        py: Python<'_>,
+        stream_id: &str,
+        epoch: u64,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let stream = stream_id.to_owned();
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::cirisnode::NodeCoreService;
+                        let rows = backend
+                            .list_key_grants_for_stream_epoch(&stream, epoch)
+                            .await
+                            .map_err(|e| translate_error_kind(e.kind(), e.to_string()))?;
+                        serde_json::to_string(&rows)
+                            .map_err(|e| PyRuntimeError::new_err(format!("key_grants encode: {e}")))
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend =
+                        crate::cirisnode::sqlite::SqliteNodeCoreBackend::new(sq.conn_handle());
+                    runtime.block_on(async move {
+                        use crate::cirisnode::NodeCoreService;
+                        let rows = backend
+                            .list_key_grants_for_stream_epoch(&stream, epoch)
+                            .await
+                            .map_err(|e| translate_error_kind(e.kind(), e.to_string()))?;
+                        serde_json::to_string(&rows)
+                            .map_err(|e| PyRuntimeError::new_err(format!("key_grants encode: {e}")))
+                    })
+                }
+            })
+        })
+    }
+
     /// v3.6.0 (CIRISPersist#134) — install / clear the media-sharing
     /// operator config ([`MultimediaConfig`](crate::cirisnode::MultimediaConfig)).
     /// Wire shape: see [`MultimediaConfigWire`](crate::cirisnode::MultimediaConfigWire).
@@ -17583,6 +17630,42 @@ impl PyEngine {
     /// recipient's X25519 private key. Returns the recovered DEK b64.
     fn unwrap_dek_b64(&self, recipient_x25519_priv_b64: &str, wrap_json: &str) -> PyResult<String> {
         crate::ffi::wheel_key_grant::unwrap_dek_json(recipient_x25519_priv_b64, wrap_json)
+    }
+
+    /// v4.x (CIRISPersist#142 Cut C3b, CEG §10.5.3) — wrap a 32-byte DEK
+    /// under `wrap_algorithm: v2` (X25519 + ML-KEM-768 hybrid PQC), the
+    /// mandatory wrap for streaming epoch-DEK grants. Returns the
+    /// `KeyGrantWrapV2` JSON envelope. `recipient_ml_kem_pub_b64` is the
+    /// recipient's ML-KEM-768 public key (1184 bytes).
+    fn wrap_dek_for_recipient_v2_b64(
+        &self,
+        recipient_x25519_pub_b64: &str,
+        recipient_ml_kem_pub_b64: &str,
+        dek_b64: &str,
+    ) -> PyResult<String> {
+        crate::ffi::wheel_key_grant::wrap_dek_for_recipient_v2_json(
+            recipient_x25519_pub_b64,
+            recipient_ml_kem_pub_b64,
+            dek_b64,
+        )
+    }
+
+    /// v4.x (CIRISPersist#142 Cut C3b) — unwrap a `KeyGrantWrapV2` JSON
+    /// envelope using the recipient's X25519 private key + ML-KEM-768
+    /// private/public keys. Returns the recovered DEK b64.
+    fn unwrap_dek_v2_b64(
+        &self,
+        recipient_x25519_priv_b64: &str,
+        recipient_ml_kem_priv_b64: &str,
+        recipient_ml_kem_pub_b64: &str,
+        wrap_json: &str,
+    ) -> PyResult<String> {
+        crate::ffi::wheel_key_grant::unwrap_dek_v2_json(
+            recipient_x25519_priv_b64,
+            recipient_ml_kem_priv_b64,
+            recipient_ml_kem_pub_b64,
+            wrap_json,
+        )
     }
 
     // ── hybrid_kex (X25519 + ML-KEM-768, CIRISVerify v4.6.0) ──

--- a/src/ffi/wheel_key_grant.rs
+++ b/src/ffi/wheel_key_grant.rs
@@ -21,7 +21,10 @@
 
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
-use ciris_crypto::key_grant::{unwrap_dek, wrap_dek_for_recipient, KeyGrantWrap};
+use ciris_crypto::key_grant::{
+    unwrap_dek, unwrap_dek_v2, wrap_dek_for_recipient, wrap_dek_for_recipient_v2, KeyGrantWrap,
+    KeyGrantWrapV2, KEY_GRANT_ALGORITHM_V2,
+};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
@@ -108,6 +111,123 @@ pub fn unwrap_dek_json(recipient_x25519_priv_b64: &str, wrap_json: &str) -> PyRe
     Ok(B64.encode(dek))
 }
 
+/// v4.x (CIRISPersist#142 Cut C3b, CEG §10.5.3) — wrap a 32-byte DEK for
+/// a recipient under **`wrap_algorithm: v2`** (X25519 + ML-KEM-768 hybrid,
+/// FIPS 203 — the PQC-at-rest wrap mandated for streaming epoch DEKs).
+/// Delegates to `ciris-crypto`'s `wrap_dek_for_recipient_v2` (v4.10.0).
+/// Returns a JSON string:
+///
+/// ```json
+/// {
+///   "algorithm": "x25519-mlkem768-aes256-gcm-hkdf-sha256",
+///   "ephemeral_x25519_public_key_b64": "...",
+///   "ml_kem_ciphertext_b64": "...",
+///   "nonce_b64": "...",
+///   "ciphertext_b64": "..."
+/// }
+/// ```
+///
+/// `recipient_ml_kem_pub_b64` is the recipient's ML-KEM-768 public key
+/// (1184 bytes); a wrong length surfaces as a runtime error from the
+/// crypto layer. Other inputs are base64 (persist's `_b64` idiom).
+pub fn wrap_dek_for_recipient_v2_json(
+    recipient_x25519_pub_b64: &str,
+    recipient_ml_kem_pub_b64: &str,
+    dek_b64: &str,
+) -> PyResult<String> {
+    let recipient_x_pub =
+        decode_fixed_b64::<X25519_KEY_LEN>(recipient_x25519_pub_b64, "recipient_x25519_pub_b64")?;
+    let recipient_ml_kem_pub = B64
+        .decode(recipient_ml_kem_pub_b64)
+        .map_err(|e| PyValueError::new_err(format!("recipient_ml_kem_pub_b64 decode: {e}")))?;
+    let dek = decode_fixed_b64::<DEK_LEN>(dek_b64, "dek_b64")?;
+
+    let wrap = wrap_dek_for_recipient_v2(&recipient_x_pub, &recipient_ml_kem_pub, &dek)
+        .map_err(|e| PyRuntimeError::new_err(format!("key_grant v2 wrap: {e}")))?;
+
+    let envelope = serde_json::json!({
+        "algorithm": KEY_GRANT_ALGORITHM_V2,
+        "ephemeral_x25519_public_key_b64": B64.encode(wrap.ephemeral_x25519_public_key),
+        "ml_kem_ciphertext_b64": B64.encode(&wrap.ml_kem_ciphertext),
+        "nonce_b64": B64.encode(wrap.nonce),
+        "ciphertext_b64": B64.encode(&wrap.ciphertext),
+    });
+    serde_json::to_string(&envelope)
+        .map_err(|e| PyRuntimeError::new_err(format!("key_grant v2 envelope encode: {e}")))
+}
+
+/// v4.x (CIRISPersist#142 Cut C3b) — unwrap a `KeyGrantWrapV2`-shaped
+/// JSON envelope (the shape [`wrap_dek_for_recipient_v2_json`] produces)
+/// using the recipient's X25519 private key + ML-KEM-768 private/public
+/// keys. Returns the 32-byte DEK as base64.
+pub fn unwrap_dek_v2_json(
+    recipient_x25519_priv_b64: &str,
+    recipient_ml_kem_priv_b64: &str,
+    recipient_ml_kem_pub_b64: &str,
+    wrap_json: &str,
+) -> PyResult<String> {
+    let recipient_x_priv =
+        decode_fixed_b64::<X25519_KEY_LEN>(recipient_x25519_priv_b64, "recipient_x25519_priv_b64")?;
+    let recipient_ml_kem_priv = B64
+        .decode(recipient_ml_kem_priv_b64)
+        .map_err(|e| PyValueError::new_err(format!("recipient_ml_kem_priv_b64 decode: {e}")))?;
+    let recipient_ml_kem_pub = B64
+        .decode(recipient_ml_kem_pub_b64)
+        .map_err(|e| PyValueError::new_err(format!("recipient_ml_kem_pub_b64 decode: {e}")))?;
+
+    let envelope: serde_json::Value = serde_json::from_str(wrap_json)
+        .map_err(|e| PyValueError::new_err(format!("wrap_json decode: {e}")))?;
+
+    let ephemeral_b64 = envelope
+        .get("ephemeral_x25519_public_key_b64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            PyValueError::new_err("wrap_json: missing ephemeral_x25519_public_key_b64")
+        })?;
+    let ml_kem_ct_b64 = envelope
+        .get("ml_kem_ciphertext_b64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PyValueError::new_err("wrap_json: missing ml_kem_ciphertext_b64"))?;
+    let nonce_b64 = envelope
+        .get("nonce_b64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PyValueError::new_err("wrap_json: missing nonce_b64"))?;
+    let ciphertext_b64 = envelope
+        .get("ciphertext_b64")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PyValueError::new_err("wrap_json: missing ciphertext_b64"))?;
+
+    let ephemeral_x25519_public_key =
+        decode_fixed_b64::<X25519_KEY_LEN>(ephemeral_b64, "ephemeral_x25519_public_key_b64")?;
+    let ml_kem_ciphertext = B64
+        .decode(ml_kem_ct_b64)
+        .map_err(|e| PyValueError::new_err(format!("ml_kem_ciphertext_b64 decode: {e}")))?;
+    let nonce_vec = B64
+        .decode(nonce_b64)
+        .map_err(|e| PyValueError::new_err(format!("nonce_b64 decode: {e}")))?;
+    let nonce: [u8; 12] = nonce_vec.try_into().map_err(|v: Vec<u8>| {
+        PyValueError::new_err(format!("nonce must be 12 bytes, got {}", v.len()))
+    })?;
+    let ciphertext = B64
+        .decode(ciphertext_b64)
+        .map_err(|e| PyValueError::new_err(format!("ciphertext_b64 decode: {e}")))?;
+
+    let wrap = KeyGrantWrapV2 {
+        ephemeral_x25519_public_key,
+        ml_kem_ciphertext,
+        nonce,
+        ciphertext,
+    };
+    let dek = unwrap_dek_v2(
+        &recipient_x_priv,
+        &recipient_ml_kem_priv,
+        &recipient_ml_kem_pub,
+        &wrap,
+    )
+    .map_err(|e| PyRuntimeError::new_err(format!("key_grant v2 unwrap: {e}")))?;
+    Ok(B64.encode(dek))
+}
+
 fn decode_fixed_b64<const N: usize>(s: &str, label: &'static str) -> PyResult<[u8; N]> {
     let bytes = B64
         .decode(s)
@@ -134,6 +254,64 @@ mod tests {
             unwrap_dek_json(&B64.encode(recipient_priv), &wrap_json).expect("unwrap succeeds");
         let unwrapped = B64.decode(&unwrapped_b64).unwrap();
         assert_eq!(unwrapped, dek, "DEK survives round-trip");
+    }
+
+    #[test]
+    fn wrap_unwrap_v2_round_trip_recovers_dek() {
+        // X25519 half.
+        let recipient_x_priv: [u8; 32] = [0x42; 32];
+        let recipient_x_pub = x25519::public_from_secret(&recipient_x_priv);
+        // ML-KEM-768 half — generate_keypair() returns (private, public).
+        let (ml_kem_priv, ml_kem_pub) =
+            ciris_crypto::ml_kem::generate_keypair().expect("ml-kem keypair");
+        let dek: [u8; 32] = [0xCC; 32];
+
+        let wrap_json = wrap_dek_for_recipient_v2_json(
+            &B64.encode(recipient_x_pub),
+            &B64.encode(&ml_kem_pub),
+            &B64.encode(dek),
+        )
+        .expect("v2 wrap succeeds");
+        // The envelope advertises the v2 algorithm string.
+        assert!(
+            wrap_json.contains("x25519-mlkem768-aes256-gcm-hkdf-sha256"),
+            "v2 envelope names the v2 algorithm: {wrap_json}"
+        );
+
+        let unwrapped_b64 = unwrap_dek_v2_json(
+            &B64.encode(recipient_x_priv),
+            &B64.encode(&ml_kem_priv),
+            &B64.encode(&ml_kem_pub),
+            &wrap_json,
+        )
+        .expect("v2 unwrap succeeds");
+        let unwrapped = B64.decode(&unwrapped_b64).unwrap();
+        assert_eq!(unwrapped, dek, "DEK survives the v2 hybrid round-trip");
+    }
+
+    #[test]
+    fn unwrap_v2_rejects_wrong_x25519_key() {
+        let recipient_x_priv: [u8; 32] = [0x42; 32];
+        let recipient_x_pub = x25519::public_from_secret(&recipient_x_priv);
+        let (ml_kem_priv, ml_kem_pub) =
+            ciris_crypto::ml_kem::generate_keypair().expect("ml-kem keypair");
+        let dek: [u8; 32] = [0xCC; 32];
+        let wrap_json = wrap_dek_for_recipient_v2_json(
+            &B64.encode(recipient_x_pub),
+            &B64.encode(&ml_kem_pub),
+            &B64.encode(dek),
+        )
+        .unwrap();
+        // A different X25519 private key must fail the hybrid unwrap
+        // (AEAD tag mismatch — opaque WrapUnverified).
+        let wrong_x_priv: [u8; 32] = [0x99; 32];
+        let _err = unwrap_dek_v2_json(
+            &B64.encode(wrong_x_priv),
+            &B64.encode(&ml_kem_priv),
+            &B64.encode(&ml_kem_pub),
+            &wrap_json,
+        )
+        .unwrap_err();
     }
 
     #[test]

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3850,7 +3850,32 @@ impl crate::federation::BlobStorage for PostgresBackend {
             crate::federation::BlobError::Backend(format!("put_blob_chunk blob insert: {e}"))
         })?;
 
-        // 2. The stream-index row. The (stream_id, seq) PK enforces
+        // 2. Nonce-safety cap (CEG §10.5.2/§10.5.3, Cut C3b): the STREAM
+        //    nonce's per-epoch counter_be must never wrap. A given
+        //    (stream_id, epoch) holds at most MAX_CHUNKS_PER_EPOCH chunks;
+        //    past that the producer MUST roll the epoch. Checked in-tx so
+        //    a concurrent append can't slip past the cap.
+        let epoch_chunk_count: i64 = tx
+            .query_one(
+                "SELECT COUNT(*) FROM cirislens.federation_stream_chunks \
+                  WHERE stream_id = $1 AND epoch = $2",
+                &[&stream_id, &epoch_i64],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("put_blob_chunk epoch count: {e}"))
+            })?
+            .get(0);
+        if crate::federation::blobs::epoch_chunk_cap_reached(epoch_chunk_count as u64) {
+            return Err(crate::federation::BlobError::InvalidArgument(format!(
+                "put_blob_chunk: (stream_id={stream_id}, epoch={epoch}) is at \
+                 MAX_CHUNKS_PER_EPOCH ({}) — roll the epoch (STREAM-nonce counter \
+                 exhaustion, CEG §10.5.3)",
+                crate::federation::blobs::MAX_CHUNKS_PER_EPOCH
+            )));
+        }
+
+        // 3. The stream-index row. The (stream_id, seq) PK enforces
         //    monotonicity — a re-used seq is a PK conflict, mapped to
         //    InvalidArgument (NOT idempotent: the append-only rule).
         let inserted = tx

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3575,7 +3575,32 @@ impl crate::federation::BlobStorage for SqliteBackend {
                     now_iso,
                 ],
             )?;
-            // 2. The stream-index row. (stream_id, seq) PK = monotonicity.
+            // 2. Nonce-safety cap (CEG §10.5.2/§10.5.3, Cut C3b): the
+            //    STREAM nonce's per-epoch counter_be must never wrap. A
+            //    given (stream_id, epoch) holds at most
+            //    MAX_CHUNKS_PER_EPOCH chunks; past that the producer MUST
+            //    roll the epoch. Checked in-tx (count + insert atomic) so
+            //    a concurrent append can't slip past the cap.
+            let epoch_chunk_count: i64 = tx.query_row(
+                "SELECT COUNT(*) FROM federation_stream_chunks \
+                  WHERE stream_id = ?1 AND epoch = ?2",
+                rusqlite::params![stream_id_owned, epoch_i64],
+                |r| r.get(0),
+            )?;
+            if crate::federation::blobs::epoch_chunk_cap_reached(epoch_chunk_count as u64) {
+                // Surface as a rusqlite error so the closure's error arm
+                // maps it; the caller sees InvalidArgument.
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CONSTRAINT),
+                    Some(format!(
+                        "put_blob_chunk: (stream_id={stream_id_owned}, epoch={epoch}) \
+                         is at MAX_CHUNKS_PER_EPOCH ({}) — roll the epoch \
+                         (STREAM-nonce counter exhaustion, CEG §10.5.3)",
+                        crate::federation::blobs::MAX_CHUNKS_PER_EPOCH
+                    )),
+                ));
+            }
+            // 3. The stream-index row. (stream_id, seq) PK = monotonicity.
             let inserted = tx.execute(
                 "INSERT INTO federation_stream_chunks (\
                     stream_id, seq, chunk_sha, epoch, size_bytes, created_at\


### PR DESCRIPTION
The streaming **epoch-key cascade**. A per-`(stream_id, epoch)` DEK is wrapped to each roster recipient as a stream/epoch-addressed `key_grant` Contribution. **Persist validates / records / lists — it does NOT wrap** (the producer wraps + submits; the storage path stores the wrapped DEK opaquely; MISSION §1.7). Unblocked by CIRISVerify#58 closing.

## Dependency
- **CIRISVerify `v4.8.1` → `v4.10.0`** (6 pins). Picks up `ciris-crypto::key_grant`'s `wrap_algorithm: v2` API (`KEY_GRANT_ALGORITHM_V2`, `wrap_dek_for_recipient_v2`/`unwrap_dek_v2`/`KeyGrantWrapV2`; #58) — gated `ml-kem`, already pulled via `hybrid-kex`, so no feature change. 1028 lib tests green on live PG against 4.10.0.

## Added — the cascade
- **Stream/epoch-addressed `key_grant`** — `KeyGrantPayload` gains optional `stream_id`/`stream_epoch` (`content_sha256` now optional); `WrapAlgorithm::X25519MlKem768Aes256GcmHkdfSha256` (v2); `KeyGrantScope::StreamEpoch`. Projected onto the V064 (Cut C3a) columns, both backends.
- **`list_key_grants_for_stream_epoch(stream_id, epoch)`** on the NodeCore service + both backends + PyO3. Persist returns grants; the consumer (LensCore) applies its own **P4 catch-up depth cap** — a LensCore knob, NOT a substrate constant (CEG §10.5.3). `history_on_join` (producer envelope field) likewise stays out of persist.
- **Wheel FFI v2 helpers** (`wrap_dek_for_recipient_v2_b64` / `unwrap_dek_v2_b64`) — the only place persist *calls* the v2 wrap. Real hybrid round-trip tested.
- **`MAX_CHUNKS_PER_EPOCH = 2²⁴`** — a nonce-safety **substrate constant** (the STREAM nonce's 32-bit `counter_be` must never wrap). `put_blob_chunk` refuses an append past it, both backends.

## Enforced at ingest — the normative reject-v1
A **streaming epoch grant carrying `wrap_algorithm: v1` is rejected at `put_contribution`** (CEG §10.5.3: "a Consumer MUST reject a streaming epoch grant carrying `wrap_algorithm: v1`"). The extractor enforces **exactly-one addressing mode** (content XOR stream/epoch, mirroring the V064 CHECK) + `scope=stream_epoch`. Content-addressed v1 grants are unaffected (backward-compatible).

## Pending ratification
The **v2 payload wire string** `x25519_mlkem768_aes256_gcm_hkdf_sha256` is proposed **pending CIRISRegistry#64** (CEG mandates `wrap_algorithm: v2` but doesn't yet pin the payload enum string, unlike v1's §5.6.8.4-pinned string). Propose-then-ratify, same path as the STREAM-nonce epoch encoding (#63). Only the serde rename changes if a different string is pinned.

## Tests
Both backends (live PG + in-memory SQLite): stream/epoch grant round-trip + `(stream_id, epoch)` filtering, **ingest reject-v1**, addressing-XOR + scope validators, the `MAX_CHUNKS_PER_EPOCH` boundary, and a real v2 hybrid wrap/unwrap round-trip through the wheel FFI. **1028 lib tests green on live PG** (`postgres server pyo3 sqlite cirisnode`); clean under `-D warnings` across no-backend / `test-panic,pyo3` / full-feature; clippy clean over `--tests`.

Ships as **4.3.0**. Closes the C3b blocker; streaming substrate Cuts A, B, C1a, C1b, C2, C3a, C4, **C3b** now landed — **C3c** (rotation triggers + live seal wiring) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)