### PR TITLE
v4.4.0 — Shared CEG attestation surface, phase 1: local-tier write + read-gate (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.4.0] — 2026-06-08
+
+**Shared CEG attestation surface — phase 1: local-tier write + read-gate (CIRISPersist#171; CEG 0.15 §10.1.3 / §10.1.5; FSD `V4_4_SHARED_ATTESTATION_SURFACE.md`).**
+
+The gating dependency for CIRISAgent#840's hard cut-over (`graph_nodes` → self-level CEG attestations). `federation_attestations` is the single store all four CEG-RC1 implementations read/write; v4.0 gave it the scope-aware **read**, this adds the **local-tier write** half. FSD accepted by all four impls (Agent / Registry / LensCore / NodeCore ✅; Verify ✅ on OQ-4), surface pinned in CEG §10.1.5. **Per the Agent's staging request, this phase lands local operation; `attestation_promote` (federation-emit) is the v4.5 fast-follow — now unblocked by CIRISVerify 4.11.0 JCS.**
+
+### Dependency
+- **CIRISVerify `v4.10.0` → `v4.11.0`** — ships `ciris_verify_core::jcs::{canonicalize, verify_jcs_hybrid_signature}` (RFC 8785; CIRISVerify#59 closed), the OQ-4 deliverable for the v4.5 `promote` path. No persist call site yet; re-pinned now so v4.5 is a pure feature add.
+
+### Added — tier model + local write
+- **V066** — `federation_attestations` gains `tier` (`local | federation`, DEFAULT `federation`) + `promoted_at`. **Purely additive on both backends** (empty-sentinel scrub envelope for local rows — no NOT-NULL relaxation, no table rebuild). CHECK/trigger enforces `tier = federation ⟹ non-empty classical signature` (**AV-60**). `tier`/`promoted_at` are row metadata — NOT in the `attestation_envelope` canonical bytes, so a promoted row will be byte-identical on the wire to a native-federation one (Registry must #2).
+- **`attestation_upsert_local` / `attestation_insert_local`** (+ `_many` defaults) on `FederationDirectory`, all three backends + PyO3. `LocalAttestationInput` → deferred-signature `local` row. **upsert** replaces on `(attesting_key_id, dimension)` (singleton current-state); **insert** appends a fresh id (multi-valued memory / per-thought verdicts) — the Agent's two-write-class correction. `dimension` = the envelope `dimension` (the key + gate axis).
+
+### Enforced at ingest — the §4.1 gates
+- **`capacity:*` ineligible for local tier** (CEG §7.5 anti-Goodhart — the self-write→self-read→deferred-sig loop, **AV-62**); `check_capacity_not_self_attested` for the federation path (`attesting ≠ attested`). Raised as load-bearing by LensCore.
+- **Subject-side revocation ineligible** (`withdraws` / `consent:state:revoked` where the writer ∈ `subject_key_ids` — CEG §10.1.3, **AV-61**).
+- **Local rows are `cohort_scope='self'`** — private to the producing occurrence. The v4.0 `self`-cohort read-gate IS the tier read-gate; combined with the federation-tier filter on the trust-reads below, this closes **AV-59** (local rows never surface to a non-producing caller).
+
+### Changed — read-gate (AV-59)
+- The **`FederationDirectory` trust-reads** (`list_attestations_for` / `list_attestations_by`, the "who-vouches-for-K" reads) now filter `tier = 'federation'` — local self-attestations are not vouches and never appear there. The agent reads its own local state via the scope-gated `ReadEngine` reads (its `self`-cohort rows). No public-signature change.
+
+### Deferred (documented, not silent)
+- **`attestation_promote`** + the dedicated dimension-prefix `attestation_query` + the §5 consent-revocation overdue-scan/`hard_case` emission → **v4.5**. `promote` is unblocked (4.11.0 JCS); the §5 clock trigger is OQ-3 / CIRISPersist#161. The §10.1.3 subject-revocation leak is already closed at ingest (gate above); §5 covers only the residual acquire-after-write case.
+
+### Tests
+Both backends (live PG + SQLite): upsert-replace, insert-append, the three gate negatives (capacity, subject-revocation, non-self-scope), dimension-required, and the AV-59 trust-read exclusion. **1035 lib tests green on live PG**; `-D warnings` clean across no-backend / `test-panic,pyo3` / full-feature; clippy clean over `--tests`.
+
 ## [4.3.0] — 2026-06-07
 
 **Streaming substrate Cut C3b — epoch-DEK `key_grant` cascade + `wrap_algorithm: v2` (PQC) + CIRISVerify 4.10.0 re-pin (CIRISPersist#142, CEG 0.15 §10.5.3).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.3.0"
+version = "4.4.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -721,10 +721,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -735,7 +735,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.10.0", version = "4", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/migrations/postgres/lens/V066__federation_attestations_tier.sql
+++ b/migrations/postgres/lens/V066__federation_attestations_tier.sql
@@ -1,0 +1,68 @@
+-- V066 — federation_attestations local/federation tier model
+-- (CIRISPersist#171; CEG 0.15 §10.1.3 local-tier signature deferral +
+-- §10.1.5 the pinned shared-attestation contract;
+-- FSD/V4_4_SHARED_ATTESTATION_SURFACE.md §3/§7).
+--
+-- v4.0 gave federation_attestations a scope-aware READ surface; this is
+-- the foundation of the WRITE+promote half. Every row is now tiered:
+--
+--   * `local`      — producer-only-authority self-attestation, signature
+--                    DEFERRED (CEG §10.1.3). Visible ONLY to the producing
+--                    occurrence (the tier read-gate, AV-59). The deferred
+--                    scrub envelope is represented by **empty-sentinel**
+--                    values (scrub_signature_classical = '', etc.) — the
+--                    same empty-sentinel discipline key_grant revocation
+--                    uses — so this migration stays PURELY ADDITIVE (no
+--                    NOT-NULL relaxation, no table rebuild on either
+--                    backend; PG/SQLite parity).
+--   * `federation` — hybrid-signed (Ed25519 + ML-DSA-65), federation-
+--                    visible. The status-quo `put_attestation` shape AND
+--                    the target of `attestation_promote` (local→federation,
+--                    JCS-signed per CEG §0.9 / CIRISVerify v4.11.0).
+--
+-- DEFAULT 'federation' so every existing row keeps its exact meaning
+-- (all current rows are signed/federation). No backfill.
+--
+-- The load-bearing invariant (AV-60): tier = 'federation' ⟹ a non-empty
+-- classical signature. Nothing crosses to federation-visible unsigned.
+
+ALTER TABLE cirislens.federation_attestations
+    ADD COLUMN IF NOT EXISTS tier TEXT NOT NULL DEFAULT 'federation'
+        CHECK (tier IN ('local', 'federation'));
+
+ALTER TABLE cirislens.federation_attestations
+    ADD COLUMN IF NOT EXISTS promoted_at TIMESTAMPTZ NULL;
+
+-- federation ⟹ signed. A `local` row may carry the empty-sentinel scrub
+-- envelope (deferred); a `federation` row (born signed OR promoted) MUST
+-- carry a non-empty classical signature. Same DROP-IF-EXISTS + ADD guard
+-- the V054/V064 constraint swaps use, so re-running the chain is
+-- idempotent.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_constraint
+        WHERE conname = 'federation_attestations_federation_tier_signed'
+          AND conrelid = 'cirislens.federation_attestations'::regclass
+    ) THEN
+        ALTER TABLE cirislens.federation_attestations
+            DROP CONSTRAINT federation_attestations_federation_tier_signed;
+    END IF;
+
+    ALTER TABLE cirislens.federation_attestations
+        ADD CONSTRAINT federation_attestations_federation_tier_signed
+            CHECK (tier = 'local' OR scrub_signature_classical <> '');
+END$$;
+
+-- Serve the §5 overdue-promotion scan + the local self-read path.
+-- Partial on tier = 'local' — the working set is small (un-promoted
+-- producer-authority rows), federation rows are excluded.
+CREATE INDEX IF NOT EXISTS federation_attestations_local_tier
+    ON cirislens.federation_attestations (tier)
+    WHERE tier = 'local';
+
+COMMENT ON COLUMN cirislens.federation_attestations.tier IS
+    'v4.4 (CIRISPersist#171, CEG §10.1.3/§10.1.5) — local (producer-only authority, signature deferred, visible only to the producing occurrence) | federation (hybrid-signed, federation-visible). DEFAULT federation. CHECK federation_attestations_federation_tier_signed enforces federation ⟹ non-empty classical signature (AV-60).';
+
+COMMENT ON COLUMN cirislens.federation_attestations.promoted_at IS
+    'v4.4 (CIRISPersist#171) — set by attestation_promote at the local→federation transition (the federation-emit moment). NULL for natively-federation rows and un-promoted local rows. Persist-internal — NOT part of the JCS canonical signing bytes (CEG §10.1.5.3 must #2).';

--- a/migrations/sqlite/lens/V066__federation_attestations_tier.sql
+++ b/migrations/sqlite/lens/V066__federation_attestations_tier.sql
@@ -1,0 +1,52 @@
+-- V066 — federation_attestations local/federation tier model, SQLite
+-- dialect (CIRISPersist#171; CEG 0.15 §10.1.3 / §10.1.5;
+-- FSD/V4_4_SHARED_ATTESTATION_SURFACE.md §3/§7).
+--
+-- Postgres parity (postgres/lens/V066). Every row is now tiered local |
+-- federation; `local` = producer-only-authority self-attestation with a
+-- DEFERRED signature (CEG §10.1.3), visible only to the producing
+-- occurrence. The deferred scrub envelope is represented by
+-- empty-sentinel values (NOT NULL), so this migration is PURELY ADDITIVE
+-- — two ADD COLUMNs, no table rebuild (the NOT-NULL scrub columns are
+-- untouched; local rows write '' / x'' sentinels). The federation ⟹
+-- signed invariant (AV-60), a cross-column rule SQLite can't express as
+-- an added table CHECK, is enforced by BEFORE INSERT/UPDATE triggers per
+-- the V054/V064 discipline.
+--
+-- Type mapping vs PG: TIMESTAMPTZ → TEXT (RFC3339).
+
+-- tier — column-level CHECK (single-column, admitted on ADD COLUMN).
+ALTER TABLE federation_attestations
+    ADD COLUMN tier TEXT NOT NULL DEFAULT 'federation'
+        CHECK (tier IN ('local', 'federation'));
+
+-- promoted_at — set at the local→federation transition; persist-internal.
+ALTER TABLE federation_attestations
+    ADD COLUMN promoted_at TEXT;
+
+-- federation ⟹ non-empty classical signature (AV-60). Cross-column →
+-- triggers (SQLite has no ALTER ADD CONSTRAINT). ABORT when a row at
+-- federation tier carries an empty classical signature.
+DROP TRIGGER IF EXISTS federation_attestations_federation_tier_signed_ins;
+DROP TRIGGER IF EXISTS federation_attestations_federation_tier_signed_upd;
+
+CREATE TRIGGER federation_attestations_federation_tier_signed_ins
+    BEFORE INSERT ON federation_attestations
+    FOR EACH ROW
+    WHEN (NEW.tier = 'federation' AND NEW.scrub_signature_classical = '')
+    BEGIN
+        SELECT RAISE(ABORT, 'federation_attestations: tier=federation requires a non-empty scrub_signature_classical (federation ⟹ signed; CEG §10.1.5 AV-60). A deferred-signature row must be tier=local.');
+    END;
+
+CREATE TRIGGER federation_attestations_federation_tier_signed_upd
+    BEFORE UPDATE ON federation_attestations
+    FOR EACH ROW
+    WHEN (NEW.tier = 'federation' AND NEW.scrub_signature_classical = '')
+    BEGIN
+        SELECT RAISE(ABORT, 'federation_attestations: tier=federation requires a non-empty scrub_signature_classical (federation ⟹ signed; CEG §10.1.5 AV-60). A deferred-signature row must be tier=local.');
+    END;
+
+-- Serve the §5 overdue-promotion scan + the local self-read path.
+CREATE INDEX IF NOT EXISTS federation_attestations_local_tier
+    ON federation_attestations (tier)
+    WHERE tier = 'local';

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -762,6 +762,8 @@ impl Engine {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
 
         let directory = self.federation_directory();

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -787,7 +787,18 @@ pub fn check_local_tier_eligibility(
     dimension: Option<&str>,
     attesting_key_id: &str,
     subject_key_ids: &[String],
+    cohort_scope: &str,
 ) -> Result<(), Error> {
+    // (0) local rows are `self`-scoped (private to the producing
+    // occurrence). The v4.0 `self`-cohort read-gate then IS the tier
+    // read-gate (FSD §3 / CEG §10.1.5, AV-59); promotion widens scope.
+    if cohort_scope != crate::federation::types::cohort_scope::SELF {
+        return Err(Error::InvalidArgument(format!(
+            "local-tier attestations must be cohort_scope='self' (private to the \
+             producing occurrence until promotion; CEG §10.1.5 tier read-gate, AV-59) \
+             — got '{cohort_scope}'"
+        )));
+    }
     // (1) capacity:* — never local (anti-Goodhart §7.5 / AV-62).
     if dimension.is_some_and(|d| d.starts_with("capacity:")) {
         return Err(Error::InvalidArgument(

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -761,6 +761,77 @@ pub fn check_cohort_scope(cohort_scope: &str) -> Result<(), Error> {
     }
 }
 
+/// v4.4.0 (CIRISPersist#171, CEG §10.1.3/§10.1.5/§7.5) — gate a row's
+/// eligibility for the **local tier** (signature-deferred,
+/// producer-only-authority). Local-tier eligibility is producer
+/// authority — NOT empty `subject_key_ids` (CEG §4.2.6: producer-
+/// authority rows legitimately name subjects). Exactly two classes are
+/// **refused** at local tier (they MUST be federation-tier, signed):
+///
+///   1. **`capacity:*` (CEG §7.5 anti-Goodhart, AV-62).** A `capacity:*`
+///      dimension rejects self-emission; the local tier's self-write →
+///      self-read → deferred-sig shape is precisely the §7.5 forbidden
+///      loop. Capacity is inherently third-party-attested.
+///   2. **Subject-side revocation (CEG §10.1.3, AV-61).** A `withdraws`
+///      (structural) or a `consent:state:revoked` dimension whose
+///      **writer (`attesting_key_id`) is a member of `subject_key_ids`**
+///      — the subject exercising its own revocation right. Subject-side
+///      revocation is the federation-observability primitive peers
+///      depend on; it cannot ride the deferral path.
+///
+/// `dimension` is the envelope dimension ([`envelope_dimension`]);
+/// `attestation_type` is the §3 structural primitive. Returns
+/// [`Error::InvalidArgument`] on an ineligible row; `Ok(())` otherwise.
+pub fn check_local_tier_eligibility(
+    attestation_type: &str,
+    dimension: Option<&str>,
+    attesting_key_id: &str,
+    subject_key_ids: &[String],
+) -> Result<(), Error> {
+    // (1) capacity:* — never local (anti-Goodhart §7.5 / AV-62).
+    if dimension.is_some_and(|d| d.starts_with("capacity:")) {
+        return Err(Error::InvalidArgument(
+            "capacity:* attestations are ineligible for the local tier (CEG §7.5 \
+             anti-Goodhart, AV-62): capacity is third-party-attested — federation-tier, \
+             signed, attesting_key_id != attested_key_id"
+                .to_string(),
+        ));
+    }
+    // (2) subject-side revocation — never local (§10.1.3 / AV-61).
+    let is_revocation = attestation_type == crate::federation::types::attestation_type::WITHDRAWS
+        || dimension.is_some_and(|d| d.starts_with("consent:state:revoked"));
+    if is_revocation && subject_key_ids.iter().any(|s| s == attesting_key_id) {
+        return Err(Error::InvalidArgument(
+            "a subject-side revocation (the writer is a member of subject_key_ids) is NOT \
+             local-tier-eligible (CEG §10.1.3, AV-61): it must be federation-tier signed / \
+             promoted within the bounded window"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// v4.4.0 (CIRISPersist#171, CEG §7.5 / AV-62) — the federation-path
+/// mirror of the `capacity:*` anti-Goodhart rule: a `capacity:*` row
+/// MUST have `attesting_key_id != attested_key_id` (no self-scoring).
+/// Enforced on `put_attestation` / `attestation_promote`. `Ok(())` for
+/// non-capacity rows.
+pub fn check_capacity_not_self_attested(
+    dimension: Option<&str>,
+    attesting_key_id: &str,
+    attested_key_id: &str,
+) -> Result<(), Error> {
+    if dimension.is_some_and(|d| d.starts_with("capacity:")) && attesting_key_id == attested_key_id
+    {
+        return Err(Error::InvalidArgument(
+            "capacity:* attestation must not be self-attested (attesting_key_id == \
+             attested_key_id) — CEG §7.5 anti-Goodhart, AV-62"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// v3.11.0 (CIRISPersist#143, CIRISVerify FEDERATION_THREAT_MODEL
 /// §3.3.2 R1) — admission-gate validation of the producer-side
 /// `observed_region` field on a revocation.

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -1374,6 +1374,8 @@ pub(crate) async fn emit_withdraws_attestation_helper(
         subject_key_ids: Vec::new(),
         withdraws_admission_rule: None,
         cohort_scope: "federation".to_string(),
+        tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+        promoted_at: None,
     };
 
     directory

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -209,6 +209,58 @@ pub trait FederationDirectory: Send + Sync {
     /// Insert a new attestation row.
     async fn put_attestation(&self, attestation: SignedAttestation) -> Result<(), Error>;
 
+    /// v4.4.0 (CIRISPersist#171, CEG §10.1.3) — **upsert** a local-tier
+    /// self-attestation (singleton current-state): replace any prior
+    /// `local` row for `(attesting_key_id, dimension)`, then insert.
+    /// Signature deferred (no hybrid sig; the row is `tier = local`,
+    /// visible only to the producing occurrence). Runs the §4.1 local-tier
+    /// gate (refuse `capacity:*` and subject-side revocations) plus the
+    /// shared admission gates (trust / dimension / cohort_scope). Returns
+    /// the new row's `attestation_id`.
+    async fn attestation_upsert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, Error>;
+
+    /// v4.4.0 (CIRISPersist#171) — **insert** (append) a local-tier
+    /// attestation for a multi-valued / event dimension (memory, per-
+    /// thought verdicts): a fresh row keyed by a server-assigned id, NOT
+    /// collapsed by dimension. Same gates as
+    /// [`attestation_upsert_local`](Self::attestation_upsert_local).
+    /// Returns the new `attestation_id`.
+    async fn attestation_insert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, Error>;
+
+    /// v4.4.0 (CIRISPersist#171) — batched [`attestation_upsert_local`]
+    /// for the boot-time `graph_nodes → attestations` backlog. Default
+    /// loops; backends MAY override for single-transaction chunking.
+    /// Returns the new ids in input order.
+    async fn attestation_upsert_local_many(
+        &self,
+        inputs: Vec<crate::federation::types::LocalAttestationInput>,
+    ) -> Result<Vec<String>, Error> {
+        let mut ids = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            ids.push(self.attestation_upsert_local(input).await?);
+        }
+        Ok(ids)
+    }
+
+    /// v4.4.0 (CIRISPersist#171) — batched [`attestation_insert_local`].
+    /// Default loops; backends MAY override for chunked single-tx insert.
+    async fn attestation_insert_local_many(
+        &self,
+        inputs: Vec<crate::federation::types::LocalAttestationInput>,
+    ) -> Result<Vec<String>, Error> {
+        let mut ids = Vec::with_capacity(inputs.len());
+        for input in inputs {
+            ids.push(self.attestation_insert_local(input).await?);
+        }
+        Ok(ids)
+    }
+
     /// All attestations targeting `attested_key_id` (consumer asks
     /// "who vouches for K?"). Ordered by `asserted_at` DESC.
     async fn list_attestations_for(&self, attested_key_id: &str)

--- a/src/federation/precedence.rs
+++ b/src/federation/precedence.rs
@@ -208,6 +208,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 

--- a/src/federation/replication/trust_scoring.rs
+++ b/src/federation/replication/trust_scoring.rs
@@ -148,6 +148,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -465,13 +465,19 @@ pub struct LocalAttestationInput {
     /// revocation, not subject-naming).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subject_key_ids: Vec<String>,
-    /// Producer-side visibility scope. Defaults `federation`; a local
-    /// self-attestation typically tags `self`.
-    #[serde(
-        default = "default_cohort_scope",
-        skip_serializing_if = "is_default_cohort_scope"
-    )]
+    /// Producer-side visibility scope. **Local-tier rows MUST be
+    /// `self`** (private to the producing occurrence until promotion;
+    /// the FSD §3 / CEG §10.1.5 tier read-gate is exactly the v4.0
+    /// `self`-cohort gate). Defaults `self`; the write path rejects any
+    /// other value at local tier. Promotion (v4.5) widens the scope.
+    #[serde(default = "default_self_cohort_scope")]
     pub cohort_scope: String,
+}
+
+/// Default cohort_scope for a local-tier write — `self` (private to the
+/// producing occurrence; CEG §10.1.5 tier read-gate).
+fn default_self_cohort_scope() -> String {
+    cohort_scope::SELF.to_string()
 }
 
 impl LocalAttestationInput {

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -433,6 +433,92 @@ fn is_default_tier(tier: &str) -> bool {
     tier == attestation_tier::FEDERATION
 }
 
+/// v4.4.0 (CIRISPersist#171, CEG §10.1.3) — caller input for a local-tier
+/// attestation write (`attestation_upsert_local` / `_insert_local`). The
+/// producer-only-authority self-attestation envelope: the caller supplies
+/// the semantic fields; persist fills the tier (`local`), the deferred
+/// empty-sentinel scrub envelope, `asserted_at`, and the row id. The
+/// signature is deferred to `attestation_promote` (no hybrid sig here).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalAttestationInput {
+    /// The producing occurrence's `federation_keys.key_id` (the
+    /// `witness_relation: self` producer). Must exist in federation_keys.
+    pub attesting_key_id: String,
+    /// Primary attested key. Defaults to `attesting_key_id` (a
+    /// self-attestation) when omitted. Must exist in federation_keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attested_key_id: Option<String>,
+    /// The §3 structural primitive (`scores` / `supersedes` / …).
+    pub attestation_type: String,
+    /// Optional weight signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub weight: Option<f64>,
+    /// Optional expiry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// The CEG attestation envelope. MUST carry a `"dimension"` string
+    /// (the `(occurrence, dimension)` upsert key + the §7.5/§10.1.3
+    /// local-tier gates read it).
+    pub attestation_envelope: serde_json::Value,
+    /// §4.2.6 subjects this attestation names (producer-authority rows
+    /// MAY name subjects; the local-tier gate refuses only a subject-side
+    /// revocation, not subject-naming).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subject_key_ids: Vec<String>,
+    /// Producer-side visibility scope. Defaults `federation`; a local
+    /// self-attestation typically tags `self`.
+    #[serde(
+        default = "default_cohort_scope",
+        skip_serializing_if = "is_default_cohort_scope"
+    )]
+    pub cohort_scope: String,
+}
+
+impl LocalAttestationInput {
+    /// The envelope `dimension` (the local-tier key + gate axis).
+    pub fn dimension(&self) -> Option<&str> {
+        self.attestation_envelope
+            .get("dimension")
+            .and_then(|v| v.as_str())
+    }
+
+    /// Build the `local`-tier [`Attestation`] row: caller fields + the
+    /// deferred empty-sentinel scrub envelope (`scrub_signature_classical
+    /// = ""` — admitted at local tier by the V066 CHECK; `scrub_key_id =
+    /// attesting_key_id` so the FK holds; `original_content_hash = ""`,
+    /// recomputed via JCS at promote). `persist_row_hash` is filled by the
+    /// caller after construction (`compute_persist_row_hash`).
+    pub fn into_local_row(self, attestation_id: String, asserted_at: DateTime<Utc>) -> Attestation {
+        let attested_key_id = self
+            .attested_key_id
+            .unwrap_or_else(|| self.attesting_key_id.clone());
+        Attestation {
+            attestation_id,
+            attesting_key_id: self.attesting_key_id.clone(),
+            attested_key_id,
+            attestation_type: self.attestation_type,
+            weight: self.weight,
+            asserted_at,
+            expires_at: self.expires_at,
+            attestation_envelope: self.attestation_envelope,
+            // Sentinel (empty) — local rows defer the scrub envelope.
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
+            // FK-valid sentinel: the producer's own key.
+            scrub_key_id: self.attesting_key_id,
+            scrub_timestamp: asserted_at,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            subject_key_ids: self.subject_key_ids,
+            withdraws_admission_rule: None,
+            cohort_scope: self.cohort_scope,
+            tier: attestation_tier::LOCAL.to_string(),
+            promoted_at: None,
+        }
+    }
+}
+
 /// v3.9.0 (CIRISPersist#150) — default cohort_scope for backward compat.
 /// Pre-v3.9.0 attestations had no cohort_scope; reading them under the
 /// new schema returns the column DEFAULT 'federation', so the Rust

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -393,6 +393,44 @@ pub struct Attestation {
         skip_serializing_if = "is_default_cohort_scope"
     )]
     pub cohort_scope: String,
+    /// v4.4.0 (CIRISPersist#171, CEG §10.1.3/§10.1.5). Row tier:
+    /// `"local"` (producer-only authority, signature deferred, visible
+    /// ONLY to the producing occurrence) | `"federation"` (hybrid-signed,
+    /// federation-visible). Default `"federation"` (preserves pre-v4.4.0
+    /// rows). **Persist-internal row metadata — NOT part of the
+    /// `attestation_envelope` JCS canonical signing bytes** (CEG
+    /// §10.1.5.3 must #2): the signature covers `attestation_envelope`,
+    /// not this struct, so a promoted row is byte-identical on the wire
+    /// to a natively-federation one. `skip_serializing_if` default keeps
+    /// federation-row JSON output stable across the v4.4 schema bump.
+    #[serde(default = "default_tier", skip_serializing_if = "is_default_tier")]
+    pub tier: String,
+    /// v4.4.0 — wall-clock of the local→federation `attestation_promote`
+    /// transition (the federation-emit moment). `None` for natively-
+    /// federation rows and un-promoted local rows. Persist-internal; not
+    /// in the canonical bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub promoted_at: Option<DateTime<Utc>>,
+}
+
+/// v4.4.0 (CIRISPersist#171) — attestation tier wire constants.
+pub mod attestation_tier {
+    /// Producer-only-authority, signature-deferred, self-visible-only.
+    pub const LOCAL: &str = "local";
+    /// Hybrid-signed, federation-visible (status quo + promotion target).
+    pub const FEDERATION: &str = "federation";
+}
+
+/// Default tier for backward compat: pre-v4.4.0 rows are all federation.
+fn default_tier() -> String {
+    attestation_tier::FEDERATION.to_string()
+}
+
+/// True iff the tier equals the default (`federation`) — federation rows
+/// omit the field from JSON so legacy canonical/round-trip output stays
+/// stable across the v4.4 schema bump.
+fn is_default_tier(tier: &str) -> bool {
+    tier == attestation_tier::FEDERATION
 }
 
 /// v3.9.0 (CIRISPersist#150) — default cohort_scope for backward compat.

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -714,6 +714,51 @@ impl PyEngine {
         Ok(())
     }
 
+    /// v4.4.0 (CIRISPersist#171) — shared dispatch for the local-tier
+    /// attestation write PyO3 methods (`replace` = upsert vs insert).
+    fn local_attestation_write(
+        &self,
+        py: Python<'_>,
+        input_json: &str,
+        replace: bool,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let input: crate::federation::types::LocalAttestationInput =
+                serde_json::from_str(input_json).map_err(|e| {
+                    PyValueError::new_err(format!("LocalAttestationInput JSON decode: {e}"))
+                })?;
+            let runtime = self.runtime.clone();
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::FederationDirectory;
+                        if replace {
+                            backend.attestation_upsert_local(input).await
+                        } else {
+                            backend.attestation_insert_local(input).await
+                        }
+                        .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::FederationDirectory;
+                        if replace {
+                            backend.attestation_upsert_local(input).await
+                        } else {
+                            backend.attestation_insert_local(input).await
+                        }
+                        .map_err(federation_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
     /// v3.6.8 (CIRISPersist#138, #140) — select the signer for a
     /// PyO3 sign-emitting method based on the caller-supplied
     /// `attesting_key_id`.
@@ -3197,6 +3242,24 @@ impl PyEngine {
                 }
             })
         })
+    }
+
+    /// v4.4.0 (CIRISPersist#171, CEG §10.1.3) — upsert a local-tier
+    /// self-attestation (`input_json` = a `LocalAttestationInput`).
+    /// Replace-on-`(occurrence, dimension)`; signature deferred; the row
+    /// is `tier=local`, `cohort_scope=self` (private to the producing
+    /// occurrence until promotion). Returns the `attestation_id`.
+    fn attestation_upsert_local(&self, py: Python<'_>, input_json: &str) -> PyResult<String> {
+        self.local_attestation_write(py, input_json, true)
+    }
+
+    /// v4.4.0 (CIRISPersist#171) — insert (append) a local-tier
+    /// attestation for a multi-valued dimension (memory / per-thought
+    /// verdicts). Same shape as
+    /// [`attestation_upsert_local`](Self::attestation_upsert_local);
+    /// appends a fresh row instead of replacing.
+    fn attestation_insert_local(&self, py: Python<'_>, input_json: &str) -> PyResult<String> {
+        self.local_attestation_write(py, input_json, false)
     }
 
     // NB (v4.0 #135) — the legacy `list_attestations_for(attested_key_id)

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -147,6 +147,7 @@ impl MemoryBackend {
             Some(dimension.as_str()),
             &input.attesting_key_id,
             &input.subject_key_ids,
+            &input.cohort_scope,
         )?;
         crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
 
@@ -715,7 +716,10 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_attestations
             .iter()
-            .filter(|a| a.attested_key_id == attested_key_id)
+            .filter(|a| {
+                a.attested_key_id == attested_key_id
+                    && a.tier == crate::federation::types::attestation_tier::FEDERATION
+            })
             .cloned()
             .collect();
         // Match postgres ORDER BY asserted_at DESC.
@@ -731,7 +735,10 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_attestations
             .iter()
-            .filter(|a| a.attesting_key_id == attesting_key_id)
+            .filter(|a| {
+                a.attesting_key_id == attesting_key_id
+                    && a.tier == crate::federation::types::attestation_tier::FEDERATION
+            })
             .cloned()
             .collect();
         rows.sort_by_key(|a| std::cmp::Reverse(a.asserted_at));

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -2710,6 +2710,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -3602,6 +3604,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -3779,6 +3783,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
         backend
             .put_attestation(SignedAttestation { attestation: att })

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -129,6 +129,73 @@ impl MemoryBackend {
         Self::default()
     }
 
+    /// v4.4.0 (CIRISPersist#171) — local-tier write (upsert/insert)
+    /// parity with the sqlite/postgres backends. Synchronous (in-process).
+    fn memory_write_local_attestation(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+        replace: bool,
+    ) -> Result<String, crate::federation::Error> {
+        use crate::federation::Error;
+        let dimension = input.dimension().map(|s| s.to_string()).ok_or_else(|| {
+            Error::InvalidArgument(
+                "local attestation envelope must carry a \"dimension\" string".into(),
+            )
+        })?;
+        crate::federation::admission::check_local_tier_eligibility(
+            &input.attestation_type,
+            Some(dimension.as_str()),
+            &input.attesting_key_id,
+            &input.subject_key_ids,
+        )?;
+        crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        let mut state = self.state.lock().expect("memory backend lock");
+        let identity_type = match state.federation_keys.get(&input.attesting_key_id) {
+            Some(rec) => rec.identity_type.clone(),
+            None => {
+                return Err(Error::InvalidArgument(format!(
+                    "attesting_key_id {} does not exist in federation_keys",
+                    input.attesting_key_id
+                )))
+            }
+        };
+        let dim = crate::federation::admission::envelope_dimension(&input.attestation_envelope);
+        crate::federation::admission::DimensionAdmissionPolicy::default().check(
+            &input.attestation_type,
+            dim,
+            &identity_type,
+        )?;
+        // attested_key_id (defaults to attesting) must exist too.
+        let attested = input
+            .attested_key_id
+            .clone()
+            .unwrap_or_else(|| input.attesting_key_id.clone());
+        if !state.federation_keys.contains_key(&attested) {
+            return Err(Error::InvalidArgument(format!(
+                "attested_key_id {attested} does not exist in federation_keys"
+            )));
+        }
+
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let attesting_key_id = input.attesting_key_id.clone();
+        let mut row = input.into_local_row(attestation_id.clone(), chrono::Utc::now());
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+
+        if replace {
+            state.federation_attestations.retain(|a| {
+                !(a.attesting_key_id == attesting_key_id
+                    && a.tier == crate::federation::types::attestation_tier::LOCAL
+                    && a.attestation_envelope
+                        .get("dimension")
+                        .and_then(|v| v.as_str())
+                        == Some(dimension.as_str()))
+            });
+        }
+        state.federation_attestations.push(row);
+        Ok(attestation_id)
+    }
+
     /// Register a public key. For test fixtures. v0.4.0 — writes to
     /// federation_keys (the canonical pubkey directory post-lens#8
     /// ASK 2). Pre-v0.4.0 wrote to a separate `keys` map; the legacy
@@ -624,6 +691,20 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         state.federation_attestations.push(row);
         Ok(())
+    }
+
+    async fn attestation_upsert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.memory_write_local_attestation(input, true)
+    }
+
+    async fn attestation_insert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.memory_write_local_attestation(input, false)
     }
 
     async fn list_attestations_for(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1763,6 +1763,20 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         Ok(())
     }
 
+    async fn attestation_upsert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.pg_write_local_attestation(input, true).await
+    }
+
+    async fn attestation_insert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.pg_write_local_attestation(input, false).await
+    }
+
     async fn list_attestations_for(
         &self,
         attested_key_id: &str,
@@ -6010,6 +6024,135 @@ fn pg_row_to_key_record(
         roles,
         attestation_evidence,
     })
+}
+
+impl PostgresBackend {
+    /// v4.4.0 (CIRISPersist#171) — shared local-tier write path for
+    /// `attestation_upsert_local` (`replace = true`) /
+    /// `attestation_insert_local` (`replace = false`). Mirrors the SQLite
+    /// path: §4.1 local-tier gate + dimension/cohort_scope admission,
+    /// deferred-signature `local` row, upsert = delete-prior-then-insert.
+    async fn pg_write_local_attestation(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+        replace: bool,
+    ) -> Result<String, crate::federation::Error> {
+        use crate::federation::Error;
+
+        let dimension = input.dimension().map(|s| s.to_string()).ok_or_else(|| {
+            Error::InvalidArgument(
+                "local attestation envelope must carry a \"dimension\" string".into(),
+            )
+        })?;
+
+        crate::federation::admission::check_local_tier_eligibility(
+            &input.attestation_type,
+            Some(dimension.as_str()),
+            &input.attesting_key_id,
+            &input.subject_key_ids,
+        )?;
+        crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        let mut client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+
+        // FK precondition + §7.0.1 emitter gate (no federation trust gate
+        // for local — producer-only authority).
+        let identity_type: String = client
+            .query_opt(
+                "SELECT identity_type FROM cirislens.federation_keys WHERE key_id = $1",
+                &[&input.attesting_key_id],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("lookup attesting identity_type: {e}")))?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "attesting_key_id {} does not exist in federation_keys",
+                    input.attesting_key_id
+                ))
+            })?
+            .get(0);
+        let dim = crate::federation::admission::envelope_dimension(&input.attestation_envelope);
+        crate::federation::admission::DimensionAdmissionPolicy::default().check(
+            &input.attestation_type,
+            dim,
+            &identity_type,
+        )?;
+
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
+        let attesting_key_id = input.attesting_key_id.clone();
+        let mut row = input.into_local_row(attestation_id.clone(), now);
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let subject_key_ids_json = serde_json::to_value(&row.subject_key_ids)
+            .map_err(|e| Error::Backend(format!("subject_key_ids serialize: {e}")))?;
+        let original_content_hash: Vec<u8> = Vec::new(); // empty sentinel
+        let attestation_uuid = uuid::Uuid::parse_str(&attestation_id)
+            .map_err(|e| Error::Backend(format!("uuid parse: {e}")))?;
+
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| Error::Backend(format!("begin tx: {e}")))?;
+        if replace {
+            tx.execute(
+                "DELETE FROM cirislens.federation_attestations \
+                  WHERE attesting_key_id = $1 AND tier = 'local' \
+                    AND attestation_envelope->>'dimension' = $2",
+                &[&attesting_key_id, &dimension],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("local upsert delete: {e}")))?;
+        }
+        tx.execute(
+            "INSERT INTO cirislens.federation_attestations (\
+                attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                weight, asserted_at, expires_at, attestation_envelope, \
+                original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, \
+                subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at\
+             ) VALUES ($1, $2, $3, $4, $5::float8::numeric, $6, $7, $8, $9, $10, $11, $12, \
+                       $13, $14, $15, $16, $17, $18, 'local', NULL)",
+            &[
+                &attestation_uuid,
+                &row.attesting_key_id,
+                &row.attested_key_id,
+                &row.attestation_type,
+                &row.weight,
+                &row.asserted_at,
+                &row.expires_at,
+                &row.attestation_envelope,
+                &original_content_hash,
+                &row.scrub_signature_classical,
+                &row.scrub_signature_pqc,
+                &row.scrub_key_id,
+                &row.scrub_timestamp,
+                &row.pqc_completed_at,
+                &row.persist_row_hash,
+                &subject_key_ids_json,
+                &None::<i16>,
+                &row.cohort_scope,
+            ],
+        )
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("foreign key") || msg.contains("violates foreign key") {
+                Error::InvalidArgument(format!(
+                    "FK constraint violated on local attestation insert \
+                     (attesting/attested/scrub key must exist in federation_keys): {msg}"
+                ))
+            } else {
+                Error::Backend(format!("insert local attestation: {msg}"))
+            }
+        })?;
+        tx.commit()
+            .await
+            .map_err(|e| Error::Backend(format!("local attestation commit: {e}")))?;
+        Ok(attestation_id)
+    }
 }
 
 fn pg_row_to_attestation(
@@ -19680,6 +19823,116 @@ mod tests {
             matches!(err, crate::federation::BlobError::InvalidArgument(ref m)
                 if m.contains("equivocation")),
             "PG subscriber equivocation must be rejected, got: {err:?}"
+        );
+    }
+
+    // ── Cut #171 phase 1: local-tier write on live Postgres ──
+
+    fn pg_local_input(
+        attesting: &str,
+        attestation_type: &str,
+        dimension: &str,
+        subjects: Vec<String>,
+    ) -> crate::federation::types::LocalAttestationInput {
+        crate::federation::types::LocalAttestationInput {
+            attesting_key_id: attesting.into(),
+            attested_key_id: None,
+            attestation_type: attestation_type.into(),
+            weight: Some(1.0),
+            expires_at: None,
+            attestation_envelope: serde_json::json!({
+                "id": "x", "dimension": dimension, "score": 1.0, "confidence": 0.9,
+            }),
+            subject_key_ids: subjects,
+            cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_local_attestation_upsert_insert_and_gates() {
+        use crate::federation::types::attestation_type::{SCORES, WITHDRAWS};
+        use crate::federation::FederationDirectory;
+        use crate::store::backend::Backend;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let occ = format!("occ-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &occ,
+                    "registry",
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+
+        // Upsert twice on the same dimension → one local row (replace).
+        backend
+            .attestation_upsert_local(pg_local_input(&occ, SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        backend
+            .attestation_upsert_local(pg_local_input(&occ, SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, &occ)
+            .await
+            .unwrap();
+        let local: Vec<_> = rows
+            .iter()
+            .filter(|a| a.tier == crate::federation::types::attestation_tier::LOCAL)
+            .collect();
+        assert_eq!(
+            local.len(),
+            1,
+            "PG upsert replaces on (occurrence, dimension)"
+        );
+        assert!(local[0].scrub_signature_classical.is_empty());
+        assert_eq!(local[0].tier, "local");
+
+        // Insert appends a distinct row.
+        backend
+            .attestation_insert_local(pg_local_input(&occ, SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        let after = crate::federation::FederationDirectory::list_attestations_for(&backend, &occ)
+            .await
+            .unwrap();
+        let local_n = after
+            .iter()
+            .filter(|a| a.tier == crate::federation::types::attestation_tier::LOCAL)
+            .count();
+        assert_eq!(local_n, 2, "insert appends (1 upsert-survivor + 1 append)");
+
+        // Gate: capacity:* ineligible for local.
+        let err = backend
+            .attestation_upsert_local(pg_local_input(&occ, SCORES, "capacity:core:v1", vec![]))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("capacity")),
+            "got: {err:?}"
+        );
+
+        // Gate: subject-side revocation ineligible for local.
+        let err = backend
+            .attestation_upsert_local(pg_local_input(
+                &occ,
+                WITHDRAWS,
+                "consent:state:revoked:v1",
+                vec![occ.clone()],
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
+            "got: {err:?}"
         );
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1797,7 +1797,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                  FROM cirislens.federation_attestations \
-                 WHERE attested_key_id = $1 \
+                 WHERE attested_key_id = $1 AND tier = 'federation' \
                  ORDER BY asserted_at DESC",
                 &[&attested_key_id],
             )
@@ -1824,7 +1824,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                  FROM cirislens.federation_attestations \
-                 WHERE attesting_key_id = $1 \
+                 WHERE attesting_key_id = $1 AND tier = 'federation' \
                  ORDER BY asserted_at DESC",
                 &[&attesting_key_id],
             )
@@ -6050,6 +6050,7 @@ impl PostgresBackend {
             Some(dimension.as_str()),
             &input.attesting_key_id,
             &input.subject_key_ids,
+            &input.cohort_scope,
         )?;
         crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
 
@@ -19881,34 +19882,45 @@ mod tests {
             .attestation_upsert_local(pg_local_input(&occ, SCORES, "identity_binding:v1", vec![]))
             .await
             .unwrap();
-        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, &occ)
-            .await
-            .unwrap();
-        let local: Vec<_> = rows
-            .iter()
-            .filter(|a| a.tier == crate::federation::types::attestation_tier::LOCAL)
-            .collect();
+        // Read local rows directly — the FederationDirectory trust-read
+        // excludes tier='local' (AV-59).
+        let count_local = |occ: &str| {
+            let occ = occ.to_string();
+            let backend = &backend;
+            async move {
+                let client = backend.get_client().await.unwrap();
+                let row = client
+                    .query_one(
+                        "SELECT COUNT(*)::int8 FROM cirislens.federation_attestations \
+                          WHERE attesting_key_id = $1 AND tier = 'local'",
+                        &[&occ],
+                    )
+                    .await
+                    .unwrap();
+                row.try_get::<_, i64>(0).unwrap()
+            }
+        };
         assert_eq!(
-            local.len(),
+            count_local(&occ).await,
             1,
             "PG upsert replaces on (occurrence, dimension)"
         );
-        assert!(local[0].scrub_signature_classical.is_empty());
-        assert_eq!(local[0].tier, "local");
+        // AV-59: federation trust-read does not surface local rows.
+        let trust = crate::federation::FederationDirectory::list_attestations_for(&backend, &occ)
+            .await
+            .unwrap();
+        assert!(trust.is_empty(), "local rows must not leak (AV-59)");
 
         // Insert appends a distinct row.
         backend
             .attestation_insert_local(pg_local_input(&occ, SCORES, "identity_binding:v1", vec![]))
             .await
             .unwrap();
-        let after = crate::federation::FederationDirectory::list_attestations_for(&backend, &occ)
-            .await
-            .unwrap();
-        let local_n = after
-            .iter()
-            .filter(|a| a.tier == crate::federation::types::attestation_tier::LOCAL)
-            .count();
-        assert_eq!(local_n, 2, "insert appends (1 upsert-survivor + 1 append)");
+        assert_eq!(
+            count_local(&occ).await,
+            2,
+            "insert appends (1 upsert-survivor + 1 append)"
+        );
 
         // Gate: capacity:* ineligible for local.
         let err = backend

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1781,7 +1781,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 "SELECT attestation_id::text, attesting_key_id, attested_key_id, attestation_type, \
                     weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                  FROM cirislens.federation_attestations \
                  WHERE attested_key_id = $1 \
                  ORDER BY asserted_at DESC",
@@ -1808,7 +1808,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 "SELECT attestation_id::text, attesting_key_id, attested_key_id, attestation_type, \
                     weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                  FROM cirislens.federation_attestations \
                  WHERE attesting_key_id = $1 \
                  ORDER BY asserted_at DESC",
@@ -2278,7 +2278,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 "SELECT attestation_id::text, attesting_key_id, attested_key_id, attestation_type, \
                     weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                  FROM cirislens.federation_attestations WHERE attestation_id = $1::uuid",
                 &[&attestation_id],
             )
@@ -3571,6 +3571,8 @@ impl crate::federation::BlobStorage for PostgresBackend {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
         let attestation_envelope_jsonb = attestation_row.attestation_envelope.clone();
         let persist_row_hash = crate::federation::types::compute_persist_row_hash(&attestation_row)
@@ -6041,6 +6043,10 @@ fn pg_row_to_attestation(
         subject_key_ids,
         withdraws_admission_rule: withdraws_admission_rule.map(|v| v as u8),
         cohort_scope: row.safe_get_with("cohort_scope", mk_err)?,
+        // v4.4.0 (CIRISPersist#171) — tier (DEFAULT 'federation' for
+        // pre-V066 rows) + promoted_at.
+        tier: row.safe_get_with("tier", mk_err)?,
+        promoted_at: row.safe_get_with("promoted_at", mk_err)?,
     })
 }
 
@@ -8210,7 +8216,7 @@ impl crate::read::ReadEngine for PostgresBackend {
             "SELECT attestation_id::text AS attestation_id, attesting_key_id, attested_key_id, \
                     attestation_type, weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
              FROM cirislens.federation_attestations \
              {where_sql} \
              ORDER BY asserted_at DESC, attestation_id DESC \
@@ -8308,7 +8314,7 @@ impl crate::read::ReadEngine for PostgresBackend {
             "SELECT attestation_id::text AS attestation_id, attesting_key_id, attested_key_id, \
                     attestation_type, weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
              FROM cirislens.federation_attestations \
              {where_sql} \
              ORDER BY asserted_at DESC, attestation_id DESC \
@@ -14408,6 +14414,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -14810,6 +14818,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -15975,6 +15985,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -16755,6 +16767,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
         backend
             .put_attestation(crate::federation::SignedAttestation { attestation: att })
@@ -18893,6 +18907,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
         backend
             .put_attestation(crate::federation::SignedAttestation {
@@ -19070,6 +19086,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1482,6 +1482,20 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         Ok(())
     }
 
+    async fn attestation_upsert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.sqlite_write_local_attestation(input, true).await
+    }
+
+    async fn attestation_insert_local(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+    ) -> Result<String, crate::federation::Error> {
+        self.sqlite_write_local_attestation(input, false).await
+    }
+
     async fn list_attestations_for(
         &self,
         attested_key_id: &str,
@@ -5980,6 +5994,148 @@ fn sqlite_row_to_key_record(
         roles,
         attestation_evidence,
     })
+}
+
+impl SqliteBackend {
+    /// v4.4.0 (CIRISPersist#171) — shared local-tier write path for
+    /// `attestation_upsert_local` (`replace = true`) /
+    /// `attestation_insert_local` (`replace = false`). Runs the §4.1
+    /// local-tier gate + the shared dimension/cohort_scope admission,
+    /// builds the deferred-signature `local` row, and writes it (upsert =
+    /// delete prior local rows for `(attesting, dimension)` then insert;
+    /// insert = append a fresh id). Returns the new `attestation_id`.
+    async fn sqlite_write_local_attestation(
+        &self,
+        input: crate::federation::types::LocalAttestationInput,
+        replace: bool,
+    ) -> Result<String, crate::federation::Error> {
+        use crate::federation::Error;
+
+        // The (occurrence, dimension) key + the gate axis. Required.
+        let dimension = input.dimension().map(|s| s.to_string()).ok_or_else(|| {
+            Error::InvalidArgument(
+                "local attestation envelope must carry a \"dimension\" string".into(),
+            )
+        })?;
+
+        // §4.1 local-tier gate: refuse capacity:* + subject-side revocation.
+        crate::federation::admission::check_local_tier_eligibility(
+            &input.attestation_type,
+            Some(dimension.as_str()),
+            &input.attesting_key_id,
+            &input.subject_key_ids,
+        )?;
+
+        // cohort_scope value validation (closed set).
+        crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        // FK precondition + §7.0.1 emitter gate: the attesting key must
+        // exist; its identity_type gates the dimension. Mirrors
+        // put_attestation, minus the federation trust-threshold gate
+        // (local = producer-only authority, not federation-trust-gated).
+        let identity_type = {
+            let conn = self.conn.clone();
+            let attesting = input.attesting_key_id.clone();
+            (move || -> Result<Option<String>, rusqlite::Error> {
+                let conn = conn.lock();
+                conn.query_row(
+                    "SELECT identity_type FROM federation_keys WHERE key_id = ?1",
+                    [&attesting],
+                    |r| r.get::<_, String>(0),
+                )
+                .optional()
+            })()
+            .map_err(|e| Error::Backend(format!("lookup attesting identity_type: {e}")))?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "attesting_key_id {} does not exist in federation_keys",
+                    input.attesting_key_id
+                ))
+            })?
+        };
+        let dim = crate::federation::admission::envelope_dimension(&input.attestation_envelope);
+        crate::federation::admission::DimensionAdmissionPolicy::default().check(
+            &input.attestation_type,
+            dim,
+            &identity_type,
+        )?;
+
+        // Build the local row + its persist_row_hash.
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now();
+        let attesting_key_id = input.attesting_key_id.clone();
+        let mut row = input.into_local_row(attestation_id.clone(), now);
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+
+        let envelope_text = serde_json::to_string(&row.attestation_envelope)
+            .map_err(|e| Error::Backend(format!("envelope serialize: {e}")))?;
+        let subject_key_ids_json = serde_json::to_string(&row.subject_key_ids)
+            .map_err(|e| Error::Backend(format!("subject_key_ids serialize: {e}")))?;
+        // Empty-sentinel scrub envelope: original_content_hash hex "" → [].
+        let original_content_hash: Vec<u8> = Vec::new();
+        let conn = self.conn.clone();
+
+        (move || -> Result<(), rusqlite::Error> {
+            let mut conn = conn.lock();
+            let tx = conn.transaction()?;
+            if replace {
+                // Upsert-replace: drop any prior local row for this
+                // (occurrence, dimension). History is carried by the
+                // `supersedes` composer, not by retaining stale current
+                // state (CIRISAgent review).
+                tx.execute(
+                    "DELETE FROM federation_attestations \
+                      WHERE attesting_key_id = ?1 AND tier = 'local' \
+                        AND json_extract(attestation_envelope, '$.dimension') = ?2",
+                    rusqlite::params![attesting_key_id, dimension],
+                )?;
+            }
+            tx.execute(
+                "INSERT INTO federation_attestations (\
+                    attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                    weight, asserted_at, expires_at, attestation_envelope, \
+                    original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, \
+                    subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, \
+                           ?16, ?17, ?18, 'local', NULL)",
+                rusqlite::params![
+                    row.attestation_id,
+                    row.attesting_key_id,
+                    row.attested_key_id,
+                    row.attestation_type,
+                    row.weight,
+                    row.asserted_at.to_rfc3339(),
+                    row.expires_at.map(|t| t.to_rfc3339()),
+                    envelope_text,
+                    original_content_hash,
+                    row.scrub_signature_classical,
+                    row.scrub_signature_pqc,
+                    row.scrub_key_id,
+                    row.scrub_timestamp.to_rfc3339(),
+                    row.pqc_completed_at.map(|t| t.to_rfc3339()),
+                    row.persist_row_hash,
+                    subject_key_ids_json,
+                    None::<i64>,
+                    row.cohort_scope,
+                ],
+            )?;
+            tx.commit()?;
+            Ok(())
+        })()
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("FOREIGN KEY") {
+                Error::InvalidArgument(format!(
+                    "FK constraint violated on local attestation insert \
+                     (attesting/attested/scrub key must exist in federation_keys): {msg}"
+                ))
+            } else {
+                Error::Backend(format!("insert local attestation: {msg}"))
+            }
+        })?;
+        Ok(attestation_id)
+    }
 }
 
 fn sqlite_row_to_attestation(
@@ -11790,6 +11946,142 @@ mod tests {
             .unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].cohort_scope, "self");
+    }
+
+    // ── Cut #171 phase 1: local-tier write (upsert/insert + gates) ──
+
+    fn local_input(
+        attesting: &str,
+        attestation_type: &str,
+        dimension: &str,
+        subjects: Vec<String>,
+    ) -> crate::federation::types::LocalAttestationInput {
+        crate::federation::types::LocalAttestationInput {
+            attesting_key_id: attesting.into(),
+            attested_key_id: None,
+            attestation_type: attestation_type.into(),
+            weight: Some(1.0),
+            expires_at: None,
+            attestation_envelope: serde_json::json!({
+                "id": "x", "dimension": dimension, "score": 1.0, "confidence": 0.9,
+            }),
+            subject_key_ids: subjects,
+            cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+        }
+    }
+
+    async fn fresh_backend_with_occurrence(occ: &str) -> SqliteBackend {
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key_with_identity_type(
+                    occ,
+                    "registry",
+                    occ,
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+    }
+
+    use crate::federation::types::attestation_tier::LOCAL as TIER_LOCAL;
+    use crate::federation::types::attestation_type::{SCORES, WITHDRAWS};
+
+    #[tokio::test]
+    async fn sqlite_local_upsert_replaces_on_dimension() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        // Two upserts of the same dimension → exactly one local row (replace).
+        backend
+            .attestation_upsert_local(local_input("occ", SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        backend
+            .attestation_upsert_local(local_input("occ", SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, "occ")
+            .await
+            .unwrap();
+        let local: Vec<_> = rows.iter().filter(|a| a.tier == TIER_LOCAL).collect();
+        assert_eq!(local.len(), 1, "upsert replaces on (occurrence, dimension)");
+        assert_eq!(local[0].tier, "local");
+        assert!(
+            local[0].scrub_signature_classical.is_empty(),
+            "local row carries the deferred empty-sentinel signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_local_insert_appends_multivalued() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        let id1 = backend
+            .attestation_insert_local(local_input("occ", SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        let id2 = backend
+            .attestation_insert_local(local_input("occ", SCORES, "identity_binding:v1", vec![]))
+            .await
+            .unwrap();
+        assert_ne!(id1, id2, "append yields distinct ids");
+        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, "occ")
+            .await
+            .unwrap();
+        let local = rows.iter().filter(|a| a.tier == TIER_LOCAL).count();
+        assert_eq!(local, 2, "insert appends, never collapses by dimension");
+    }
+
+    #[tokio::test]
+    async fn sqlite_local_rejects_capacity_self_emission() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        // capacity:* is the §7.5 anti-Goodhart bypass — ineligible for local.
+        let err = backend
+            .attestation_upsert_local(local_input(
+                "occ",
+                SCORES,
+                "capacity:core_identity:v1",
+                vec![],
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("capacity")),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_local_rejects_subject_side_revocation() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        // withdraws where the writer is in subject_key_ids = a subject-side
+        // revocation → must be federation-tier signed (§10.1.3).
+        let err = backend
+            .attestation_upsert_local(local_input(
+                "occ",
+                WITHDRAWS,
+                "consent:state:revoked:v1",
+                vec!["occ".to_string()],
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_local_requires_dimension() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        let mut input = local_input("occ", SCORES, "identity_binding:v1", vec![]);
+        input.attestation_envelope = serde_json::json!({"id": "x", "score": 1.0}); // no dimension
+        let err = backend.attestation_upsert_local(input).await.unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("dimension")),
+            "got: {err:?}"
+        );
     }
 
     /// Stable `kind()` token for the cohort_scope rejection — consumers

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1495,7 +1495,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     "SELECT attestation_id, attesting_key_id, attested_key_id, attestation_type, \
                         weight, asserted_at, expires_at, attestation_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                      FROM federation_attestations \
                      WHERE attested_key_id = ?1 \
                      ORDER BY asserted_at DESC",
@@ -1519,7 +1519,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     "SELECT attestation_id, attesting_key_id, attested_key_id, attestation_type, \
                         weight, asserted_at, expires_at, attestation_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                      FROM federation_attestations \
                      WHERE attesting_key_id = ?1 \
                      ORDER BY asserted_at DESC",
@@ -1968,7 +1968,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     "SELECT attestation_id, attesting_key_id, attested_key_id, attestation_type, \
                         weight, asserted_at, expires_at, attestation_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
-                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                      FROM federation_attestations WHERE attestation_id = ?1",
                     [&id],
                     sqlite_row_to_attestation,
@@ -3315,6 +3315,8 @@ impl crate::federation::BlobStorage for SqliteBackend {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         };
         let persist_row_hash = crate::federation::types::compute_persist_row_hash(&attestation_row)
             .map_err(|e| crate::federation::BlobError::Backend(format!("persist_row_hash: {e}")))?;
@@ -6027,6 +6029,14 @@ fn sqlite_row_to_attestation(
         subject_key_ids,
         withdraws_admission_rule: withdraws_admission_rule.map(|v| v as u8),
         cohort_scope: row.get("cohort_scope")?,
+        // v4.4.0 (CIRISPersist#171) — tier defaults to 'federation' for
+        // pre-V066 rows (the column DEFAULT); promoted_at NULL for
+        // natively-federation + un-promoted local rows.
+        tier: row.get("tier")?,
+        promoted_at: {
+            let p: Option<String> = row.get("promoted_at")?;
+            p.as_deref().map(parse_rfc3339)
+        },
     })
 }
 
@@ -8101,7 +8111,7 @@ impl crate::read::ReadEngine for SqliteBackend {
                     attestation_type, weight, asserted_at, expires_at, \
                     attestation_envelope, original_content_hash, \
                     scrub_signature_classical, scrub_signature_pqc, scrub_key_id, \
-                    scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
              FROM federation_attestations {where_sql} \
              ORDER BY asserted_at DESC, attestation_id DESC LIMIT ?{p_limit}"
         );
@@ -8190,7 +8200,7 @@ impl crate::read::ReadEngine for SqliteBackend {
                     attestation_type, weight, asserted_at, expires_at, \
                     attestation_envelope, original_content_hash, \
                     scrub_signature_classical, scrub_signature_pqc, scrub_key_id, \
-                    scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope \
+                    scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
              FROM federation_attestations {where_sql} \
              ORDER BY asserted_at DESC, attestation_id DESC LIMIT ?{p_limit}"
         );
@@ -10152,6 +10162,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -11931,6 +11943,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -12872,6 +12886,8 @@ mod tests {
                     subject_key_ids: Vec::new(),
                     withdraws_admission_rule: None,
                     cohort_scope: "federation".to_string(),
+                    tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+                    promoted_at: None,
                 },
             })
             .await
@@ -15782,6 +15798,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 
@@ -18219,6 +18237,8 @@ mod tests {
             subject_key_ids: Vec::new(),
             withdraws_admission_rule: None,
             cohort_scope: "federation".to_string(),
+            tier: crate::federation::types::attestation_tier::FEDERATION.to_string(),
+            promoted_at: None,
         }
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1511,7 +1511,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                      FROM federation_attestations \
-                     WHERE attested_key_id = ?1 \
+                     WHERE attested_key_id = ?1 AND tier = 'federation' \
                      ORDER BY asserted_at DESC",
                 )?;
                 let rows = stmt.query_map([&key], sqlite_row_to_attestation)?;
@@ -1535,7 +1535,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
                      FROM federation_attestations \
-                     WHERE attesting_key_id = ?1 \
+                     WHERE attesting_key_id = ?1 AND tier = 'federation' \
                      ORDER BY asserted_at DESC",
                 )?;
                 let rows = stmt.query_map([&key], sqlite_row_to_attestation)?;
@@ -6024,6 +6024,7 @@ impl SqliteBackend {
             Some(dimension.as_str()),
             &input.attesting_key_id,
             &input.subject_key_ids,
+            &input.cohort_scope,
         )?;
 
         // cohort_scope value validation (closed set).
@@ -11987,8 +11988,27 @@ mod tests {
         backend
     }
 
-    use crate::federation::types::attestation_tier::LOCAL as TIER_LOCAL;
     use crate::federation::types::attestation_type::{SCORES, WITHDRAWS};
+
+    /// Read local rows directly (the FederationDirectory trust-reads now
+    /// exclude tier='local' — AV-59 — so tests count via the DB).
+    /// Returns (tier, scrub_signature_classical) per local row.
+    fn local_rows(backend: &SqliteBackend, attesting: &str) -> Vec<(String, String)> {
+        let conn = backend.conn_handle();
+        let conn = conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT tier, scrub_signature_classical FROM federation_attestations \
+                 WHERE attesting_key_id = ?1 AND tier = 'local'",
+            )
+            .unwrap();
+        stmt.query_map([attesting], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+    }
 
     #[tokio::test]
     async fn sqlite_local_upsert_replaces_on_dimension() {
@@ -12002,15 +12022,20 @@ mod tests {
             .attestation_upsert_local(local_input("occ", SCORES, "identity_binding:v1", vec![]))
             .await
             .unwrap();
-        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, "occ")
+        let local = local_rows(&backend, "occ");
+        assert_eq!(local.len(), 1, "upsert replaces on (occurrence, dimension)");
+        assert_eq!(local[0].0, "local");
+        assert!(
+            local[0].1.is_empty(),
+            "local row carries the deferred empty-sentinel signature"
+        );
+        // AV-59: the FederationDirectory trust-read does NOT surface local.
+        let trust = crate::federation::FederationDirectory::list_attestations_for(&backend, "occ")
             .await
             .unwrap();
-        let local: Vec<_> = rows.iter().filter(|a| a.tier == TIER_LOCAL).collect();
-        assert_eq!(local.len(), 1, "upsert replaces on (occurrence, dimension)");
-        assert_eq!(local[0].tier, "local");
         assert!(
-            local[0].scrub_signature_classical.is_empty(),
-            "local row carries the deferred empty-sentinel signature"
+            trust.is_empty(),
+            "local rows must not leak through the federation trust-read (AV-59)"
         );
     }
 
@@ -12026,11 +12051,11 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(id1, id2, "append yields distinct ids");
-        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, "occ")
-            .await
-            .unwrap();
-        let local = rows.iter().filter(|a| a.tier == TIER_LOCAL).count();
-        assert_eq!(local, 2, "insert appends, never collapses by dimension");
+        assert_eq!(
+            local_rows(&backend, "occ").len(),
+            2,
+            "insert appends, never collapses by dimension"
+        );
     }
 
     #[tokio::test]
@@ -12069,6 +12094,18 @@ mod tests {
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
             "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_local_rejects_non_self_cohort_scope() {
+        let backend = fresh_backend_with_occurrence("occ").await;
+        let mut input = local_input("occ", SCORES, "identity_binding:v1", vec![]);
+        input.cohort_scope = crate::federation::types::cohort_scope::FEDERATION.to_string();
+        let err = backend.attestation_upsert_local(input).await.unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("self")),
+            "local rows must be cohort_scope='self'; got: {err:?}"
         );
     }
 


### PR DESCRIPTION
Phase 1 of the shared CEG attestation surface (CIRISPersist#171) — the gating dependency for **CIRISAgent#840**'s hard cut-over. FSD (`FSD/V4_4_SHARED_ATTESTATION_SURFACE.md`) accepted by all four CEG-RC1 impls; surface pinned in CEG §10.1.5. Per the Agent's staging request, this lands **local operation**; `attestation_promote` is the v4.5 fast-follow (now unblocked by CIRISVerify 4.11.0 JCS).

## Dependency
- **CIRISVerify 4.10.0 → 4.11.0** — ships `ciris_verify_core::jcs::{canonicalize, verify_jcs_hybrid_signature}` (RFC 8785; #59 closed), the OQ-4 deliverable for v4.5 `promote`. No call site yet — re-pinned now so v4.5 is a pure feature add.

## Added
- **V066 tier model** — `federation_attestations` gains `tier` (`local|federation`, DEFAULT federation) + `promoted_at`. Purely additive on both backends (empty-sentinel scrub envelope for local rows — no NOT-NULL relaxation, no table rebuild). CHECK/trigger: `federation ⟹ signed` (**AV-60**). Metadata columns, NOT in the canonical bytes → a promoted row will be byte-identical to a native-federation one (Registry must #2).
- **`attestation_upsert_local` / `attestation_insert_local`** (+`_many`) on `FederationDirectory`, all 3 backends + PyO3. `LocalAttestationInput` → deferred-signature `local` row. upsert replaces on `(attesting_key_id, dimension)`; insert appends (multi-valued memory) — the Agent's two-write-class correction.

## Enforced at ingest (§4.1 gates)
- **`capacity:*` ineligible for local** (§7.5 anti-Goodhart, **AV-62**) + `attesting≠attested` on the federation path — LensCore's load-bearing catch.
- **Subject-side revocation ineligible** (writer ∈ `subject_key_ids`; §10.1.3, **AV-61**).
- **Local rows are `cohort_scope='self'`** → the v4.0 self-cohort gate IS the tier read-gate; with the trust-read filter below, closes **AV-59**.

## Changed
- `FederationDirectory::list_attestations_for`/`_by` (trust-reads) filter `tier='federation'` — local self-attestations never surface there. The agent reads its own state via the scoped `ReadEngine` reads. No public-signature change.

## Deferred → v4.5 (documented)
`attestation_promote` (unblocked, 4.11.0), the dimension-prefix `attestation_query`, and the §5 consent-revocation overdue-scan/`hard_case` (clock = OQ-3/#161). The §10.1.3 subject-revocation leak is already closed at ingest; §5 covers only the acquire-after-write residual.

## Tests
Both backends (live PG + SQLite): upsert-replace, insert-append, 3 gate negatives (capacity / subject-revocation / non-self-scope), dimension-required, AV-59 trust-read exclusion. **1035 lib tests green on live PG**; `-D warnings` clean across no-backend / `test-panic,pyo3` / full; clippy clean over `--tests`. Ships as **4.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)