### PR TITLE
v4.6.0 — JCS canonicalization cutover surface (#171, #176, CEG §0.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.6.0] — 2026-06-09
+
+**JCS (RFC 8785) canonicalization cutover — foundation + signed-epoch version gate + `attestation_promote` (CIRISPersist#171/#176; CEG 1.0 §0.9; FSD `V4_6_JCS_CANONICALIZATION.md`).**
+
+persist becomes §0.9-ready. The blocker this closes: persist signs/verifies with `PythonJsonDumpsCanonicalizer` (`json.dumps(sort_keys=True, ensure_ascii=True)`), which is byte-identical to JCS *only* for pure-ASCII — the agent measured 2/6 real traces byte-identical, breaking on non-English `thought_content`/`rationale` and the `⚠️` disclosure emoji. This cut lands the JCS machinery **flip-ready but inert** (produce stays Python until the one-line cutover at the 2.9.6 substrate triple), plus the mandatory signed-epoch version gate so pre-cut Python rows stay verifiable forever, plus `attestation_promote` (the #171 phase-2 piece JCS unblocks). **persist 4.6 ships FIRST**; the agent validates byte-identity via CIRISConformance#9, then bumps pins (OQ-4).
+
+### Added — JCS foundation (`verify/canonical.rs`)
+- **`JcsCanonicalizer`** — wraps `ciris_verify_core::jcs::canonicalize` (CIRISVerify v4.11.0, the single cross-impl-blessed JCS impl; OQ-1). No second JCS impl to keep in lockstep.
+- **`CanonVersion {V1Python, V2Jcs}`** + **`canonicalizer_for(version) -> &'static dyn Canonicalizer`** (static dispatch over `PYTHON_CANON`/`JCS_CANON`).
+- **`produce_canon_version() -> CanonVersion`** — `const`, returns `V1Python` until the 2.9.6 cutover (a one-line flip to `V2Jcs`). **`ceg_produce_canonicalize(value)`** is the single produce-side entry point; behavior-preserving today.
+
+### Added — signed-epoch version gate (the mandatory OQ-5 piece)
+The canonicalizer is selected by each row's **signed, attacker-uncontrollable** discriminator, NOT a caller flag:
+- **Traces** (`verify/ed25519.rs::canon_version_for_trace_schema`): `trace_schema_version` major ≥ 3 → JCS, else Python. Wired into production trace verify (`server/pipeline.rs`, `ingest.rs`). Inert until 3.x enters `SUPPORTED_VERSIONS`.
+- **`persist_row_hash` stays Python (OQ-2)** — internal-only, never crosses the federation boundary; flipping it would break existing rows' integrity recompute. The ingest component scrub-diff likewise stays Python (not a boundary signing surface; FSD §scope).
+
+### Added — `Engine::attestation_promote(attestation_id) -> Result<bool>` (#171 phase 2)
+Promotes a **local**-tier self-attestation to **federation** tier: canonicalize the envelope via the produce gate → `sha256` → `Engine::sign_hybrid` (Ed25519 + ML-DSA-65) → write the scrub envelope + flip `tier=federation` + stamp `promoted_at`. The signing bytes are the §0.9-canonical envelope, so a promoted row is byte-identical on the wire to a natively-federation attestation (Registry must #1 holds once JCS is live). Idempotent: re-promoting a `federation` row returns `Ok(false)`. New `FederationDirectory::{get_attestation, promote_attestation}` on all three backends (Postgres / SQLite / memory). PyO3 binding deferred pending the agent-facing shape decision (synchronous-hybrid vs. classical-write-then-PQC-sweep) — Engine + storage surface is complete and tested.
+
+### Fixed — latent Postgres UUID-serialization bug on the deferred-PQC completion path
+`attach_attestation_pqc_signature` / `attach_revocation_pqc_signature` bound a `&str` against a `$N::uuid` param — which panics with `error serializing parameter 0` on real Postgres. These run in production via `Engine.run_pqc_sweep` (PyO3), but were covered **only** on the in-memory backend (string-keyed map, never exercised the driver), so the bug was invisible. Both now parse to `uuid::Uuid` before binding (the proven `put_revocation` pattern). **CI gap closed** with a live-PG attach round-trip test for both paths.
+
+### Tests
+- `attestation_promote` round-trip on **both** backends (SQLite + live PG): `local → promote → tier=federation` + hybrid scrub envelope populated + 64-hex `original_content_hash` + `promoted_at` stamped + envelope untouched + idempotent re-promote; missing-row → `InvalidArgument`.
+- JCS foundation: production-JCS-matches-RFC8785-reference, version-gate routing, the agent-measured divergence corpus, trace-schema major-version gate.
+- **1045 lib tests green on SQLite, 747 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full `--tests`; clippy clean.
+
+### Migration / lockstep
+Behavior is **unchanged** this release — produce stays Python, verify already gates per-row. The cutover is a separate, coordinated event: at the **2.9.6 substrate triple** (agent 3.0 JCS + persist 4.6 + ciris-verify 4.11.0 + edge + lens), flip `produce_canon_version()` to `V2Jcs`. **Upstream ask (OQ-1):** CIRISVerify must expose `jcs::canonicalize` as a Python binding so the agent producer canonicalizes byte-identically.
+
 ## [4.5.0] — 2026-06-09
 
 **Shared CEG attestation surface — `attestation_query` filters (CIRISPersist#171; CEG 0.15 §10.1.5.4).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.5.0"
+version = "4.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/FSD/V4_6_JCS_CANONICALIZATION.md
+++ b/FSD/V4_6_JCS_CANONICALIZATION.md
@@ -1,0 +1,92 @@
+# FSD: CIRISPersist — JCS (RFC 8785) canonicalization flip — the CEG 1.0 §0.9 conformance milestone
+
+**Status:** **ACCEPTED (CIRISAgent ✅, conditional — folded in 2026-06-09).** Ships as **persist v4.6.0**, which lands FIRST; the agent validates byte-identity via CIRISConformance#9, then bumps pins at the **2.9.6 substrate triple** (agent 3.0 JCS + persist 4.6 + ciris-verify 4.11.0 + edge + lens). The lockstep go-forward cut is safe in every language. **Two conditions from the agent review, both folded:** (1) the "ASCII-identity dividend" framing was *wrong* — the agent signs `ensure_ascii=True`, so Python-compat ⊥ JCS on **all** non-ASCII (agent measured 2/6 byte-identical, §0); (2) OQ-5's signed-epoch **version gate is MANDATORY and part of this cut**, not a follow-up.
+**Author:** Eric Moore (CIRIS Team) with Claude Opus 4.8
+**Created:** 2026-06-09
+**Repo:** `~/CIRISPersist`
+**Target cut:** **v4.6.0** (the canonicalizer flip + the signed-epoch version gate) — gates `attestation_promote` and persist's CEG 1.0 / agent-3.0 readiness. (v4.5.0 shipped only `attestation_query`; the production canonicalizer is still Python-compat.)
+**Risk:** **Breaking, federation-wide, bidirectionally coupled.** persist both *produces* signatures (attestations, keys, outbound replication) and *verifies* producer signatures (agent trace ingest). The signing bytes change for non-ASCII envelopes. persist MUST flip in **lockstep** with the agent's 3.0 RFC-8785 flip (and lens/registry), or each side fails to verify the other.
+**Normative anchor:** CEG 0.15 **§0.9** ("A CEG-Conforming Producer MUST produce signing bytes via JCS [RFC 8785] over the envelope object; a CEG-Conforming Consumer MUST recompute via the same JCS rule"). The §0.9 mandate is *global* — Python-compat canonicalization is non-conformant everywhere it feeds a CEG signature.
+**Driving context:** CIRISVerify is agent-3.0 / ceg-1.0 ready (shipped `ciris_verify_core::jcs`, v4.11.0). persist is the next link in the chain. CIRISAgent#840 (CEG-native agent, 3.0) is the lockstep counterpart. Blocks CIRISPersist#171 phase 2 (`attestation_promote` — OQ-4 requires JCS).
+
+---
+
+## 0. TL;DR for reviewers
+
+persist canonicalizes every CEG signing payload with **`PythonJsonDumpsCanonicalizer`** — sorted-key `json.dumps`, which the code itself documents as *"not RFC 8785 JCS"* and whose flip is *"gated on the agent flip\[ping] to JCS."* CEG §0.9 mandates **JCS**. This FSD flips persist's CEG signing/verifying canonicalizer **Python-compat → JCS** (`Rfc8785Canonicalizer`, already implemented in-tree; or `ciris_verify_core::jcs`, pinned v4.11.0). The flip is the §0.9 conformance milestone and the precondition for `attestation_promote`.
+
+**The one hard fact that shapes everything:** persist *verifies* agent trace signatures (`ingest.rs`) and *produces* its own (attestations/keys/replication). So this is not a unilateral persist change — it is a **coordinated, simultaneous flip** with the agent (3.0) and the other CEG-RC1 impls.
+
+**Parity reality (corrected by the CIRISAgent #174 measurement — the draft's "ASCII-identity dividend" was wrong).** The agent signs with `json.dumps(sort_keys=True, separators=(",",":"))` and **no `ensure_ascii` argument** → Python's default **`ensure_ascii=True`**, which `\uXXXX`-escapes every non-ASCII codepoint. persist's `PythonJsonDumpsCanonicalizer` escapes identically, so it matches the agent today *in every language*. **JCS (RFC 8785 §3.2.2.2) emits raw UTF-8** for non-ASCII. Therefore Python-compat ⊥ JCS on **every non-ASCII character** — *not* merely the non-BMP tail. The agent measured **2/6 byte-identical** over realistic 9-field traces: ✅ pure-ASCII GENERIC/DETAILED en; ❌ every non-English `thought_content`/`rationale` (am/zh/ar) **and** any English trace carrying the `⚠️` attestation-disclosure emoji (fires at GENERIC). So the breaking corpus is the **majority** of a 29-language reasoner's stream, not an edge case.
+
+**What that does to the cut:** the **go-forward** path (new traces signed under JCS) is clean and language-independent — both sides flip together at 2.9.6, so agent-JCS ≡ persist-JCS in any locale. The **backward** path (verifying pre-cut Python-signed rows after the flip) breaks for all that non-ASCII corpus → a **mandatory, signed-epoch-bound version gate** (OQ-5) selects the legacy canonicalizer for pre-cut rows. The pure-ASCII identity still buys one thing: ASCII traffic (most keys/scores/hashes/ISO timestamps) needs no gate either way.
+
+---
+
+## 1. Why this exists — the mission case
+
+### 1.1 The gap
+`src/verify/canonical.rs` is explicit: the production canonicalizer is `PythonJsonDumpsCanonicalizer`, and *"unless the agent flips to JCS, the lens must produce \[Python-compat]"* — the canonicalizer choice is deliberately **slaved to the agent**. CEG §0.9 makes JCS mandatory for every CEG-conforming producer and consumer. So **persist is not §0.9-conformant**, and cannot be until it flips — which it cannot safely do until the agent flips (it verifies the agent's signatures). Verify shipping `jcs` (4.11.0) + declaring ceg-1.0-readiness is the signal that the chain is flipping; persist is next.
+
+### 1.2 Alignment against MISSION.md
+- **§1.1 / §1.5** — one canonicalization rule across every tier and impl is the integrity floor; a federation cannot measure a corpus it cannot consistently verify.
+- **§1.4 apophatic bound** — JCS is a *fixed, externally-specified* rule (RFC 8785), not a persist invention; adopting it removes a persist-local quirk, it does not add a knob.
+- **§1.6 fail-honest** — a canonicalizer mismatch is a *silent* whole-signature failure (the worst class, same as the nonce/wrap encodings #63/#64). Pinning JCS closes a silent-divergence surface.
+- **§1.7** — persist records/verifies what the chain signs; it must use the chain's canonicalization, not its own.
+
+---
+
+## 2. Scope — the flip surface
+
+Every site where persist computes canonical bytes that feed a **CEG signature or content-hash crossing the federation boundary**:
+
+| Site | Direction | Today | Risk |
+|---|---|---|---|
+| `ingest.rs` (trace verify) | **verify** agent signatures | Python-compat | **Lockstep** — must match what the agent 3.0 signs |
+| `engine.rs` (attestation / key / withdraws / blob-signing `original_content_hash`) | **produce** | Python-compat | Peers verifying persist-produced rows must use the same |
+| `queue.rs` + `federation/replication/mod.rs` (outbound replication envelopes) | **produce** | Python-compat | Replication peers must match |
+| FFI `canonicalize_envelope` (pyo3) | **producer-facing** | Python-compat | Python callers sign over this — flipping changes their bytes |
+| `types.rs` `compute_persist_row_hash` / `original_content_hash` | internal + boundary | Python-compat | `original_content_hash` is boundary (signed); `persist_row_hash` is internal-only (may stay) |
+
+**In scope:** flip the boundary-crossing signing/verifying sites to JCS. **Out of scope (named):** the purely-internal `persist_row_hash` integrity hash MAY stay Python-compat (it never crosses the federation boundary) — decided in OQ-2.
+
+`Rfc8785Canonicalizer` (in-tree, `serde_json_canonicalizer` 0.3) is a working impl; `ciris_verify_core::jcs::canonicalize` (v4.11.0) is the cross-impl-blessed one. **OQ-1: one or the other** — prefer the Verify module so persist and Verify share the exact bytes (no second JCS impl to keep in lockstep).
+
+## 3. The migration strategy — the load-bearing decision
+
+The corpus already holds Python-signed rows/traces; the agent already emits Python-signed traces. A hard cut breaks verification of everything signed before the flip (for non-ASCII payloads). Three candidate strategies (**OQ-3, the central open question**):
+
+- **(A) Lockstep hard cut.** persist + agent + lens + registry flip at one coordinated version boundary (agent 3.0 / persist 4.5 / ceg 1.0). Simplest contract; requires the federation to cut together and accepts that pre-cut non-ASCII rows verify only under the legacy rule (a dated `valid_from`/version gate selects the canonicalizer).
+- **(B) Dual-verify transition.** persist verifies under JCS, falling back to Python-compat on failure (and vice-versa), for a bounded window; produces JCS only. Tolerates mixed-version peers; doubles verify cost in the window; needs a sunset.
+- **(C) Version-tagged envelopes.** Every envelope carries a `canon: jcs|python` tag; verifier picks the canonicalizer per-row. Most robust, but a wire-format addition (touches §4 — heavier CEG change).
+
+**RESOLVED (agent + persist): (A) hard cut + a MANDATORY signed-epoch version gate.** The chain cuts to ceg-1.0 together (agent 3.0 / persist 4.6 / verify 4.11), so go-forward is (A). But because the breaking corpus is the *majority* (not a tail — §0), (A) is **not** naked: pre-cut rows MUST verify under the legacy canonicalizer, selected by a **signed-epoch-bound** discriminator (attacker-uncontrollable per the §6 downgrade guard), bounded by the agent's trace-retention window, after which the legacy path sunsets. (B) bounded dual-verify stays the known-shape fallback — persist already runs a 2-field→9-field *try-both* accept window at ingest, so the dual-canonicalizer machinery is familiar. (C) version-tag-in-envelope is rejected (it touches §4 wire format).
+
+**The version-gate mechanism (persist proposes; agent validates at the 2.9.6 pin-bump).** persist selects Python-compat vs JCS per row using a discriminator that is *inside the signed bytes* (so it cannot be downgraded): the row's signed schema/epoch. Concretely — gate on the signed `schema_version` / `crypto_kind` the producer stamps at the flip (agent 3.0 bumps it), with a pinned boundary; pre-boundary → Python-compat, at/after → JCS. The exact field + boundary value is pinned with the agent during the Conformance#9 byte-identity validation before they bump pins.
+
+## 4. `attestation_promote` rides on this (CIRISPersist#171 phase 2)
+Once the signing canonicalizer is JCS, `attestation_promote` is unblocked and trivial: load the `local` row → `jcs::canonicalize(attestation_envelope)` → `Engine::sign_hybrid` → write the scrub envelope + flip `tier=federation` (Registry must #1 byte-identity now holds, because native rows are *also* JCS). promote lands in the same v4.5 cut or immediately after.
+
+## 5. Backend / parity
+The canonicalizer is backend-agnostic (it runs above the store). Both backends already call the same `canonicalize_value` sites; the flip is a single canonicalizer swap, parity-preserving. The existing `ascii_only_python_matches_jcs` parity test extends into a conformance vector set (composes with CIRISConformance#9's RFC 8785 vectors).
+
+## 6. Threat / conformance
+- **AV-63 (canonicalizer-mismatch silent failure)** — a producer and consumer disagreeing on the canonicalizer yields a silent whole-signature failure (forged-rejection or, worse, a mismatch read as tampering). Closed by pinning JCS chain-wide + the shared `ciris_verify_core::jcs` impl + the conformance vector set. Same hazard class as #63/#64.
+- **Downgrade guard** — under any transition strategy, the flip MUST NOT let an attacker force the weaker/legacy canonicalizer to bypass a check; the version gate is signed-bytes-bound, not caller-selectable.
+
+## 7. Open questions — resolved by the CIRISAgent #174 review
+- **OQ-1 — which JCS impl. ✅ `ciris_verify_core::jcs`** (single blessed impl shared Rust-side). Agent ask folded: **CIRISVerify must also expose that same impl as a Python binding** so the agent's producer side canonicalizes byte-identically (the agent has no JCS lib today). One impl across Rust + the Python producer, or we reintroduce the divergence this FSD closes. → upstream ask on CIRISVerify.
+- **OQ-2 — `persist_row_hash`. ✅ leave Python-compat.** Internal-only, never crosses the boundary; flipping it would break existing rows' integrity recompute. Flip ONLY boundary-crossing sites. Agent agrees (it never touches `persist_row_hash`).
+- **OQ-3 — migration strategy. ✅ (A) hard cut + MANDATORY signed-epoch version gate** (§3). Not (A)-naked — the breaking corpus is the majority, so the legacy path is required, bounded by retention then sunset.
+- **OQ-4 — lockstep timing. ✅ NOT live yet; cut boundary = the 2.9.6 substrate triple** (agent 3.0 JCS + persist 4.6 + verify 4.11 + edge + lens). **persist 4.6 ships FIRST**; the agent validates byte-identity via Conformance#9, then bumps pins. Agent hard-veto satisfied.
+- **OQ-5 — legacy rows. ✅ REQUIRED, version-gate-by-signed-epoch** (this cut, not a follow-up). Re-signing is unavailable (the agent doesn't retain pre-cut canonical state); the canonicalizer is selected by the row's signed epoch (attacker-uncontrollable), bounded by trace retention, then the legacy path sunsets.
+
+## 8. Reviewers — status
+This is the signing contract — the **whole chain** agrees, not just persist's usual consumers:
+- **CIRISAgent (#840, 3.0)** — **✅ NOD (conditional, both conditions folded):** the lockstep go-forward cut is safe in every language; conditions = (1) fix the false ASCII-identity premise (done, §0 + `canonical.rs`), (2) the version gate is part of this cut (done, §3/OQ-5). Confirmed the 2.9.6 boundary + persist-4.6-first + OQ-1 shared impl. Offered the multilingual + `⚠️`-disclosure vectors to Conformance#9.
+- **CIRISVerify** — owns the shared `jcs` impl; persist consumes `ciris_verify_core::jcs` (OQ-1). **Open ask:** expose the same impl as a Python binding for the agent producer.
+- **CIRISRegistry (CEG authority)** — §0.9 conformance. (C) version-tag rejected, so no §4 wire change.
+- **CIRISLensCore** — also verifies/produces CEG signatures; flips in the same 2.9.6 lockstep.
+- **CIRISConformance#9** — the cross-impl RFC 8785 vector set (+ the agent's multilingual / `⚠️` vectors) that proves byte-identity before the agent bumps pins.
+
+**Accepted.** persist builds 4.6 (the flip + the signed-epoch version gate), ships first, and the chain validates via Conformance#9 before the 2.9.6 pin-bump. `attestation_promote` follows on the JCS foundation.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -856,6 +856,90 @@ impl Engine {
         Ok(sig)
     }
 
+    /// v4.6 (CIRISPersist#171 phase 2, CEG §10.1.3/§10.1.5) — promote a
+    /// **local**-tier self-attestation to **federation**: canonicalize the
+    /// row's envelope through the produce-side gate (JCS post-cut, §0.9),
+    /// hybrid-sign the canonical bytes (Ed25519 + ML-DSA-65), and write
+    /// back the scrub envelope + flip `tier` to `federation`. The signing
+    /// bytes are the §0.9-canonical envelope, so the promoted row is
+    /// byte-identical on the wire to a natively-federation attestation
+    /// (Registry must #1). Returns `Ok(true)` on promotion, `Ok(false)` if
+    /// the row is already `federation` (idempotent). Requires a
+    /// PQC-configured `LocalSigner`.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn attestation_promote(
+        &self,
+        attestation_id: &str,
+    ) -> Result<bool, crate::federation::Error> {
+        use crate::federation::FederationDirectory;
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+        use sha2::{Digest, Sha256};
+
+        // 1. Load the row (any tier).
+        let row = match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.get_attestation(attestation_id).await?,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.get_attestation(attestation_id).await?,
+        }
+        .ok_or_else(|| {
+            crate::federation::Error::InvalidArgument(format!(
+                "attestation_promote: row {attestation_id} does not exist"
+            ))
+        })?;
+        if row.tier == crate::federation::types::attestation_tier::FEDERATION {
+            return Ok(false); // idempotent
+        }
+
+        // 2. Canonicalize the envelope (produce gate → JCS post-cut) + hash.
+        let canonical = crate::verify::canonical::ceg_produce_canonicalize(
+            &row.attestation_envelope,
+        )
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!("attestation_promote canonicalize: {e}"))
+        })?;
+        let original_content_hash_hex = hex::encode(Sha256::digest(&canonical));
+
+        // 3. Hybrid-sign the canonical bytes (matches the native produce
+        // path: signer.sign(canonical_bytes)).
+        let sig = self.sign_hybrid(&canonical).await.map_err(|e| {
+            crate::federation::Error::Backend(format!("attestation_promote sign_hybrid: {e}"))
+        })?;
+        let classical_b64 = B64.encode(&sig.classical.signature);
+        let pqc_b64 = B64.encode(&sig.pqc.signature);
+        let scrub_key_id = self.signer.current_alias().to_owned();
+        let now = chrono::Utc::now();
+
+        // 4. Write back the scrub envelope + flip tier (signed-epoch gate
+        // on the verify side will read these post-cut as JCS).
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => {
+                b.promote_attestation(
+                    attestation_id,
+                    &classical_b64,
+                    Some(&pqc_b64),
+                    &original_content_hash_hex,
+                    &scrub_key_id,
+                    now,
+                )
+                .await
+            }
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => {
+                b.promote_attestation(
+                    attestation_id,
+                    &classical_b64,
+                    Some(&pqc_b64),
+                    &original_content_hash_hex,
+                    &scrub_key_id,
+                    now,
+                )
+                .await
+            }
+        }
+    }
+
     /// Borrow the SQLite backend Arc, if this Engine was constructed
     /// with a `sqlite://` DSN. Returns `None` for Postgres-backed
     /// Engines (or when the `sqlite` feature is off).
@@ -3966,5 +4050,261 @@ mod tests {
             empty_holder_count as u64 >= report.rows_evicted,
             "evicted blobs must have list_holders return empty after withdraws"
         );
+    }
+
+    // ── v4.6.0 (CIRISPersist#171, CEG §10.1.5) — attestation_promote:
+    //    local-tier self-attestation → federation-tier hybrid-signed row.
+
+    /// PQC-configured signer whose classical alias is `occ`, so the
+    /// producing occurrence (`attesting_key_id`) and the promotion
+    /// signer (`scrub_key_id = current_alias()`) are the same
+    /// federation key — one seeded `federation_keys` row satisfies both
+    /// FKs. `attestation_promote` calls `sign_hybrid`, so PQC is required.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    fn pqc_signer(alias: &str) -> Arc<LocalSigner> {
+        use ciris_keyring::MlDsa65SoftwareSigner;
+        let signing_key = SigningKey::from_bytes(&[0x5Au8; 32]);
+        let pqc = MlDsa65SoftwareSigner::from_seed_bytes(&[0x5Au8 ^ 0x55; 32], "promote-test-pqc")
+            .expect("pqc seed");
+        let pqc_arc: Arc<dyn ciris_keyring::PqcSigner> = Arc::new(pqc);
+        Arc::new(LocalSigner::from_parts(
+            signing_key,
+            alias.to_owned(),
+            Some(pqc_arc),
+            Some("promote-test-pqc".to_owned()),
+        ))
+    }
+
+    /// Seed a `federation_keys` row for `key_id` so the local-tier write
+    /// gate's `attesting_key_id` FK and the promote path's `scrub_key_id`
+    /// FK both hold.
+    #[cfg(feature = "sqlite")]
+    async fn seed_promote_key(sq: &Arc<SqliteBackend>, key_id: &str) {
+        use crate::federation::{FederationDirectory, KeyRecord, SignedKeyRecord};
+        let record = KeyRecord {
+            key_id: key_id.into(),
+            pubkey_ed25519_base64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
+            pubkey_ml_dsa_65_base64: None,
+            algorithm: crate::federation::types::algorithm::HYBRID.into(),
+            identity_type: crate::federation::types::identity_type::STEWARD.into(),
+            identity_ref: key_id.into(),
+            valid_from: "2026-05-01T00:00:00Z".parse().unwrap(),
+            valid_until: None,
+            registration_envelope: serde_json::json!({ "id": key_id }),
+            original_content_hash: "deadbeef".into(),
+            scrub_signature_classical: "c2lnbmF0dXJl".into(),
+            scrub_signature_pqc: None,
+            scrub_key_id: key_id.into(),
+            scrub_timestamp: "2026-05-01T00:00:00Z".parse().unwrap(),
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+        };
+        sq.put_public_key(SignedKeyRecord { record }).await.unwrap();
+    }
+
+    /// Round-trip: write a `local` self-attestation, promote it, confirm
+    /// the row flips to `federation` with a populated hybrid scrub
+    /// envelope, a recomputed `original_content_hash`, and the producing
+    /// occurrence as `scrub_key_id`. A second promote is idempotent
+    /// (`Ok(false)`, no further mutation).
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn attestation_promote_flips_local_to_federation_signed() {
+        use crate::federation::types::attestation_type::SCORES;
+        use crate::federation::FederationDirectory;
+
+        let engine = Engine::with_signer(pqc_signer("occ"), "sqlite::memory:")
+            .await
+            .expect("construct engine");
+        let sq = engine.sqlite_backend().expect("sqlite present").clone();
+        seed_promote_key(&sq, "occ").await;
+
+        // Write a local-tier self-attestation (signature deferred).
+        let input = crate::federation::types::LocalAttestationInput {
+            attesting_key_id: "occ".into(),
+            attested_key_id: None,
+            attestation_type: SCORES.into(),
+            weight: Some(1.0),
+            expires_at: None,
+            attestation_envelope: serde_json::json!({
+                "id": "att-1", "dimension": "identity_binding:v1",
+                "score": 1.0, "confidence": 0.9,
+            }),
+            subject_key_ids: vec![],
+            cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+        };
+        let att_id = sq.attestation_upsert_local(input).await.unwrap();
+
+        // Pre-promote: the row is local with an empty-sentinel scrub.
+        let before = sq.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            before.tier,
+            crate::federation::types::attestation_tier::LOCAL
+        );
+        assert!(before.scrub_signature_classical.is_empty());
+        assert!(before.original_content_hash.is_empty());
+        assert!(before.promoted_at.is_none());
+
+        // Promote.
+        let promoted = engine.attestation_promote(&att_id).await.unwrap();
+        assert!(promoted, "first promote flips the tier");
+
+        let after = sq.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            after.tier,
+            crate::federation::types::attestation_tier::FEDERATION,
+            "tier flips to federation"
+        );
+        assert!(
+            !after.scrub_signature_classical.is_empty(),
+            "Ed25519 scrub signature populated"
+        );
+        assert!(
+            after
+                .scrub_signature_pqc
+                .as_deref()
+                .is_some_and(|s| !s.is_empty()),
+            "ML-DSA-65 scrub signature populated"
+        );
+        assert_eq!(
+            after.original_content_hash.len(),
+            64,
+            "original_content_hash is the hex SHA-256 of the canonical envelope"
+        );
+        assert_eq!(
+            after.scrub_key_id, "occ",
+            "promoter is the producing occurrence"
+        );
+        assert!(after.promoted_at.is_some(), "promoted_at stamped");
+        // Envelope is untouched by promotion (signing reads it, never edits).
+        assert_eq!(after.attestation_envelope, before.attestation_envelope);
+
+        // Idempotent: re-promoting a federation row is a no-op.
+        let again = engine.attestation_promote(&att_id).await.unwrap();
+        assert!(!again, "re-promote of a federation row returns Ok(false)");
+        let after2 = sq.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            after2.scrub_signature_classical, after.scrub_signature_classical,
+            "idempotent re-promote does not re-sign"
+        );
+        assert_eq!(after2.promoted_at, after.promoted_at);
+    }
+
+    /// Promoting a non-existent row is an `InvalidArgument`, not a panic
+    /// or a silent success.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn attestation_promote_missing_row_is_invalid_argument() {
+        let engine = Engine::with_signer(pqc_signer("occ"), "sqlite::memory:")
+            .await
+            .expect("construct engine");
+        let err = engine
+            .attestation_promote("00000000-0000-0000-0000-000000000000")
+            .await
+            .expect_err("missing row");
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("does not exist")),
+            "got: {err:?}"
+        );
+    }
+
+    /// Live-PG twin of `attestation_promote_flips_local_to_federation_signed`.
+    /// Exercises the Postgres `get_attestation` + `promote_attestation`
+    /// backend impls end-to-end through the Engine orchestrator. Skips
+    /// when `CIRIS_PERSIST_TEST_PG_URL` is unset.
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn attestation_promote_flips_local_to_federation_signed_postgres() {
+        use crate::federation::types::attestation_type::SCORES;
+        use crate::federation::{FederationDirectory, KeyRecord, SignedKeyRecord};
+
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        // Unique occurrence key so concurrent/shared-DB runs don't collide.
+        let occ = format!("occ-promote-{}", uuid::Uuid::new_v4().simple());
+
+        let engine = Engine::with_signer(pqc_signer(&occ), &dsn)
+            .await
+            .expect("construct PG engine");
+        let pg = engine.postgres_backend().expect("pg backend");
+
+        // Seed the federation_keys row for both attesting + scrub FKs.
+        let record = KeyRecord {
+            key_id: occ.clone(),
+            pubkey_ed25519_base64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
+            pubkey_ml_dsa_65_base64: None,
+            algorithm: crate::federation::types::algorithm::HYBRID.into(),
+            identity_type: crate::federation::types::identity_type::STEWARD.into(),
+            identity_ref: occ.clone(),
+            valid_from: "2026-05-01T00:00:00Z".parse().unwrap(),
+            valid_until: None,
+            registration_envelope: serde_json::json!({ "id": occ.clone() }),
+            original_content_hash: "deadbeef".into(),
+            scrub_signature_classical: "c2lnbmF0dXJl".into(),
+            scrub_signature_pqc: None,
+            scrub_key_id: occ.clone(),
+            scrub_timestamp: "2026-05-01T00:00:00Z".parse().unwrap(),
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+        };
+        pg.put_public_key(SignedKeyRecord { record }).await.unwrap();
+
+        let input = crate::federation::types::LocalAttestationInput {
+            attesting_key_id: occ.clone(),
+            attested_key_id: None,
+            attestation_type: SCORES.into(),
+            weight: Some(1.0),
+            expires_at: None,
+            attestation_envelope: serde_json::json!({
+                "id": "att-pg-1", "dimension": "identity_binding:v1",
+                "score": 1.0, "confidence": 0.9,
+            }),
+            subject_key_ids: vec![],
+            cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+        };
+        let att_id = pg.attestation_upsert_local(input).await.unwrap();
+
+        let before = pg.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            before.tier,
+            crate::federation::types::attestation_tier::LOCAL
+        );
+        assert!(before.scrub_signature_classical.is_empty());
+        assert!(before.original_content_hash.is_empty());
+
+        let promoted = engine.attestation_promote(&att_id).await.unwrap();
+        assert!(promoted, "first promote flips the tier");
+
+        let after = pg.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            after.tier,
+            crate::federation::types::attestation_tier::FEDERATION
+        );
+        assert!(!after.scrub_signature_classical.is_empty());
+        assert!(after
+            .scrub_signature_pqc
+            .as_deref()
+            .is_some_and(|s| !s.is_empty()));
+        assert_eq!(after.original_content_hash.len(), 64);
+        assert_eq!(after.scrub_key_id, occ);
+        assert!(after.promoted_at.is_some());
+        assert_eq!(after.attestation_envelope, before.attestation_envelope);
+
+        // Idempotent re-promote.
+        let again = engine.attestation_promote(&att_id).await.unwrap();
+        assert!(!again, "re-promote of a federation row returns Ok(false)");
+        let after2 = pg.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(
+            after2.scrub_signature_classical,
+            after.scrub_signature_classical
+        );
+        assert_eq!(after2.promoted_at, after.promoted_at);
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -711,7 +711,6 @@ impl Engine {
         target_holds_bytes_type: &str,
         signer_key_id: &str,
     ) -> Result<(), crate::federation::BlobError> {
-        use crate::verify::canonical::{Canonicalizer, PythonJsonDumpsCanonicalizer};
         use base64::engine::general_purpose::STANDARD as B64;
         use base64::Engine as _;
         use sha2::{Digest, Sha256};
@@ -720,8 +719,10 @@ impl Engine {
             target_attestation_id,
             target_holds_bytes_type,
         );
-        let canonical_bytes = PythonJsonDumpsCanonicalizer
-            .canonicalize_value(&envelope)
+        // v4.6 (#176) — produce-side gate: emit Python pre-cut, JCS post-
+        // cut (one-line flip in produce_canon_version). Keeps persist's
+        // produced withdraws attestation verifiable by the chain.
+        let canonical_bytes = crate::verify::canonical::ceg_produce_canonicalize(&envelope)
             .map_err(|e| {
                 crate::federation::BlobError::Backend(format!("withdraws canonicalize: {e}"))
             })?;

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -754,7 +754,6 @@ pub trait BlobStorage: Send + Sync {
         Self: Sync,
     {
         async move {
-            use crate::verify::canonical::{Canonicalizer, PythonJsonDumpsCanonicalizer};
             use base64::engine::general_purpose::STANDARD as B64;
             use base64::Engine as _;
             use sha2::{Digest, Sha256};
@@ -823,8 +822,8 @@ pub trait BlobStorage: Send + Sync {
             }
 
             let envelope = holds_bytes_attestation_envelope(sha256);
-            let canonical_bytes = PythonJsonDumpsCanonicalizer
-                .canonicalize_value(&envelope)
+            // v4.6 (#176) — produce-side gate (Python pre-cut, JCS post-cut).
+            let canonical_bytes = crate::verify::canonical::ceg_produce_canonicalize(&envelope)
                 .map_err(|e| {
                     BlobError::InvalidArgument(format!("canonicalize holds_bytes envelope: {e}"))
                 })?;

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -613,6 +613,31 @@ pub trait FederationDirectory: Send + Sync {
         scrub_signature_pqc: &str,
     ) -> Result<(), Error>;
 
+    /// v4.6 (CIRISPersist#171 phase 2) — fetch a single attestation row
+    /// by id (any tier). `None` if absent. Used by `Engine::attestation_
+    /// promote` to load the `local` row's envelope before signing.
+    async fn get_attestation(&self, attestation_id: &str) -> Result<Option<Attestation>, Error>;
+
+    /// v4.6 (CIRISPersist#171 phase 2, CEG §10.1.3/§10.1.5) — the
+    /// local→federation **promotion** write-back: stamp the hybrid scrub
+    /// envelope computed by [`crate::Engine::attestation_promote`] and
+    /// flip `tier` to `federation` (+ `promoted_at`), iff the row is
+    /// currently `local`. Returns `Ok(true)` on promotion, `Ok(false)` if
+    /// the row is already `federation` (idempotent), `Err` if absent. The
+    /// signing bytes are the §0.9-canonical envelope (gated produce
+    /// canonicalizer), so a promoted row is byte-identical on the wire to
+    /// a natively-federation one (Registry must #1).
+    #[allow(clippy::too_many_arguments)]
+    async fn promote_attestation(
+        &self,
+        attestation_id: &str,
+        scrub_signature_classical: &str,
+        scrub_signature_pqc: Option<&str>,
+        original_content_hash_hex: &str,
+        scrub_key_id: &str,
+        scrub_timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, Error>;
+
     // ── Hybrid-pending sweep (CIRISPersist#11, v0.3.2) ─────────────
     //
     // Per V004's schema header §"Phase transitions":

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2014,11 +2014,10 @@ impl PyEngine {
         catch_panic(|| {
             let value: serde_json::Value = serde_json::from_str(envelope_json)
                 .map_err(|e| PyValueError::new_err(format!("envelope JSON decode: {e}")))?;
-            let bytes = <PythonJsonDumpsCanonicalizer as crate::verify::canonical::Canonicalizer>::canonicalize_value(
-            &PythonJsonDumpsCanonicalizer,
-            &value,
-        )
-        .map_err(|e| PyRuntimeError::new_err(format!("canonicalize: {e}")))?;
+            // v4.6 (#176) — produce-side gate: producers signing over these
+            // bytes emit Python pre-cut, JCS post-cut (one-line flip).
+            let bytes = crate::verify::canonical::ceg_produce_canonicalize(&value)
+                .map_err(|e| PyRuntimeError::new_err(format!("canonicalize: {e}")))?;
             Ok(PyBytes::new(py, &bytes).unbind())
         })
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -792,7 +792,18 @@ where
         // and bubbled SignatureMismatch from), we still emit the
         // warn with `None` for the canonical fields and return
         // the typed SignatureMismatch error.
-        match verify_trace(trace, self.canonicalizer, &key) {
+        // v4.6 (#176) — select the canonicalizer by the trace's SIGNED
+        // schema epoch (Python-compat 1.x/2.x, JCS 3.x+), not the
+        // struct's injected default. Signed-bytes-bound, not
+        // caller-selectable. (The injected `self.canonicalizer` remains
+        // the best-effort diagnostic canonicalizer below; in production
+        // it equals the gate's V1 result for current 1.x/2.x traffic.)
+        let canon = crate::verify::canonical::canonicalizer_for(
+            crate::verify::ed25519::canon_version_for_trace_schema(
+                trace.trace_schema_version.as_str(),
+            ),
+        );
+        match verify_trace(trace, canon, &key) {
             Ok(()) => Ok(()),
             Err(VerifyError::SignatureMismatch) => {
                 let diag =

--- a/src/server/pipeline.rs
+++ b/src/server/pipeline.rs
@@ -247,7 +247,15 @@ where
                     .into_response();
             }
         };
-        if let Err(e) = verify_trace(trace, &PythonJsonDumpsCanonicalizer, &key) {
+        // v4.6 (#176) — select the canonicalizer by the trace's SIGNED
+        // schema epoch (Python-compat for 1.x/2.x, JCS for 3.x+). Signed-
+        // bytes-bound: not caller-selectable.
+        let canon = crate::verify::canonical::canonicalizer_for(
+            crate::verify::ed25519::canon_version_for_trace_schema(
+                trace.trace_schema_version.as_str(),
+            ),
+        );
+        if let Err(e) = verify_trace(trace, canon, &key) {
             return invariant_response(
                 KIND_INNER_SIGNATURE,
                 format!("agent signature failed verify: {e}"),

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -987,6 +987,56 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         Ok(())
     }
 
+    async fn get_attestation(
+        &self,
+        attestation_id: &str,
+    ) -> Result<Option<crate::federation::Attestation>, crate::federation::Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state
+            .federation_attestations
+            .iter()
+            .find(|a| a.attestation_id == attestation_id)
+            .cloned())
+    }
+
+    async fn promote_attestation(
+        &self,
+        attestation_id: &str,
+        scrub_signature_classical: &str,
+        scrub_signature_pqc: Option<&str>,
+        original_content_hash_hex: &str,
+        scrub_key_id: &str,
+        scrub_timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, crate::federation::Error> {
+        use crate::federation::types::attestation_tier;
+        let mut state = self.state.lock().expect("memory backend lock");
+        let row = state
+            .federation_attestations
+            .iter_mut()
+            .find(|a| a.attestation_id == attestation_id)
+            .ok_or_else(|| {
+                crate::federation::Error::InvalidArgument(format!(
+                    "federation_attestations row {attestation_id} does not exist"
+                ))
+            })?;
+        if row.tier == attestation_tier::FEDERATION {
+            return Ok(false);
+        }
+        let now = scrub_timestamp;
+        row.original_content_hash = original_content_hash_hex.to_owned();
+        row.scrub_signature_classical = scrub_signature_classical.to_owned();
+        row.scrub_signature_pqc = scrub_signature_pqc.map(|s| s.to_owned());
+        row.scrub_key_id = scrub_key_id.to_owned();
+        row.scrub_timestamp = now;
+        row.pqc_completed_at = scrub_signature_pqc.map(|_| now);
+        row.tier = attestation_tier::FEDERATION.to_string();
+        row.promoted_at = Some(now);
+        let mut for_hash = row.clone();
+        for_hash.persist_row_hash = String::new();
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&for_hash)?;
+        Ok(true)
+    }
+
     async fn attach_revocation_pqc_signature(
         &self,
         revocation_id: &str,

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2285,6 +2285,11 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .get_client()
             .await
             .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Parse to uuid::Uuid before binding — the driver refuses a &str
+        // against a `uuid`-typed param (see the 1693 / put_revocation note).
+        let att_uuid = uuid::Uuid::parse_str(attestation_id).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("attestation_id uuid: {e}"))
+        })?;
         // Read existing row to recompute the hash with new fields.
         let row_opt = client
             .query_opt(
@@ -2293,8 +2298,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
-                 FROM cirislens.federation_attestations WHERE attestation_id = $1::uuid",
-                &[&attestation_id],
+                 FROM cirislens.federation_attestations WHERE attestation_id = $1",
+                &[&att_uuid],
             )
             .await
             .map_err(|e| crate::federation::Error::Backend(format!("attach lookup: {e}")))?;
@@ -2321,8 +2326,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .execute(
                 "UPDATE cirislens.federation_attestations \
                  SET scrub_signature_pqc = $1, pqc_completed_at = $2, persist_row_hash = $3 \
-                 WHERE attestation_id = $4::uuid AND pqc_completed_at IS NULL",
-                &[&scrub_signature_pqc, &now, &new_hash, &attestation_id],
+                 WHERE attestation_id = $4 AND pqc_completed_at IS NULL",
+                &[&scrub_signature_pqc, &now, &new_hash, &att_uuid],
             )
             .await
             .map_err(|e| {
@@ -2336,6 +2341,107 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         Ok(())
     }
 
+    async fn get_attestation(
+        &self,
+        attestation_id: &str,
+    ) -> Result<Option<crate::federation::Attestation>, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Parse attestation_id to uuid::Uuid before binding — the driver
+        // refuses to serialize a &str against a `uuid`-typed param (see
+        // put_revocation / the 1693 comment). Invalid → no such row.
+        let Ok(att_uuid) = uuid::Uuid::parse_str(attestation_id) else {
+            return Ok(None);
+        };
+        let row_opt = client
+            .query_opt(
+                "SELECT attestation_id::text, attesting_key_id, attested_key_id, attestation_type, \
+                    weight::float8 AS weight, asserted_at, expires_at, attestation_envelope, \
+                    original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
+                 FROM cirislens.federation_attestations WHERE attestation_id = $1",
+                &[&att_uuid],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("get_attestation: {e}")))?;
+        row_opt.map(pg_row_to_attestation).transpose()
+    }
+
+    async fn promote_attestation(
+        &self,
+        attestation_id: &str,
+        scrub_signature_classical: &str,
+        scrub_signature_pqc: Option<&str>,
+        original_content_hash_hex: &str,
+        scrub_key_id: &str,
+        scrub_timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, crate::federation::Error> {
+        use crate::federation::types::attestation_tier;
+        let mut row = self.get_attestation(attestation_id).await?.ok_or_else(|| {
+            crate::federation::Error::InvalidArgument(format!(
+                "federation_attestations row {attestation_id} does not exist"
+            ))
+        })?;
+        if row.tier == attestation_tier::FEDERATION {
+            return Ok(false); // idempotent
+        }
+        let och: Vec<u8> = hex::decode(original_content_hash_hex).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("original_content_hash hex: {e}"))
+        })?;
+        let now = scrub_timestamp;
+        let pqc_owned = scrub_signature_pqc.map(|s| s.to_owned());
+        row.original_content_hash = original_content_hash_hex.to_owned();
+        row.scrub_signature_classical = scrub_signature_classical.to_owned();
+        row.scrub_signature_pqc = pqc_owned.clone();
+        row.scrub_key_id = scrub_key_id.to_owned();
+        row.scrub_timestamp = now;
+        row.pqc_completed_at = pqc_owned.as_ref().map(|_| now);
+        row.tier = attestation_tier::FEDERATION.to_string();
+        row.promoted_at = Some(now);
+        let mut for_hash = row.clone();
+        for_hash.persist_row_hash = String::new();
+        let new_hash = crate::federation::types::compute_persist_row_hash(&for_hash)?;
+        let pqc_completed = row.pqc_completed_at;
+        // get_attestation already succeeded above → attestation_id parses.
+        let att_uuid = uuid::Uuid::parse_str(attestation_id).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("attestation_id uuid: {e}"))
+        })?;
+
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let n = client
+            .execute(
+                "UPDATE cirislens.federation_attestations \
+                 SET original_content_hash = $1, scrub_signature_classical = $2, \
+                     scrub_signature_pqc = $3, scrub_key_id = $4, scrub_timestamp = $5, \
+                     pqc_completed_at = $6, persist_row_hash = $7, tier = 'federation', \
+                     promoted_at = $5 \
+                 WHERE attestation_id = $8 AND tier = 'local'",
+                &[
+                    &och,
+                    &scrub_signature_classical,
+                    &pqc_owned,
+                    &scrub_key_id,
+                    &now,
+                    &pqc_completed,
+                    &new_hash,
+                    &att_uuid,
+                ],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("promote_attestation: {e}")))?;
+        if n == 0 {
+            return Err(crate::federation::Error::Conflict(format!(
+                "federation_attestations row {attestation_id} was concurrently promoted"
+            )));
+        }
+        Ok(true)
+    }
+
     async fn attach_revocation_pqc_signature(
         &self,
         revocation_id: &str,
@@ -2345,14 +2451,18 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .get_client()
             .await
             .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Parse to uuid::Uuid before binding — see the 1693 note.
+        let rev_uuid = uuid::Uuid::parse_str(revocation_id).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("revocation_id uuid: {e}"))
+        })?;
         let row_opt = client
             .query_opt(
                 "SELECT revocation_id::text, revoked_key_id, revoking_key_id, reason, \
                     revoked_at, effective_at, revocation_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, observed_region, persist_row_hash \
-                 FROM cirislens.federation_revocations WHERE revocation_id = $1::uuid",
-                &[&revocation_id],
+                 FROM cirislens.federation_revocations WHERE revocation_id = $1",
+                &[&rev_uuid],
             )
             .await
             .map_err(|e| crate::federation::Error::Backend(format!("attach lookup: {e}")))?;
@@ -2379,8 +2489,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .execute(
                 "UPDATE cirislens.federation_revocations \
                  SET scrub_signature_pqc = $1, pqc_completed_at = $2, persist_row_hash = $3 \
-                 WHERE revocation_id = $4::uuid AND pqc_completed_at IS NULL",
-                &[&scrub_signature_pqc, &now, &new_hash, &revocation_id],
+                 WHERE revocation_id = $4 AND pqc_completed_at IS NULL",
+                &[&scrub_signature_pqc, &now, &new_hash, &rev_uuid],
             )
             .await
             .map_err(|e| {
@@ -14643,6 +14753,107 @@ mod tests {
             err,
             crate::federation::Error::AccordDimensionRequiresAccordHolder { .. }
         ));
+    }
+
+    /// v4.6.0 (CIRISPersist#171/#176) — live-PG coverage for the
+    /// deferred-PQC completion path (`attach_attestation_pqc_signature` /
+    /// `attach_revocation_pqc_signature`), the sweep `Engine.run_pqc_sweep`
+    /// drives via PyO3. Previously tested ONLY on the in-memory backend,
+    /// whose string-keyed map never exercised the `attestation_id`/`uuid`
+    /// driver serialization — so a `&str`-bound `$N::uuid` param (which
+    /// panics with "error serializing parameter 0" on real Postgres) went
+    /// undetected. This test closes that gap for both attach paths.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_attach_pqc_for_attestation_and_revocation() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::FederationDirectory;
+
+        let steward = format!("pg-attach-steward-{}", uuid_like());
+        let target = format!("pg-attach-target-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &steward,
+                    "registry",
+                    crate::federation::types::identity_type::STEWARD,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &target,
+                    "primitive-a",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+
+        // Federation-tier, PQC-pending attestation (real UUID id).
+        let att = pg_scores_attestation(&steward, &target, &steward, "identity_binding:v1");
+        let att_id = att.attestation_id.clone();
+        backend
+            .put_attestation(crate::federation::SignedAttestation { attestation: att })
+            .await
+            .unwrap();
+        backend
+            .attach_attestation_pqc_signature(&att_id, "att-pqc-sig")
+            .await
+            .expect("attach attestation PQC sig must serialize the uuid param");
+        let after = backend
+            .get_attestation(&att_id)
+            .await
+            .unwrap()
+            .expect("row");
+        assert!(
+            after.is_pqc_complete(),
+            "attestation PQC-complete after attach"
+        );
+
+        // Same for a federation revocation (real UUID id; valid 64-hex
+        // original_content_hash — the revocation path hex-decodes it).
+        let now = chrono::Utc::now();
+        let rev_id = uuid::Uuid::new_v4().to_string();
+        let rev = crate::federation::Revocation {
+            revocation_id: rev_id.clone(),
+            revoked_key_id: target.clone(),
+            revoking_key_id: steward.clone(),
+            reason: Some("test".into()),
+            revoked_at: now,
+            effective_at: now,
+            revocation_envelope: serde_json::json!({ "id": rev_id }),
+            original_content_hash:
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into(),
+            scrub_signature_classical: "c2ln".into(),
+            scrub_signature_pqc: None,
+            scrub_key_id: steward.clone(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            observed_region: crate::federation::verify_coord::region::US.into(),
+            persist_row_hash: String::new(),
+        };
+        backend
+            .put_revocation(crate::federation::SignedRevocation { revocation: rev })
+            .await
+            .unwrap();
+        backend
+            .attach_revocation_pqc_signature(&rev_id, "rev-pqc-sig")
+            .await
+            .expect("attach revocation PQC sig must serialize the uuid param");
+        let revs = backend.revocations_for(&target).await.unwrap();
+        assert!(
+            revs.iter()
+                .any(|r| r.revocation_id == rev_id && r.is_pqc_complete()),
+            "revocation PQC-complete after attach"
+        );
     }
 
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2031,6 +2031,102 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         Ok(())
     }
 
+    async fn get_attestation(
+        &self,
+        attestation_id: &str,
+    ) -> Result<Option<crate::federation::Attestation>, crate::federation::Error> {
+        let conn = self.conn.clone();
+        let id = attestation_id.to_owned();
+        (move || -> Result<Option<crate::federation::Attestation>, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                    weight, asserted_at, expires_at, attestation_envelope, \
+                    original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, \
+                    subject_key_ids, withdraws_admission_rule, cohort_scope, tier, promoted_at \
+                 FROM federation_attestations WHERE attestation_id = ?1",
+                [&id],
+                sqlite_row_to_attestation,
+            )
+            .optional()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("get_attestation: {e}")))
+    }
+
+    async fn promote_attestation(
+        &self,
+        attestation_id: &str,
+        scrub_signature_classical: &str,
+        scrub_signature_pqc: Option<&str>,
+        original_content_hash_hex: &str,
+        scrub_key_id: &str,
+        scrub_timestamp: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool, crate::federation::Error> {
+        use crate::federation::types::attestation_tier;
+        // Load + tier-check + stamp the row's promoted shape so we can
+        // recompute persist_row_hash over the post-promotion fields.
+        let mut row = self.get_attestation(attestation_id).await?.ok_or_else(|| {
+            crate::federation::Error::InvalidArgument(format!(
+                "federation_attestations row {attestation_id} does not exist"
+            ))
+        })?;
+        if row.tier == attestation_tier::FEDERATION {
+            return Ok(false); // idempotent: already promoted / native-federation
+        }
+        let och = hex::decode(original_content_hash_hex).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("original_content_hash hex: {e}"))
+        })?;
+        let now = scrub_timestamp;
+        row.original_content_hash = original_content_hash_hex.to_owned();
+        row.scrub_signature_classical = scrub_signature_classical.to_owned();
+        row.scrub_signature_pqc = scrub_signature_pqc.map(|s| s.to_owned());
+        row.scrub_key_id = scrub_key_id.to_owned();
+        row.scrub_timestamp = now;
+        row.pqc_completed_at = scrub_signature_pqc.map(|_| now);
+        row.tier = attestation_tier::FEDERATION.to_string();
+        row.promoted_at = Some(now);
+        let mut for_hash = row.clone();
+        for_hash.persist_row_hash = String::new();
+        let new_hash = crate::federation::types::compute_persist_row_hash(&for_hash)?;
+
+        let conn = self.conn.clone();
+        let id = attestation_id.to_owned();
+        let classical = scrub_signature_classical.to_owned();
+        let pqc = scrub_signature_pqc.map(|s| s.to_owned());
+        let scrub_key = scrub_key_id.to_owned();
+        let ts = now.to_rfc3339();
+        let pqc_completed = row.pqc_completed_at.map(|t| t.to_rfc3339());
+        let n = (move || -> Result<usize, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "UPDATE federation_attestations \
+                 SET original_content_hash = ?1, scrub_signature_classical = ?2, \
+                     scrub_signature_pqc = ?3, scrub_key_id = ?4, scrub_timestamp = ?5, \
+                     pqc_completed_at = ?6, persist_row_hash = ?7, tier = 'federation', \
+                     promoted_at = ?5 \
+                 WHERE attestation_id = ?8 AND tier = 'local'",
+                rusqlite::params![
+                    och,
+                    classical,
+                    pqc,
+                    scrub_key,
+                    ts,
+                    pqc_completed,
+                    new_hash,
+                    id
+                ],
+            )
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("promote_attestation: {e}")))?;
+        if n == 0 {
+            return Err(crate::federation::Error::Conflict(format!(
+                "federation_attestations row {attestation_id} was concurrently promoted"
+            )));
+        }
+        Ok(true)
+    }
+
     async fn attach_revocation_pqc_signature(
         &self,
         revocation_id: &str,

--- a/src/verify/canonical.rs
+++ b/src/verify/canonical.rs
@@ -129,6 +129,61 @@ impl Canonicalizer for Rfc8785Canonicalizer {
     }
 }
 
+/// v4.6 (CIRISPersist#171 / CEG §0.9) — the **JCS (RFC 8785)**
+/// canonicalizer: the CEG-1.0 signing canonicalization. Production impl,
+/// delegating to the single blessed cross-impl implementation
+/// [`ciris_verify_core::jcs::canonicalize`] (OQ-1) so persist's bytes are
+/// byte-identical to what CIRISVerify and the agent (3.0) recompute — no
+/// second JCS impl to keep in lockstep. Selected for post-flip rows by
+/// the signed-epoch version gate ([`canonicalizer_for`]).
+///
+/// Unlike [`PythonJsonDumpsCanonicalizer`] this emits **raw UTF-8** for
+/// non-ASCII (RFC 8785 §3.2.2.2), so the two agree on pure-ASCII payloads
+/// and diverge on every non-ASCII character — the migration's whole
+/// reason for the version gate.
+pub struct JcsCanonicalizer;
+
+impl Canonicalizer for JcsCanonicalizer {
+    fn canonicalize_value(&self, v: &serde_json::Value) -> Result<Vec<u8>, Error> {
+        ciris_verify_core::jcs::canonicalize(v)
+            .map_err(|e| Error::Canonicalization(format!("jcs (rfc 8785): {e}")))
+    }
+}
+
+/// v4.6 (CIRISPersist#171 / CEG §0.9 / CIRISAgent#840) — the CEG
+/// canonicalization version: the signed-epoch discriminator for the JCS
+/// migration. `V1Python` is the pre-flip Python-compat rule; `V2Jcs` is
+/// the 2.9.6 RFC 8785 flip. A row's version is read from a
+/// **signed-bytes-bound** field (`crypto_kind` for federation signatures
+/// / the producer's schema epoch for traces) so an attacker flipping the
+/// discriminator only ever causes a canonicalization *mismatch →
+/// rejection*, never a check bypass (§6 downgrade guard). The exact
+/// per-surface field + boundary value is pinned with the agent during
+/// the CIRISConformance#9 byte-identity validation before the 2.9.6
+/// pin-bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonVersion {
+    /// Pre-flip: Python `json.dumps(sort_keys=True, ensure_ascii=True)`.
+    V1Python,
+    /// 2.9.6 flip: RFC 8785 JCS.
+    V2Jcs,
+}
+
+static PYTHON_CANON: PythonJsonDumpsCanonicalizer = PythonJsonDumpsCanonicalizer;
+static JCS_CANON: JcsCanonicalizer = JcsCanonicalizer;
+
+/// v4.6 — the version gate: select the canonicalizer for a row's signed
+/// [`CanonVersion`]. The single point the JCS migration routes through;
+/// verify reads the version per-row (so persist verifies both pre-cut
+/// Python and post-cut JCS), and the produce side stamps the current
+/// epoch's version.
+pub fn canonicalizer_for(version: CanonVersion) -> &'static dyn Canonicalizer {
+    match version {
+        CanonVersion::V1Python => &PYTHON_CANON,
+        CanonVersion::V2Jcs => &JCS_CANON,
+    }
+}
+
 // ─── Python-compat writer ──────────────────────────────────────────
 
 fn write_value(buf: &mut Vec<u8>, v: &serde_json::Value) {
@@ -455,6 +510,80 @@ mod tests {
         // Python form has the escape literal; JCS has UTF-8 bytes.
         assert!(py.contains("\\u00e9"), "python emits backslash-u-escape");
         assert!(j.contains("\u{00e9}"), "jcs emits raw UTF-8");
+    }
+
+    // ─── v4.6 JCS flip: production JcsCanonicalizer + version gate ───
+
+    fn jcs_prod(v: serde_json::Value) -> String {
+        String::from_utf8(JcsCanonicalizer.canonicalize_value(&v).unwrap()).unwrap()
+    }
+
+    /// OQ-1: the production `JcsCanonicalizer` (delegating to
+    /// `ciris_verify_core::jcs`) is byte-identical to the in-tree
+    /// `serde_json_canonicalizer` reference across ASCII + non-ASCII +
+    /// nested — i.e. the blessed impl IS RFC 8785. If this ever drifts,
+    /// persist and Verify would disagree on the wire.
+    #[test]
+    fn production_jcs_matches_rfc8785_reference() {
+        for v in [
+            json!({"k": "hello", "n": 42, "list": [1, 2, 3]}),
+            json!({"dimension": "config:filter:v1", "score": 1, "z": true, "a": null}),
+            json!({"msg": "用户 ⚠️ héllo", "nested": {"ar": "مرحبا", "am": "ሰላም"}}),
+        ] {
+            assert_eq!(
+                jcs_prod(v.clone()),
+                jcs(v.clone()),
+                "ciris_verify_core::jcs must equal the RFC 8785 reference for {v}"
+            );
+        }
+    }
+
+    /// The version gate routes V1→Python-compat, V2→JCS.
+    #[test]
+    fn version_gate_routes() {
+        let v = json!({"k": "héllo"});
+        let via_v1 = String::from_utf8(
+            canonicalizer_for(CanonVersion::V1Python)
+                .canonicalize_value(&v)
+                .unwrap(),
+        )
+        .unwrap();
+        let via_v2 = String::from_utf8(
+            canonicalizer_for(CanonVersion::V2Jcs)
+                .canonicalize_value(&v)
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(via_v1, pyc(v.clone()), "V1 = Python-compat");
+        assert_eq!(via_v2, jcs_prod(v), "V2 = JCS");
+        assert_ne!(
+            via_v1, via_v2,
+            "the two epochs produce different bytes on non-ASCII"
+        );
+    }
+
+    /// Encodes the CIRISAgent #174 measurement: ASCII identical, but the
+    /// real breaking corpus (non-Latin reasoning text + the ⚠️
+    /// attestation-disclosure emoji on English GENERIC traces) diverges —
+    /// NOT just a non-BMP tail. This is why the version gate is mandatory.
+    #[test]
+    fn agent_measured_divergence_corpus() {
+        // ✅ pure-ASCII trace shape — identical (no gate needed).
+        let ascii_trace =
+            json!({"dimension":"identity_binding:v1","score":1,"thought_content":"ok"});
+        assert_eq!(pyc(ascii_trace.clone()), jcs_prod(ascii_trace));
+        // ❌ the ⚠️ disclosure emoji on an otherwise-English trace.
+        let warn = json!({"context":"⚠️ WARNING: attestation"});
+        assert_ne!(pyc(warn.clone()), jcs_prod(warn));
+        // ❌ non-Latin reasoning narrative (am / zh / ar).
+        for text in ["የተደረገ", "用户推理", "سبب"] {
+            let v = json!({"rationale": text});
+            assert_ne!(
+                pyc(v.clone()),
+                jcs_prod(v),
+                "non-Latin rationale must diverge (pre-cut rows need the legacy gate): {text}"
+            );
+        }
     }
 
     #[test]

--- a/src/verify/canonical.rs
+++ b/src/verify/canonical.rs
@@ -78,12 +78,26 @@ pub trait Canonicalizer: Send + Sync {
 }
 
 /// Phase 1 canonicalizer — byte-exact match with the agent's
-/// `json.dumps(canonical, sort_keys=True, separators=(",", ":"),
-/// ensure_ascii=True)` output.
+/// `json.dumps(canonical, sort_keys=True, separators=(",", ":"))` output.
 ///
-/// `ensure_ascii=True` is Python's default; the agent code in
-/// `accord_metrics/services.py:208-368` does not pass
-/// `ensure_ascii=False`, so the wire is ASCII-only.
+/// The agent's signing sites
+/// (`ciris_adapters/ciris_accord_metrics/services.py:450`,
+/// `authentication/service.py`, `dsar/signature_service.py`) pass **no**
+/// `ensure_ascii` argument, so Python applies its default
+/// **`ensure_ascii=True`**: every non-ASCII codepoint is `\uXXXX`-escaped
+/// (BMP) or surrogate-pair-escaped (non-BMP). This canonicalizer escapes
+/// identically (see [`write_string`]), so the produced bytes are
+/// pure-ASCII and byte-match the agent in **every** language.
+///
+/// **Contrast with JCS (the v4.6 flip target):** RFC 8785 §3.2.2.2 emits
+/// **raw UTF-8** for non-ASCII (escaping only `"`, `\`, C0 controls). So
+/// Python-compat and JCS agree on pure-ASCII payloads but **diverge on
+/// every non-ASCII character** — not merely the non-BMP tail. Per the
+/// CIRISAgent #174 measurement, that breaking set is the majority of the
+/// multilingual corpus (any `thought_content`/`rationale` in a non-Latin
+/// locale, plus the `⚠️` attestation-disclosure emoji on English traces).
+/// This is why the v4.6 flip needs a signed-epoch version gate, not a
+/// naked swap.
 pub struct PythonJsonDumpsCanonicalizer;
 
 impl Canonicalizer for PythonJsonDumpsCanonicalizer {

--- a/src/verify/canonical.rs
+++ b/src/verify/canonical.rs
@@ -184,6 +184,31 @@ pub fn canonicalizer_for(version: CanonVersion) -> &'static dyn Canonicalizer {
     }
 }
 
+/// v4.6 (CIRISPersist#171 / #176) — the canonicalization version persist
+/// **produces** at today. Until the coordinated **2.9.6 cutover**, persist
+/// emits `V1Python` so the still-Python chain (agent ≤ 2.9.5, lens, edge)
+/// can verify persist-produced federation rows; the cutover flips this to
+/// `V2Jcs` in lockstep. It is a `const fn`, not a runtime toggle — the
+/// flip is a release event coordinated chain-wide (the activation is a
+/// one-line change here, re-released as the 2.9.6 triple lands). The
+/// **verify** side gates per-row regardless ([`canonicalizer_for`] keyed
+/// on the row's signed epoch), so persist verifies both V1 and V2 rows no
+/// matter what it produces.
+pub const fn produce_canon_version() -> CanonVersion {
+    // 2.9.6 cutover flips this to CanonVersion::V2Jcs (lockstep).
+    CanonVersion::V1Python
+}
+
+/// v4.6 — canonicalize a payload persist is about to **sign/emit**, via
+/// the [`produce_canon_version`] gate. The single produce-side
+/// canonicalization entry point: routing every persist-produced signing
+/// payload through here makes the 2.9.6 flip a one-line change and keeps
+/// the produce epoch consistent across all surfaces (withdraws /
+/// holds_bytes / attestation_promote / key registration / FFI).
+pub fn ceg_produce_canonicalize(value: &serde_json::Value) -> Result<Vec<u8>, Error> {
+    canonicalizer_for(produce_canon_version()).canonicalize_value(value)
+}
+
 // ─── Python-compat writer ──────────────────────────────────────────
 
 fn write_value(buf: &mut Vec<u8>, v: &serde_json::Value) {

--- a/src/verify/ed25519.rs
+++ b/src/verify/ed25519.rs
@@ -499,6 +499,36 @@ where
     Err(Error::SignatureMismatch)
 }
 
+/// v4.6 (CIRISPersist#171 / #176 / CEG §0.9) — map a trace's **signed**
+/// `trace_schema_version` to its canonicalization version (the #176
+/// signed-epoch version gate). The JCS flip is a **major-version** era
+/// boundary: `1.x`/`2.x` are Python-compat (pre-cut); **`3.x`+ is JCS**
+/// (the agent's 2.9.6 / 3.0 flip). Robust to point-version bumps within
+/// an era — no per-point-version enumeration.
+///
+/// `trace_schema_version` is part of the signed canonical bytes, so this
+/// is attacker-uncontrollable (signed-bytes-bound, #176 / #174 §6): a
+/// forged version that flips the canonicalizer changes the canonical →
+/// signature mismatch → rejection, never a check bypass.
+///
+/// **Inert until 3.x lands:** a `3.x` trace is only *reachable* once that
+/// schema is added to `SUPPORTED_VERSIONS` + the field-layout dispatch in
+/// [`verify_trace`]; the exact 3.0 schema string + layout are pinned with
+/// the agent at the CIRISConformance#9 byte-identity validation. Until
+/// then this gate returns `V1Python` for every supported schema — the
+/// production canonicalizer is unchanged, persist 4.6 ships safe + ready.
+pub fn canon_version_for_trace_schema(wire: &str) -> crate::verify::canonical::CanonVersion {
+    use crate::verify::canonical::CanonVersion;
+    if let Some((major, _)) = wire.split_once('.') {
+        if let Ok(m) = major.parse::<u32>() {
+            if m >= 3 {
+                return CanonVersion::V2Jcs;
+            }
+        }
+    }
+    CanonVersion::V1Python
+}
+
 /// Convenience wrapper: verify with a [`PublicKeyDirectory`] in front
 /// (looks up the key by id, then defers to [`verify_trace`]). Useful
 /// for the standalone-verifier test path; production ingest looks up
@@ -527,6 +557,27 @@ mod tests {
     use crate::schema::SchemaVersion;
     use ed25519_dalek::{Signer, SigningKey};
     use std::collections::HashMap;
+
+    /// v4.6 (#176) — the signed-epoch gate: 1.x/2.x → Python-compat,
+    /// 3.x+ → JCS (the agent's 2.9.6 flip era), robust to point bumps;
+    /// unparseable/major-less → Python (safe default).
+    #[test]
+    fn canon_version_gate_by_major() {
+        use crate::verify::canonical::CanonVersion::{V1Python, V2Jcs};
+        for (wire, want) in [
+            ("2.7.0", V1Python),
+            ("2.7.9", V1Python),
+            ("2.7.legacy", V1Python),
+            ("1.0.0", V1Python),
+            ("3.0.0", V2Jcs),
+            ("3.5.2", V2Jcs),
+            ("10.0.0", V2Jcs),
+            ("garbage", V1Python),
+            ("", V1Python),
+        ] {
+            assert_eq!(canon_version_for_trace_schema(wire), want, "schema {wire}");
+        }
+    }
 
     /// In-memory PublicKeyDirectory for tests.
     struct MemKeys {


### PR DESCRIPTION
Completes the v4.6 JCS-cutover cut. persist becomes CEG 1.0 §0.9-ready: the JCS machinery + mandatory signed-epoch version gate land **flip-ready but inert** (produce stays Python until the one-line cutover at the 2.9.6 substrate triple), and `attestation_promote` (the #171 phase-2 piece JCS unblocks) ships. **persist 4.6 ships FIRST**; the agent validates byte-identity via CIRISConformance#9, then bumps pins (OQ-4).

## Commits
1. **foundation** (`ebaabc0`) — `JcsCanonicalizer` (wraps `ciris_verify_core::jcs`, OQ-1) + `CanonVersion {V1Python,V2Jcs}` + `canonicalizer_for` + `produce_canon_version()` (const, V1Python until cutover) + `ceg_produce_canonicalize`.
2. **trace-verify gate** (`459facc`) — `canon_version_for_trace_schema` (major ≥3 → JCS), wired into `server/pipeline.rs` + `ingest.rs` production verify. Gates per signed, attacker-uncontrollable epoch (OQ-5).
3. **produce-side gate** (`695f030`) — routes the FSD-named federation produce sites (engine withdraws, blobs holds_bytes, FFI `canonicalize_envelope`) through the gate. `persist_row_hash` (OQ-2) + the ingest scrub-diff stay Python (internal, not boundary signing).
4. **attestation_promote + PG bugfix** (`f08259e`) — see below.

## `Engine::attestation_promote(id) -> Result<bool>` (#171 phase 2)
Local self-attestation → federation: canonicalize via the produce gate → sha256 → `sign_hybrid` (Ed25519 + ML-DSA-65) → write scrub envelope + flip `tier=federation` + stamp `promoted_at`. Signs the §0.9-canonical bytes → a promoted row is wire-identical to a native federation attestation once JCS is live (Registry must #1). Idempotent (`federation` → `Ok(false)`). New `FederationDirectory::{get_attestation, promote_attestation}` on Postgres / SQLite / memory.

**PyO3 binding deferred** pending the agent-facing shape decision (synchronous-hybrid vs. classical-write-then-PQC-sweep, tied to lockstep timing). Engine + storage surface complete + tested.

## Fixed — latent Postgres UUID-serialize bug (deferred-PQC completion path)
`attach_attestation_pqc_signature` / `attach_revocation_pqc_signature` bound a `&str` against a `$N::uuid` param → `error serializing parameter 0` on real Postgres. These run in prod via `Engine.run_pqc_sweep` (PyO3) but were covered **only** on the in-memory backend (string-keyed map, never hit the driver), so the bug was invisible. Now parse to `uuid::Uuid` first (the `put_revocation` pattern). **CI gap closed** with a live-PG attach round-trip for both paths.

## Tests
- `attestation_promote` round-trip on **both** backends (SQLite + live PG): tier flip, hybrid scrub envelope, 64-hex OCH, `promoted_at`, idempotent re-promote, missing-row → `InvalidArgument`.
- JCS foundation: production-JCS-matches-RFC8785, version-gate routing, agent-measured divergence corpus, trace-schema major gate.
- **1045 lib green on SQLite, 747 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full `--tests`; clippy clean.

## Lockstep
Behavior **unchanged** this release (produce stays Python, verify already gates per-row). Cutover is a separate coordinated event at the 2.9.6 triple (agent 3.0 JCS + persist 4.6 + ciris-verify 4.11.0 + edge + lens): flip `produce_canon_version()` to `V2Jcs`. **Upstream ask (OQ-1):** CIRISVerify exposes `jcs::canonicalize` as a Python binding for the agent producer.

Closes #176. Advances #171 (phase 2 / promote at the Engine + storage layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)