### PR TITLE
v4.7.0 — typed register_public_key: Registered / AlreadyRegistered / RotationCollision (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.7.0] — 2026-06-09
+
+**Typed `register_public_key` — `Registered` / `AlreadyRegistered` / `RotationCollision` (CIRISPersist#177; CEG §0.0; gates CIRISAgent#809).**
+
+`register_public_key` (the agent's sole boot-time key-registration call → `accord_public_keys`) now returns a **typed result dict** instead of `None`. Consumers stop reverse-engineering the insert-vs-match-vs-rotation determination from an exception string (`str(exc).lower()` for `"already"/"exists"/"conflict"`) — per CEG §0.0 the substrate authors the trust-relevant signal; the consumer surfaces it.
+
+**The bug this fixes is sharper than "fragile string-match":** the prior path was `INSERT … ON CONFLICT (key_id) DO NOTHING` with **no collision detection at all**. A same-`key_id`/different-pubkey rotation was **silently swallowed** — invisible, not mis-reported. So the agent's rotation-collision handler (CIRISAgent#809) was **dead code**: the signal it branched on never existed. This release makes a key rotation observable for the first time.
+
+### Added
+- **`store::KeyRegistrationOutcome`** — `Registered` (newly inserted) / `AlreadyRegistered` (idempotent same-pubkey match — the steady-state reboot path) / `RotationCollision { existing_key_fingerprint }` (same `key_id`, **different** pubkey — a rotation / potential-compromise signal). A collision is a **normal return value, not an error** — the idempotent boot path stays non-throwing.
+- **`store::classify_key_registration`** (pure, exhaustively unit-tested incl. the TOCTOU edge — never fabricates a false rotation alarm) + **`store::accord_key_fingerprint`** (SHA-256 hex of the **stored** pubkey).
+- **`PostgresBackend::register_accord_public_key` / `SqliteBackend::register_accord_public_key`** — `INSERT … ON CONFLICT DO NOTHING` → read-after-conflict on the same connection → classify. Collision is **non-destructive** (the stored pubkey is never overwritten).
+
+### Changed — PyO3 surface
+`register_public_key(...)` returns a dict `{ "status", "key_id", ["existing_key_fingerprint"] }` (was `None`). `status` ∈ `"registered" | "already_registered" | "rotation_collision"`; `existing_key_fingerprint` is present only for `rotation_collision`. The agent replaces its `except`-string block with a typed match and surfaces `rotation_collision` on `/v1/system/health` (#809). Source-compatible for callers that ignored the return.
+
+### Scope
+Targets `register_public_key` per the agent's confirmation that it is the agent's *sole* key-registration call (`put_public_key`/`federation_keys` is reached only inside Edge's Rust). Whether the agent's federation signing key should instead live in `federation_keys` (which already has Conflict detection) is a CEG-native key-model question — **CIRISAgent#840, out of scope here**.
+
+### Tests
+Pure classifier (5 cases: insert / idempotent / collision-fingerprint / TOCTOU / status tokens) + **SQLite and live-PG round-trips** (registered → already_registered → rotation_collision, asserting fingerprint-of-stored + non-destructive). **1052 lib green on SQLite, 753 on live PG**; `-D warnings` + clippy clean.
+
 ## [4.6.1] — 2026-06-09
 
 **Re-pin the CIRISVerify stack to v5.0.0 — the CEG 1.0 / Agent 3.0 substrate release.**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.6.1"
+version = "4.7.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2377,27 +2377,42 @@ impl PyEngine {
     ///   `accord_public_keys.expires_at`.
     /// - `added_by` — operator / process annotation for audit.
     ///
-    /// Idempotent: re-registering the same `signature_key_id`
-    /// is a no-op (ON CONFLICT DO NOTHING). For genuine key
-    /// rotation, use the lens's revocation surface (set
-    /// `revoked_at` on the old row, register a new row with a
-    /// different `signature_key_id`). Mission constraint
-    /// (MISSION.md §3 anti-pattern #3): no automated key rotation
-    /// under attacker control.
+    /// Idempotent: re-registering the same `signature_key_id` with the
+    /// **same** pubkey is a no-op. For genuine key rotation, use the
+    /// lens's revocation surface (set `revoked_at` on the old row,
+    /// register a new row with a different `signature_key_id`). Mission
+    /// constraint (MISSION.md §3 anti-pattern #3): no automated key
+    /// rotation under attacker control.
+    ///
+    /// v4.7.0 (CIRISPersist#177) — **returns a typed result dict**
+    /// instead of `None`, so consumers no longer reverse-engineer the
+    /// insert-vs-match-vs-rotation determination from an exception
+    /// string (per CEG §0.0 the substrate authors trust signals; the
+    /// consumer surfaces them). The dict carries:
+    /// - `status` — `"registered"` (newly inserted) /
+    ///   `"already_registered"` (idempotent same-pubkey match) /
+    ///   `"rotation_collision"` (same `key_id`, **different** pubkey — a
+    ///   rotation / potential-compromise signal; CIRISAgent#809).
+    /// - `key_id` — echoed for the caller's convenience.
+    /// - `existing_key_fingerprint` — present **only** for
+    ///   `rotation_collision`: SHA-256 hex of the stored pubkey.
+    ///
+    /// A rotation collision is a normal return, **not** an exception —
+    /// the idempotent boot path stays non-throwing.
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (signature_key_id, public_key_b64,
                         algorithm = None, description = None,
                         expires_at = None, added_by = None))]
-    fn register_public_key(
+    fn register_public_key<'py>(
         &self,
-        py: Python<'_>,
+        py: Python<'py>,
         signature_key_id: &str,
         public_key_b64: &str,
         algorithm: Option<&str>,
         description: Option<&str>,
         expires_at: Option<&str>,
         added_by: Option<&str>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Bound<'py, PyDict>> {
         self.ensure_usable()?;
         catch_panic(|| {
             let runtime = self.runtime.clone();
@@ -2417,65 +2432,53 @@ impl PyEngine {
                 })?),
             };
 
-            py.detach(move || match &self.backend {
+            let key_id_for_dict = key_id.clone();
+            let outcome = py.detach(move || match &self.backend {
                 BackendDispatch::Postgres(pg) => {
                     let backend = pg.clone();
                     runtime.block_on(async move {
-                        let client = backend
-                            .pool()
-                            .get()
-                            .await
-                            .map_err(|e| PyRuntimeError::new_err(format!("pool: {e}")))?;
-                        client
-                            .execute(
-                                "INSERT INTO cirislens.accord_public_keys \
-                             (key_id, public_key_base64, algorithm, description, \
-                              expires_at, added_by) \
-                             VALUES ($1, $2, $3, $4, $5, $6) \
-                             ON CONFLICT (key_id) DO NOTHING",
-                                &[&key_id, &pub_b64, &algo, &desc, &expires_dt, &added],
+                        backend
+                            .register_accord_public_key(
+                                &key_id,
+                                &pub_b64,
+                                &algo,
+                                desc.as_deref(),
+                                expires_dt,
+                                added.as_deref(),
                             )
                             .await
-                            .map_err(|e| PyRuntimeError::new_err(format!("register: {e}")))?;
-                        Ok::<_, PyErr>(())
+                            .map_err(|e| PyRuntimeError::new_err(format!("register: {e}")))
                     })
                 }
                 #[cfg(feature = "sqlite")]
                 BackendDispatch::Sqlite(sq) => {
-                    // SQLite shape (migrations/sqlite/lens/V001
-                    // accord_public_keys): unqualified table name (no
-                    // `cirislens.` schema prefix), `?N` placeholders,
-                    // TEXT-encoded ISO-8601 for `expires_at` matching
-                    // the rest of the SQLite TEXT-as-TIMESTAMPTZ
-                    // convention. Idempotent on `key_id` PRIMARY KEY
-                    // via `ON CONFLICT DO NOTHING` (same shape as PG).
-                    let conn = sq.conn_handle();
-                    let expires_text: Option<String> = expires_dt.map(|t| t.to_rfc3339());
+                    let backend = sq.clone();
                     runtime.block_on(async move {
-                        (move || -> Result<(), rusqlite::Error> {
-                            let conn = conn.lock();
-                            conn.execute(
-                                    "INSERT INTO accord_public_keys \
-                                     (key_id, public_key_base64, algorithm, description, \
-                                      expires_at, added_by) \
-                                     VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
-                                     ON CONFLICT (key_id) DO NOTHING",
-                                    rusqlite::params![
-                                        key_id,
-                                        pub_b64,
-                                        algo,
-                                        desc,
-                                        expires_text,
-                                        added,
-                                    ],
-                                )?;
-                            Ok(())
-                        })()
-                        .map_err(|e| PyRuntimeError::new_err(format!("register: {e}")))?;
-                        Ok::<_, PyErr>(())
+                        backend
+                            .register_accord_public_key(
+                                &key_id,
+                                &pub_b64,
+                                &algo,
+                                desc.as_deref(),
+                                expires_dt,
+                                added.as_deref(),
+                            )
+                            .await
+                            .map_err(|e| PyRuntimeError::new_err(format!("register: {e}")))
                     })
                 }
-            })
+            })?;
+
+            let dict = PyDict::new(py);
+            dict.set_item("status", outcome.status())?;
+            dict.set_item("key_id", key_id_for_dict)?;
+            if let crate::store::KeyRegistrationOutcome::RotationCollision {
+                existing_key_fingerprint,
+            } = &outcome
+            {
+                dict.set_item("existing_key_fingerprint", existing_key_fingerprint)?;
+            }
+            Ok(dict)
         })
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -33,7 +33,8 @@ pub use postgres::PostgresBackend;
 #[cfg(feature = "sqlite")]
 pub use sqlite::SqliteBackend;
 pub use types::{
-    AuditEntry, ClaimParams, GraphNode, ServiceCorrelation, Task, TraceEventRow, TraceLlmCallRow,
+    accord_key_fingerprint, classify_key_registration, AuditEntry, ClaimParams, GraphNode,
+    KeyRegistrationOutcome, ServiceCorrelation, Task, TraceEventRow, TraceLlmCallRow,
     VerificationSource,
 };
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -382,6 +382,63 @@ impl PostgresBackend {
             .map_err(|e| Error::Backend(format!("pool get: {e}")))
     }
 
+    /// v4.7.0 (CIRISPersist#177) — register an `accord_public_keys`
+    /// pubkey and return a typed [`KeyRegistrationOutcome`] instead of a
+    /// bare `Ok(())` that hid insert-vs-match-vs-rotation. Inserts
+    /// `ON CONFLICT (key_id) DO NOTHING`; on a no-op (conflict) it reads
+    /// the stored pubkey on the same client and classifies via the
+    /// shared [`crate::store::classify_key_registration`]. The idempotent
+    /// boot path stays non-throwing — a `RotationCollision` is a normal
+    /// return value (the trust signal CIRISAgent#809 surfaces), not an
+    /// error.
+    pub async fn register_accord_public_key(
+        &self,
+        key_id: &str,
+        public_key_base64: &str,
+        algorithm: &str,
+        description: Option<&str>,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+        added_by: Option<&str>,
+    ) -> Result<crate::store::KeyRegistrationOutcome, Error> {
+        let client = self.get_client().await?;
+        let inserted = client
+            .execute(
+                "INSERT INTO cirislens.accord_public_keys \
+                    (key_id, public_key_base64, algorithm, description, expires_at, added_by) \
+                 VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (key_id) DO NOTHING",
+                &[
+                    &key_id,
+                    &public_key_base64,
+                    &algorithm,
+                    &description,
+                    &expires_at,
+                    &added_by,
+                ],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("register insert: {e}")))?;
+        if inserted == 1 {
+            return Ok(crate::store::KeyRegistrationOutcome::Registered);
+        }
+        // Conflict — read the stored pubkey on the same client to classify.
+        let existing: Option<String> = client
+            .query_opt(
+                "SELECT public_key_base64 FROM cirislens.accord_public_keys WHERE key_id = $1",
+                &[&key_id],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("register read: {e}")))?
+            .map(|r| r.try_get::<_, String>(0))
+            .transpose()
+            .map_err(|e| Error::Backend(format!("register read col: {e}")))?;
+        Ok(crate::store::classify_key_registration(
+            false,
+            existing.as_deref(),
+            public_key_base64,
+        ))
+    }
+
     /// Open a one-shot non-pooled connection. Used by
     /// [`Backend::run_migrations`] to hold the session-scoped
     /// advisory lock. When the returned client drops, the
@@ -20335,5 +20392,59 @@ mod tests {
             .await,
             want_valid
         );
+    }
+
+    /// v4.7.0 (CIRISPersist#177) — live-PG round-trip for the typed
+    /// key-registration outcome. Mirrors the SQLite twin: new key →
+    /// `Registered`; same key+pubkey → `AlreadyRegistered`; same key,
+    /// different pubkey → `RotationCollision` (fingerprint of the stored
+    /// key) and the stored row is left intact. Unique `key_id` per run
+    /// for the shared DB.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_register_accord_public_key_classifies_outcomes() {
+        use crate::store::{accord_key_fingerprint, KeyRegistrationOutcome};
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let key_id = format!("agent-k-{}", uuid_like());
+
+        let reg = backend
+            .register_accord_public_key(&key_id, "pubA", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        assert_eq!(reg, KeyRegistrationOutcome::Registered);
+
+        let again = backend
+            .register_accord_public_key(&key_id, "pubA", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        assert_eq!(again, KeyRegistrationOutcome::AlreadyRegistered);
+
+        let collision = backend
+            .register_accord_public_key(&key_id, "pubB", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        match collision {
+            KeyRegistrationOutcome::RotationCollision {
+                existing_key_fingerprint,
+            } => assert_eq!(existing_key_fingerprint, accord_key_fingerprint("pubA")),
+            other => panic!("expected RotationCollision, got {other:?}"),
+        }
+        // Non-destructive: the stored pubkey is unchanged.
+        let client = backend.get_client().await.unwrap();
+        let stored: String = client
+            .query_one(
+                "SELECT public_key_base64 FROM cirislens.accord_public_keys WHERE key_id = $1",
+                &[&key_id],
+            )
+            .await
+            .unwrap()
+            .try_get::<_, String>(0)
+            .unwrap();
+        assert_eq!(stored, "pubA", "rotation collision must not overwrite");
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -113,6 +113,64 @@ impl SqliteBackend {
         self.conn.clone()
     }
 
+    /// v4.7.0 (CIRISPersist#177) — SQLite twin of
+    /// [`PostgresBackend::register_accord_public_key`]. Inserts
+    /// `ON CONFLICT (key_id) DO NOTHING`; on a no-op reads the stored
+    /// pubkey on the same locked connection and classifies via the
+    /// shared [`crate::store::classify_key_registration`]. Returns a
+    /// typed [`KeyRegistrationOutcome`](crate::store::KeyRegistrationOutcome);
+    /// a rotation collision is a normal return, not an error.
+    pub async fn register_accord_public_key(
+        &self,
+        key_id: &str,
+        public_key_base64: &str,
+        algorithm: &str,
+        description: Option<&str>,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+        added_by: Option<&str>,
+    ) -> Result<crate::store::KeyRegistrationOutcome, Error> {
+        let conn = self.conn.clone();
+        let key_id = key_id.to_owned();
+        let pubkey = public_key_base64.to_owned();
+        let algorithm = algorithm.to_owned();
+        let description = description.map(str::to_owned);
+        let expires_text: Option<String> = expires_at.map(|t| t.to_rfc3339());
+        let added_by = added_by.map(str::to_owned);
+        (move || -> Result<crate::store::KeyRegistrationOutcome, rusqlite::Error> {
+            let conn = conn.lock();
+            let inserted = conn.execute(
+                "INSERT INTO accord_public_keys \
+                    (key_id, public_key_base64, algorithm, description, expires_at, added_by) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                 ON CONFLICT (key_id) DO NOTHING",
+                rusqlite::params![
+                    key_id,
+                    pubkey,
+                    algorithm,
+                    description,
+                    expires_text,
+                    added_by
+                ],
+            )?;
+            if inserted == 1 {
+                return Ok(crate::store::KeyRegistrationOutcome::Registered);
+            }
+            let existing: Option<String> = conn
+                .query_row(
+                    "SELECT public_key_base64 FROM accord_public_keys WHERE key_id = ?1",
+                    [&key_id],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            Ok(crate::store::classify_key_registration(
+                false,
+                existing.as_deref(),
+                &pubkey,
+            ))
+        })()
+        .map_err(|e| Error::Backend(format!("register_accord_public_key: {e}")))
+    }
+
     /// v2.1 (CIRISPersist#101) — construct a `SqliteBackend` from an
     /// existing connection handle (e.g. one shared with the cirisnode
     /// substrate). Used internally by `cirisnode::sqlite` to compose
@@ -12833,6 +12891,62 @@ mod tests {
             .put_attestation(SignedAttestation { attestation: att })
             .await
             .unwrap();
+    }
+
+    // ─── v4.7.0 (CIRISPersist#177) — typed register_accord_public_key ──
+
+    /// SQLite round-trip for the typed key-registration outcome: a new
+    /// key → `Registered`; the same key+pubkey → `AlreadyRegistered`; the
+    /// same key with a *different* pubkey → `RotationCollision` carrying
+    /// the SHA-256 fingerprint of the **stored** (original) pubkey.
+    #[tokio::test]
+    async fn sqlite_register_accord_public_key_classifies_outcomes() {
+        use crate::store::{accord_key_fingerprint, KeyRegistrationOutcome};
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let reg = backend
+            .register_accord_public_key("agent-k", "pubA", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        assert_eq!(reg, KeyRegistrationOutcome::Registered);
+
+        let again = backend
+            .register_accord_public_key("agent-k", "pubA", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        assert_eq!(
+            again,
+            KeyRegistrationOutcome::AlreadyRegistered,
+            "same key+pubkey is the idempotent reboot path"
+        );
+
+        let collision = backend
+            .register_accord_public_key("agent-k", "pubB", "Ed25519", None, None, Some("boot"))
+            .await
+            .unwrap();
+        match collision {
+            KeyRegistrationOutcome::RotationCollision {
+                existing_key_fingerprint,
+            } => assert_eq!(
+                existing_key_fingerprint,
+                accord_key_fingerprint("pubA"),
+                "fingerprint is of the STORED key, not the incoming one"
+            ),
+            other => panic!("expected RotationCollision, got {other:?}"),
+        }
+        // The collision is non-destructive: the stored pubkey is unchanged.
+        let stored: String = {
+            let conn = backend.conn_handle();
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT public_key_base64 FROM accord_public_keys WHERE key_id = 'agent-k'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored, "pubA", "rotation collision must not overwrite");
     }
 
     // ─── BlobStorage tests (v2.3, CIRISPersist#103) ────────────────

--- a/src/store/types.rs
+++ b/src/store/types.rs
@@ -454,3 +454,143 @@ pub struct ClaimParams<'a> {
     /// Wall-clock at the moment of claim.
     pub now: DateTime<Utc>,
 }
+
+/// v4.7.0 (CIRISPersist#177) — typed outcome of registering an
+/// `accord_public_keys` pubkey (the agent's boot-time signing-key
+/// registration). Replaces the string-matchable exception consumers
+/// reverse-engineered (`str(exc).lower()` for "already"/"exists"/
+/// "conflict"). A rotation collision is a **normal return value, not an
+/// error**, so the idempotent boot path stays non-throwing; per CEG §0.0
+/// the substrate authors the trust-relevant signal and the consumer
+/// surfaces it without parsing exception strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyRegistrationOutcome {
+    /// Newly inserted — no prior row for this `key_id`.
+    Registered,
+    /// Idempotent match — the `key_id` already maps to the **same**
+    /// pubkey. The expected steady-state on every reboot.
+    AlreadyRegistered,
+    /// The `key_id` already maps to a **different** pubkey — a key
+    /// rotation / potential-compromise signal the consumer MUST surface
+    /// (CIRISAgent#809). Carries a stable fingerprint of the *existing*
+    /// (stored) key so the consumer can log/compare without handling raw
+    /// key material.
+    RotationCollision {
+        /// SHA-256 (hex) of the stored `public_key_base64`.
+        existing_key_fingerprint: String,
+    },
+}
+
+impl KeyRegistrationOutcome {
+    /// Stable discriminator token for the PyO3 dict / logs / metrics.
+    pub fn status(&self) -> &'static str {
+        match self {
+            Self::Registered => "registered",
+            Self::AlreadyRegistered => "already_registered",
+            Self::RotationCollision { .. } => "rotation_collision",
+        }
+    }
+}
+
+/// SHA-256 (hex) of a stored pubkey base64 — the stable fingerprint
+/// carried on [`KeyRegistrationOutcome::RotationCollision`].
+pub fn accord_key_fingerprint(public_key_base64: &str) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(public_key_base64.as_bytes()))
+}
+
+/// Classify a registration attempt from the `INSERT … ON CONFLICT DO
+/// NOTHING` result plus any pre-existing row, read back on the same
+/// connection. Pure (no IO) so backends share one definition and it is
+/// exhaustively unit-testable.
+///
+/// - `inserted` — the insert affected a row (no prior `key_id`).
+/// - `existing_public_key_base64` — the stored pubkey when the insert
+///   was a no-op (conflict), else `None`.
+///
+/// The `inserted == false && existing == None` case is a benign TOCTOU
+/// (the conflicting row was deleted between insert and read on an
+/// otherwise append-only table); we report [`AlreadyRegistered`] rather
+/// than fabricate a [`RotationCollision`] — never raise a false rotation
+/// alarm.
+///
+/// [`AlreadyRegistered`]: KeyRegistrationOutcome::AlreadyRegistered
+/// [`RotationCollision`]: KeyRegistrationOutcome::RotationCollision
+pub fn classify_key_registration(
+    inserted: bool,
+    existing_public_key_base64: Option<&str>,
+    new_public_key_base64: &str,
+) -> KeyRegistrationOutcome {
+    if inserted {
+        return KeyRegistrationOutcome::Registered;
+    }
+    match existing_public_key_base64 {
+        Some(existing) if existing == new_public_key_base64 => {
+            KeyRegistrationOutcome::AlreadyRegistered
+        }
+        Some(existing) => KeyRegistrationOutcome::RotationCollision {
+            existing_key_fingerprint: accord_key_fingerprint(existing),
+        },
+        None => KeyRegistrationOutcome::AlreadyRegistered,
+    }
+}
+
+#[cfg(test)]
+mod keyreg_tests {
+    use super::*;
+
+    #[test]
+    fn classify_new_insert_is_registered() {
+        assert_eq!(
+            classify_key_registration(true, None, "pubA"),
+            KeyRegistrationOutcome::Registered
+        );
+    }
+
+    #[test]
+    fn classify_conflict_same_pubkey_is_already_registered() {
+        assert_eq!(
+            classify_key_registration(false, Some("pubA"), "pubA"),
+            KeyRegistrationOutcome::AlreadyRegistered
+        );
+    }
+
+    #[test]
+    fn classify_conflict_different_pubkey_is_rotation_collision() {
+        let out = classify_key_registration(false, Some("pubOLD"), "pubNEW");
+        match out {
+            KeyRegistrationOutcome::RotationCollision {
+                existing_key_fingerprint,
+            } => {
+                assert_eq!(existing_key_fingerprint, accord_key_fingerprint("pubOLD"));
+                assert_eq!(existing_key_fingerprint.len(), 64, "sha256 hex");
+            }
+            other => panic!("expected RotationCollision, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_conflict_vanished_row_is_benign_not_false_collision() {
+        // TOCTOU: never fabricate a rotation alarm.
+        assert_eq!(
+            classify_key_registration(false, None, "pubA"),
+            KeyRegistrationOutcome::AlreadyRegistered
+        );
+    }
+
+    #[test]
+    fn status_tokens_are_stable() {
+        assert_eq!(KeyRegistrationOutcome::Registered.status(), "registered");
+        assert_eq!(
+            KeyRegistrationOutcome::AlreadyRegistered.status(),
+            "already_registered"
+        );
+        assert_eq!(
+            KeyRegistrationOutcome::RotationCollision {
+                existing_key_fingerprint: "x".into()
+            }
+            .status(),
+            "rotation_collision"
+        );
+    }
+}


### PR DESCRIPTION
`register_public_key` (the agent's sole boot-time key-registration call → `accord_public_keys`) now returns a **typed result dict** instead of `None`. Consumers stop reverse-engineering insert-vs-match-vs-rotation from an exception string (per CEG §0.0 the substrate authors the trust signal; the consumer surfaces it). **Gates CIRISAgent#809.**

## The bug is sharper than "fragile string-match"
The prior path was `INSERT … ON CONFLICT (key_id) DO NOTHING` with **no collision detection at all** — a same-`key_id`/different-pubkey rotation was **silently swallowed**, invisible. So the agent's rotation-collision handler (#809) was **dead code**: the signal it branched on never existed. This release makes a rotation observable for the first time. (Confirmed by the agent: `register_public_key` is its *only* key-registration call; `put_public_key`/`federation_keys` is Edge-Rust-only.)

## Added
- **`store::KeyRegistrationOutcome`** — `Registered` / `AlreadyRegistered` (idempotent same-pubkey reboot) / `RotationCollision { existing_key_fingerprint }`. A collision is a **normal return value, not an error** — idempotent boot stays non-throwing.
- **`store::classify_key_registration`** (pure, exhaustively unit-tested incl. the TOCTOU edge — never a false rotation alarm) + **`store::accord_key_fingerprint`** (SHA-256 hex of the *stored* pubkey).
- **`{Postgres,Sqlite}Backend::register_accord_public_key`** — insert-on-conflict → read-after-conflict (same connection) → classify. Collision is **non-destructive**.

## Changed — PyO3
`register_public_key(...)` returns `{ "status", "key_id", ["existing_key_fingerprint"] }` (was `None`). `status` ∈ `registered | already_registered | rotation_collision`. Agent replaces its `except`-string block with a typed match + surfaces `rotation_collision` on `/v1/system/health` (#809). Source-compatible for callers that ignored the return.

## Scope
The accord_public_keys-vs-federation_keys key-model question is **CIRISAgent#840**, out of scope here.

## Tests
Pure classifier (5 cases) + **SQLite and live-PG round-trips** (registered → already_registered → rotation_collision; fingerprint-of-stored + non-destructive). **1052 lib green on SQLite, 753 on live PG**; `-D warnings` + clippy clean.

Closes #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)