### PR TITLE
v4.5.0 — attestation_query filters (dimension-prefix / valid_at / confidence / subject) (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.5.0] — 2026-06-09
+
+**Shared CEG attestation surface — `attestation_query` filters (CIRISPersist#171; CEG 0.15 §10.1.5.4).**
+
+The uniform read the agent's memory/config/consent/audit services wrap over — and the same read NodeCore/LensCore/Registry use. Built as additive fields on `AttestationFilter` (riding the existing scope-gated, cursor-paged `ReadEngine::list_attestations` + its PyO3 JSON wrapper — no new method, no new result type), so it composes with the v4.0 DAS scope machinery + cache. No signing involved → independent of the v4.5 JCS flip (FSD review #174).
+
+### Added — `AttestationFilter` query fields
+- **`dimension_prefixes: Vec<String>`** — **open-vocabulary**, hierarchical-prefix-matched on the envelope `dimension` (`attestation_envelope->>'dimension' LIKE 'prefix%'`, OR-combined; `%`/`_`/`\` escaped). Validated structurally, NOT against a closed enum (the OQ-2 resolution: open data, closed operators). New CEG dimension families work with no redeploy.
+- **`valid_at: Option<DateTime>`** — point-in-time validity (`asserted_at <= valid_at < COALESCE(expires_at, +inf)`).
+- **`confidence_floor: Option<f64>`** — `weight >= floor` (NULL weight excluded when a floor is set; PG compares via `weight::float8`).
+- **`subject_key_id: Option<String>`** — attestations naming a subject (PG `subject_key_ids ? $n` JSONB-array membership; SQLite `json_each`).
+
+All four AND-compose with the existing `attesting`/`attested`/`type`/`pqc` filters + the §4.3 cohort scope gate + the v4.4 tier gate. The agent reads its own local (`self`-cohort) + federation rows by dimension through this one call. PyO3: automatic — the existing `list_attestations(filter_json, …)` wrapper deserializes the richer filter.
+
+### Tests
+Both backends (live PG + SQLite): dimension-prefix (single + OR), confidence-floor (NULL-excluded), subject membership, point-in-time validity. **1037 lib tests green on live PG**; `-D warnings` clean across no-backend / `test-panic,pyo3` / full; clippy clean over `--tests`.
+
+### Note
+- `AttestationFilter` dropped its `Eq` derive (`confidence_floor: Option<f64>` is not `Eq`); it keeps `PartialEq`. Source-incompatible only for code that relied on `AttestationFilter: Eq`.
+
 ## [4.4.0] — 2026-06-08
 
 **Shared CEG attestation surface — phase 1: local-tier write + read-gate (CIRISPersist#171; CEG 0.15 §10.1.3 / §10.1.5; FSD `V4_4_SHARED_ATTESTATION_SURFACE.md`).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.4.0"
+version = "4.5.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/ceg/list/federation.rs
+++ b/src/ceg/list/federation.rs
@@ -107,7 +107,8 @@ pub struct FederationKeyListPage {
 
 /// Filter for [`crate::ceg::ReadEngine::list_attestations`]. Composes
 /// AND-style.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+// `Eq` dropped in v4.5 — `confidence_floor: Option<f64>` is not `Eq`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct AttestationFilter {
     /// Filter by the key id that DID the attesting.
     pub attesting_key_id: Option<String>,
@@ -121,6 +122,31 @@ pub struct AttestationFilter {
 
     /// Filter by PQC completion.
     pub pqc_completed: Option<bool>,
+
+    /// v4.5 (CIRISPersist#171, CEG §10.1.5.4) — **open-vocabulary**
+    /// dimension-prefix filter. Matches rows whose envelope `dimension`
+    /// (`attestation_envelope->>'dimension'`) starts with ANY of these
+    /// prefixes (hierarchical-prefix-matched, OR-combined). Empty = no
+    /// dimension filter. The `attestation_query` axis; validated
+    /// structurally, NOT against a closed enum.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dimension_prefixes: Vec<String>,
+
+    /// v4.5 — point-in-time validity: keep rows with
+    /// `asserted_at <= valid_at < COALESCE(expires_at, +inf)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_at: Option<DateTime<Utc>>,
+
+    /// v4.5 — minimum `weight` (confidence floor): keep rows with
+    /// `weight >= confidence_floor`. Rows with NULL weight are excluded
+    /// when a floor is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence_floor: Option<f64>,
+
+    /// v4.5 — narrow to attestations naming this subject (the key id is
+    /// a member of `subject_key_ids`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_key_id: Option<String>,
 }
 
 /// Opaque cursor for [`crate::ceg::ReadEngine::list_attestations`].

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -8321,6 +8321,45 @@ impl crate::read::ReadEngine for PostgresBackend {
                 "pqc_completed_at IS NULL".to_owned()
             });
         }
+        // v4.5 (CEG §10.1.5.4) — open-vocab dimension-prefix filter
+        // (OR-combined LIKE on the JSONB envelope dimension).
+        if !filter.dimension_prefixes.is_empty() {
+            let mut ors: Vec<String> = Vec::new();
+            for p in &filter.dimension_prefixes {
+                let esc = p
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_");
+                params.push(Box::new(format!("{esc}%")));
+                ors.push(format!(
+                    "attestation_envelope->>'dimension' LIKE ${}",
+                    params.len()
+                ));
+            }
+            where_parts.push(format!("({})", ors.join(" OR ")));
+        }
+        // v4.5 — point-in-time validity.
+        if let Some(va) = filter.valid_at {
+            params.push(Box::new(va));
+            let p = params.len();
+            where_parts.push(format!(
+                "(asserted_at <= ${p} AND (expires_at IS NULL OR expires_at > ${p}))"
+            ));
+        }
+        // v4.5 — confidence floor (NUMERIC weight compared via float8;
+        // NULL weight excluded when a floor is set).
+        if let Some(floor) = filter.confidence_floor {
+            params.push(Box::new(floor));
+            where_parts.push(format!(
+                "(weight IS NOT NULL AND weight::float8 >= ${})",
+                params.len()
+            ));
+        }
+        // v4.5 — subject membership (subject_key_ids JSONB array ? element).
+        if let Some(subj) = &filter.subject_key_id {
+            params.push(Box::new(subj.clone()));
+            where_parts.push(format!("(subject_key_ids ? ${})", params.len()));
+        }
         // §4.3 scope gate — federation_attestations carries cohort_scope
         // (V056) + attested_key_id (target identity, V055).
         {
@@ -19945,6 +19984,145 @@ mod tests {
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
             "got: {err:?}"
+        );
+    }
+
+    /// v4.5 attestation_query filters on live PG — exercises the
+    /// PG-specific SQL: `->>'dimension' LIKE`, `weight::float8 >=`, and
+    /// the `subject_key_ids ? $n` JSONB-array-membership operator.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_attestation_query_filters() {
+        use crate::ceg::ReadEngine;
+        use crate::federation::FederationDirectory;
+        use crate::read::AttestationFilter;
+        use crate::store::backend::Backend;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let occ = format!("occ-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &occ,
+                    "registry",
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+
+        let seed = |id: uuid::Uuid,
+                    dim: &'static str,
+                    weight: f64,
+                    subjects: serde_json::Value,
+                    expires: Option<chrono::DateTime<chrono::Utc>>| {
+            let occ = occ.clone();
+            let backend = &backend;
+            async move {
+                let client = backend.get_client().await.unwrap();
+                let env = serde_json::json!({"id": id.to_string(), "dimension": dim, "score": 1.0});
+                let empty: Vec<u8> = Vec::new();
+                let asserted = "2026-05-01T00:00:00Z"
+                    .parse::<chrono::DateTime<chrono::Utc>>()
+                    .unwrap();
+                client.execute(
+                    "INSERT INTO cirislens.federation_attestations (\
+                        attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                        weight, asserted_at, expires_at, attestation_envelope, original_content_hash, \
+                        scrub_signature_classical, scrub_signature_pqc, scrub_key_id, scrub_timestamp, \
+                        pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, \
+                        cohort_scope, tier, promoted_at\
+                     ) VALUES ($1, $2, $2, 'scores', $3::float8::numeric, $4, $5, $6, $7, \
+                              'sig', NULL, $2, $4, NULL, '0', $8, NULL, 'federation', 'federation', NULL)",
+                    &[&id, &occ, &weight, &asserted, &expires, &env, &empty, &subjects],
+                ).await.unwrap();
+            }
+        };
+        let (a, b, c, d) = (
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+        );
+        seed(a, "config:filter:v1", 0.9, serde_json::json!([]), None).await;
+        seed(b, "config:other:v1", 0.4, serde_json::json!([]), None).await;
+        seed(
+            c,
+            "goal:x:v1",
+            0.95,
+            serde_json::json!(["subj-1"]),
+            "2030-01-01T00:00:00Z".parse().ok(),
+        )
+        .await;
+        seed(
+            d,
+            "goal:y:v1",
+            0.7,
+            serde_json::json!([]),
+            "2026-05-02T00:00:00Z".parse().ok(),
+        )
+        .await;
+
+        let q = |mut f: AttestationFilter| {
+            let backend = &backend;
+            let occ = occ.clone();
+            async move {
+                // Scope to THIS run's rows (shared PG DB holds other tests').
+                f.attesting_key_id = Some(occ);
+                let mut ids: Vec<String> = backend
+                    .list_attestations(f, None, 100, crate::scope::CallerScope::Unauthenticated)
+                    .await
+                    .unwrap()
+                    .items
+                    .into_iter()
+                    .map(|a| a.attestation_id)
+                    .collect();
+                ids.sort();
+                ids
+            }
+        };
+        let mut want_config = vec![a.to_string(), b.to_string()];
+        want_config.sort();
+        assert_eq!(
+            q(AttestationFilter {
+                dimension_prefixes: vec!["config:".into()],
+                ..Default::default()
+            })
+            .await,
+            want_config
+        );
+        let mut want_floor = vec![a.to_string(), c.to_string()];
+        want_floor.sort();
+        assert_eq!(
+            q(AttestationFilter {
+                confidence_floor: Some(0.8),
+                ..Default::default()
+            })
+            .await,
+            want_floor
+        );
+        assert_eq!(
+            q(AttestationFilter {
+                subject_key_id: Some("subj-1".into()),
+                ..Default::default()
+            })
+            .await,
+            vec![c.to_string()]
+        );
+        let at = "2026-05-03T00:00:00Z".parse().unwrap();
+        let mut want_valid = vec![a.to_string(), b.to_string(), c.to_string()]; // d expired
+        want_valid.sort();
+        assert_eq!(
+            q(AttestationFilter {
+                valid_at: Some(at),
+                ..Default::default()
+            })
+            .await,
+            want_valid
         );
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -8227,6 +8227,48 @@ impl crate::read::ReadEngine for SqliteBackend {
                 "pqc_completed_at IS NULL".to_owned()
             });
         }
+        // v4.5 (CEG §10.1.5.4) — open-vocab dimension-prefix filter
+        // (OR-combined LIKE on the envelope dimension).
+        if !filter.dimension_prefixes.is_empty() {
+            let mut ors: Vec<String> = Vec::new();
+            for p in &filter.dimension_prefixes {
+                // LIKE prefix%: escape % and _ in the prefix, then append %.
+                let esc = p
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_");
+                binds.push(SqlValue::Text(format!("{esc}%")));
+                ors.push(format!(
+                    "json_extract(attestation_envelope, '$.dimension') LIKE ?{} ESCAPE '\\'",
+                    binds.len()
+                ));
+            }
+            parts.push(format!("({})", ors.join(" OR ")));
+        }
+        // v4.5 — point-in-time validity.
+        if let Some(va) = filter.valid_at {
+            binds.push(SqlValue::Text(va.to_rfc3339()));
+            let p = binds.len();
+            parts.push(format!(
+                "(asserted_at <= ?{p} AND (expires_at IS NULL OR expires_at > ?{p}))"
+            ));
+        }
+        // v4.5 — confidence floor (NULL weight excluded when a floor is set).
+        if let Some(floor) = filter.confidence_floor {
+            binds.push(SqlValue::Real(floor));
+            parts.push(format!(
+                "(weight IS NOT NULL AND weight >= ?{})",
+                binds.len()
+            ));
+        }
+        // v4.5 — subject membership (subject_key_ids is a JSON array TEXT).
+        if let Some(subj) = &filter.subject_key_id {
+            binds.push(SqlValue::Text(subj.clone()));
+            parts.push(format!(
+                "EXISTS (SELECT 1 FROM json_each(subject_key_ids) WHERE value = ?{})",
+                binds.len()
+            ));
+        }
         // §4.3 scope gate — federation_attestations carries cohort_scope
         // (V056) + attested_key_id (the row's target identity, V055). The
         // gate compares the row's cohort_scope/attested_key_id against the
@@ -12094,6 +12136,107 @@ mod tests {
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
             "got: {err:?}"
+        );
+    }
+
+    /// v4.5 attestation_query filters (CEG §10.1.5.4) — dimension prefix,
+    /// valid_at, confidence_floor, subject. Raw-inserts federation rows
+    /// (bypasses write admission) to exercise the read filters directly.
+    #[tokio::test]
+    async fn sqlite_attestation_query_filters() {
+        use crate::ceg::ReadEngine;
+        let backend = fresh_backend_with_occurrence("occ").await;
+        let seed = |id: &str, dim: &str, weight: f64, subjects: &[&str], expires: Option<&str>| {
+            let conn = backend.conn_handle();
+            let conn = conn.lock();
+            let env = serde_json::json!({"id": id, "dimension": dim, "score": 1.0}).to_string();
+            let subj = serde_json::to_string(subjects).unwrap();
+            conn.execute(
+                "INSERT INTO federation_attestations (\
+                    attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                    weight, asserted_at, expires_at, attestation_envelope, original_content_hash, \
+                    scrub_signature_classical, scrub_signature_pqc, scrub_key_id, scrub_timestamp, \
+                    pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, \
+                    cohort_scope, tier, promoted_at\
+                 ) VALUES (?1, 'occ', 'occ', 'scores', ?2, '2026-05-01T00:00:00Z', ?3, ?4, x'', \
+                          'sig', NULL, 'occ', '2026-05-01T00:00:00Z', NULL, '0', ?5, NULL, \
+                          'federation', 'federation', NULL)",
+                rusqlite::params![id, weight, expires, env, subj],
+            )
+            .unwrap();
+        };
+        seed("a", "config:filter:v1", 0.9, &[], None);
+        seed("b", "config:other:v1", 0.4, &[], None);
+        seed(
+            "c",
+            "goal:x:v1",
+            0.95,
+            &["subj-1"],
+            Some("2030-01-01T00:00:00Z"),
+        );
+        seed("d", "goal:y:v1", 0.7, &[], Some("2026-05-02T00:00:00Z")); // expires early
+
+        let q = |f: AttestationFilter| {
+            let backend = &backend;
+            async move {
+                let mut ids: Vec<String> = backend
+                    .list_attestations(f, None, 100, crate::scope::CallerScope::Unauthenticated)
+                    .await
+                    .unwrap()
+                    .items
+                    .into_iter()
+                    .map(|a| a.attestation_id)
+                    .collect();
+                ids.sort();
+                ids
+            }
+        };
+
+        // dimension prefix.
+        assert_eq!(
+            q(AttestationFilter {
+                dimension_prefixes: vec!["config:".into()],
+                ..Default::default()
+            })
+            .await,
+            vec!["a", "b"]
+        );
+        // multiple prefixes OR-combine.
+        assert_eq!(
+            q(AttestationFilter {
+                dimension_prefixes: vec!["config:filter".into(), "goal:".into()],
+                ..Default::default()
+            })
+            .await,
+            vec!["a", "c", "d"]
+        );
+        // confidence floor (NULL excluded; b at 0.4 dropped).
+        assert_eq!(
+            q(AttestationFilter {
+                confidence_floor: Some(0.8),
+                ..Default::default()
+            })
+            .await,
+            vec!["a", "c"]
+        );
+        // subject membership.
+        assert_eq!(
+            q(AttestationFilter {
+                subject_key_id: Some("subj-1".into()),
+                ..Default::default()
+            })
+            .await,
+            vec!["c"]
+        );
+        // valid_at: at 2026-05-03, d has expired (expires 05-02); a/b no expiry, c future.
+        let at = "2026-05-03T00:00:00Z".parse().unwrap();
+        assert_eq!(
+            q(AttestationFilter {
+                valid_at: Some(at),
+                ..Default::default()
+            })
+            .await,
+            vec!["a", "b", "c"]
         );
     }
 


### PR DESCRIPTION
The uniform dimension-aware attestation read (CIRISPersist#171, CEG §10.1.5.4) — the read the agent's memory/config/consent/audit services wrap over, and the same read NodeCore/LensCore/Registry use.

Built as **additive fields on `AttestationFilter`**, riding the existing scope-gated, cursor-paged `ReadEngine::list_attestations` + its PyO3 JSON wrapper — **no new method, no new result type, no new PyO3 surface**. No signing involved, so this is **independent of the v4.5 JCS flip** (FSD #174).

## Added — `AttestationFilter` query fields
- **`dimension_prefixes`** — open-vocabulary, hierarchical-prefix-matched (`attestation_envelope->>'dimension' LIKE 'prefix%'`, OR-combined; `%`/`_`/`\` escaped). Validated structurally, **not** a closed enum (the OQ-2 "open data, closed operators" resolution) — new CEG dimension families work with no redeploy.
- **`valid_at`** — point-in-time validity (`asserted_at <= valid_at < COALESCE(expires_at, +inf)`).
- **`confidence_floor`** — `weight >= floor` (NULL weight excluded; PG via `weight::float8`).
- **`subject_key_id`** — subject membership (PG `subject_key_ids ? $n`; SQLite `json_each`).

All AND-compose with the existing `attesting`/`attested`/`type`/`pqc` filters + the §4.3 cohort gate + the v4.4 tier gate. The agent reads its own local (`self`-cohort) + federation rows by dimension through one call.

## Note
`AttestationFilter` drops its `Eq` derive (`confidence_floor: Option<f64>` is not `Eq`); keeps `PartialEq`. Source-incompatible only for code relying on `AttestationFilter: Eq`.

## Tests
Both backends (live PG + SQLite): dimension-prefix (single + OR), confidence-floor (NULL-excluded), subject membership, point-in-time validity. **1037 lib tests green on live PG**; `-D warnings` clean across no-backend / `test-panic,pyo3` / full; clippy clean over `--tests`. Ships as **4.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)