### PR TITLE
v4.6.1 — re-pin CIRISVerify stack to v5.0.0 (CEG 1.0 / Agent 3.0 substrate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.6.1] — 2026-06-09
+
+**Re-pin the CIRISVerify stack to v5.0.0 — the CEG 1.0 / Agent 3.0 substrate release.**
+
+`ciris-verify-core` / `ciris-keyring` / `ciris-crypto` move `v4.11.0 → v5.0.0` (tag + `version = "5"`, all six platform pins). The major bump is a **substrate-coherence milestone** (CEG 1.0 / Agent 3.0), not a breaking Rust API change for persist:
+- **CIRISVerify#61 (our OQ-1 ask) shipped** — `from ciris_verify import jcs_canonicalize` is now a Python binding over the same `ciris_verify_core::jcs::canonicalize` persist already consumes (Rust side). This unblocks the **agent producer** side of the 2.9.6 JCS cutover; persist's consumption is unchanged.
+- **CIRISVerify#60** adds `KeyAttestationResult.boundary_degraded: bool` (hardware-absent vs. hardware-present-but-compromised). persist reads platform-attestation types but does **not** construct `KeyAttestationResult`, so this is additive here.
+
+No persist code change — purely the dependency pin. **1045 lib green on SQLite, 747 on live PG** against v5.0.0; `-D warnings` + clippy clean. Keeps the substrate workspace-coherent at the v5/CEG-1.0 line ahead of the 2.9.6 triple.
+
 ## [4.6.0] — 2026-06-09
 
 **JCS (RFC 8785) canonicalization cutover — foundation + signed-epoch version gate + `attestation_promote` (CIRISPersist#171/#176; CEG 1.0 §0.9; FSD `V4_6_JCS_CANONICALIZATION.md`).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.6.0"
+version = "4.6.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -721,10 +721,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -735,7 +735,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.11.0", version = "4", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
Re-pins `ciris-verify-core` / `ciris-keyring` / `ciris-crypto` **v4.11.0 → v5.0.0** (tag + `version = "5"`, all six platform pins). The major bump is a **substrate-coherence milestone** (CEG 1.0 / Agent 3.0), not a breaking Rust API change for persist.

## What v5.0.0 brings (relative to 4.11.0)
- **CIRISVerify#61 — our OQ-1 ask, shipped.** `from ciris_verify import jcs_canonicalize` is now a Python binding over the same `ciris_verify_core::jcs::canonicalize` persist already consumes (Rust). This unblocks the **agent-producer** side of the 2.9.6 JCS cutover. persist's Rust consumption is unchanged.
- **CIRISVerify#60** — `KeyAttestationResult` gains `boundary_degraded: bool` (hardware-absent vs. hardware-present-but-compromised). persist reads platform-attestation types but does **not** construct `KeyAttestationResult`, so additive here.

## Verification
No persist code change — purely the dependency pin. Confirmed clean compile + full green on both backends against v5.0.0:
- **1045 lib green on SQLite, 747 on live PG**; `-D warnings` clean across the full feature set; clippy clean over `--tests`.

Keeps the substrate workspace-coherent at the v5 / CEG-1.0 line ahead of the 2.9.6 triple (agent 3.0 JCS + persist 4.6 + ciris-verify 5.0.0 + edge + lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)