### PR TITLE
v4.8.0 — Option-A forward-secrecy removal/revocation primitives (#161 P1-3, CEG §11.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.8.0] — 2026-06-09
+
+**Option-A forward-secrecy removal/revocation substrate primitives (CIRISPersist#161 Phases 1–3; CEG §11.7.1).**
+
+V059 (identity_occurrence + family) and V060 (community) landed the **admission** side append-only, with no way to express "this binding/membership is currently revoked." So a removed member's read access persisted silently — `build_caller_admission` resolved every roster row regardless of revocation state. This cut closes that forge surface: the substrate can now express revocation, and the honest "currently-bound" view is what admission resolves through.
+
+### Added — V067 migration (PG + SQLite)
+Three append-only revocation tables, symmetric to the V059/V060 admission tables: `federation_identity_occurrence_revocations`, `federation_family_membership_revocations`, `federation_community_membership_revocations`. Each: subject + removed id, `revoked_at`/`removed_at`, `effective_at`, `reason`, `witness_set` (JSONB / JSON-TEXT array of vouching key_ids — single-vouch for self per §11.7.4, multi-vouch per the family/community `consensus_protocol`), `persist_row_hash`; composite PK + `effective_at` + by-removed indexes. **Supersedes V059's "an occurrence withdraws rides `federation_revocations`" note** — that table revokes a *key* globally and carries no `witness_set`, so it can't express a *binding* or *membership* removal.
+
+### Added — types + write/read surface (Asks 1–2)
+- `IdentityOccurrenceRevocation` / `FamilyMembershipRevocation` / `CommunityMembershipRevocation` + `Signed*` wrappers.
+- `FederationDirectory::put_{identity_occurrence,family_membership,community_membership}_revocation` + `list_*_revocations_for` — implemented on all three backends (Postgres / SQLite / memory). `persist_row_hash` server-computed; a revocation is **append-only** and **non-destructive** (the admission row/roster is left intact). FK-violation (subject/removed key absent) → `InvalidArgument`.
+- `list_identity_occurrences_active` / `list_families_for_member_active` / `list_communities_for_member_active` — the honest "currently-bound" view (admitted AND no revocation with `effective_at <= now`), as **default trait methods** composing the admission read with the revocation read. The existing `list_*_for` / `list_*_for_member` remain the **full-history** accessors.
+
+### Changed — honest CallerAdmission (Ask 6, the forge-surface closure)
+`build_caller_admission` now honors revocation: a **revoked occurrence falls through to the §4.4 singleton fallback** (it speaks only for itself, inheriting no identity/family/community admission), and `family_key_ids` / `community_key_ids` resolve through the `_active` reads (removed memberships excluded). Without this, a removed member's read access persisted silently.
+
+### Design note — additive, not a breaking rename
+#161 Ask 2 suggested renaming `list_*` → `list_*_active` (active-by-default). We chose **additive `_active` methods + wiring the one security-critical caller** (`build_caller_admission`) instead — the existing accessors are widely used and reading "all rows" is the documented full-history contract. No current caller is left unsafe (the DEK cascade caller is Ask 4, deferred). Net: same security property, no gratuitous breakage.
+
+### Deferred — Ask 4 (producer-side forward-secrecy gate)
+The "stop wrapping new `key_grant`s to a removed party" enforcement at `put_blob_signing` gates on the at-rest **ADD** key_grant cascade (#152), which is not in persist yet — there is no ADD cascade to make symmetric. Lands when #152 does. Ask 5 (reserved-prefix `*_membership_change` emission on removal) rides the same future cut.
+
+### Tests
+SQLite + live-PG round-trips (put → list → active-state filtering, incl. future-dated revocation does-not-take-effect, JSONB `witness_set` order-preserving round-trip, FK→`InvalidArgument`) + the two Ask-6 `build_caller_admission` honesty tests (revoked occurrence → singleton; removed family member → dropped). **1056 lib green on SQLite, 754 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full `--tests`; clippy clean.
+
 ## [4.7.0] — 2026-06-09
 
 **Typed `register_public_key` — `Registered` / `AlreadyRegistered` / `RotationCollision` (CIRISPersist#177; CEG §0.0; gates CIRISAgent#809).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.7.0"
+version = "4.8.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V067__ceg_11_7_membership_revocations.sql
+++ b/migrations/postgres/lens/V067__ceg_11_7_membership_revocations.sql
@@ -1,0 +1,136 @@
+-- V067 — CEG §11.7.1 Option-A forward-secrecy removal/revocation
+--        substrate primitives (CIRISPersist#161 Asks 1-3, v4.8.0).
+--
+-- V059 (identity_occurrence + family) and V060 (community) landed the
+-- ADMISSION side append-only, with no way to express "this binding /
+-- membership is currently revoked." V059's header note assumed an
+-- occurrence withdraws could ride the existing federation_revocations
+-- table — but that table revokes a KEY globally (revoked_key_id), not a
+-- *binding* or a *membership*, and it carries no witness_set for the
+-- family/community multi-vouch consensus_protocol path. So removal needs
+-- its own surface. These three tables supersede that assumption.
+--
+-- CEG §11.7.1 (Option-A forward secrecy): "when a member leaves a family
+-- (or an occurrence is revoked from a self-collective), the removed
+-- party retains existing key_grants for historical content; the
+-- substrate stops wrapping new key_grants on subsequent content." That
+-- stop-wrapping rule needs a substrate-side "is currently revoked"
+-- primitive; these tables provide it. The producer-side enforcement gate
+-- (CIRISPersist#161 Ask 4) is deferred until the at-rest ADD key_grant
+-- cascade (#152) lands — there is no ADD cascade to make symmetric yet.
+--
+-- Append-only, symmetric to the V059/V060 admission tables. A revocation
+-- is a NEW row that supersedes the binding; effective state =
+-- (admitted AND NOT EXISTS matching revocation with effective_at <= now).
+-- witness_set is the vouch set: single-vouch for self (CEG §11.7.4 — the
+-- revoking occurrence OR the identity_key_id), multi-vouch for
+-- family/community per the consensus_protocol (Registry-validated,
+-- CIRISRegistry#52). persist_row_hash is server-computed.
+
+-- ─── identity_occurrence revocations ───────────────────────────────
+--
+-- Revokes a single (identity_key_id, occurrence_key_id) V059 binding.
+-- PK on the binding pair — one revocation per binding (idempotent
+-- re-revoke). The binding's admission row in
+-- federation_identity_occurrences is left intact; the active-state read
+-- (V4.8 list_identity_occurrences_active) excludes pairs that have a
+-- matching row here with effective_at <= now().
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_identity_occurrence_revocations (
+    identity_key_id     TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+    occurrence_key_id   TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+
+    -- §0.5 canonical timestamps. revoked_at = when the ceremony issued
+    -- it; effective_at = when it takes effect (may be future-dated).
+    revoked_at          TIMESTAMPTZ NOT NULL,
+    effective_at        TIMESTAMPTZ NOT NULL,
+
+    reason              TEXT,
+
+    -- Vouch set (array of federation_keys.key_id). Single-vouch for self
+    -- per §11.7.4. Stored as a JSON array; members are NOT FK'd (mirrors
+    -- the family/community members roster shape).
+    witness_set         JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(witness_set) = 'array'),
+
+    persist_row_hash    TEXT NOT NULL,
+
+    PRIMARY KEY (identity_key_id, occurrence_key_id)
+);
+
+-- Active-state computation: "is this binding revoked as of now?" The PK
+-- already covers by-identity prefix lookup (list_*_revocations_for); this
+-- index serves the effective_at <= now() filter.
+CREATE INDEX IF NOT EXISTS federation_identity_occurrence_revocations_effective
+    ON cirislens.federation_identity_occurrence_revocations (effective_at);
+
+-- Reverse lookup: "is this occurrence revoked from its identity?" (the
+-- CallerAdmission singleton-fallback resolution path).
+CREATE INDEX IF NOT EXISTS federation_identity_occurrence_revocations_by_occurrence
+    ON cirislens.federation_identity_occurrence_revocations (occurrence_key_id);
+
+-- ─── family membership revocations ─────────────────────────────────
+--
+-- Removes one identity from a family roster. PK on
+-- (family_key_id, removed_identity_key_id). The family's V059 members
+-- JSONB roster is left intact; the active-membership read filters here.
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_family_membership_revocations (
+    family_key_id            TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+    removed_identity_key_id  TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+
+    removed_at               TIMESTAMPTZ NOT NULL,
+    effective_at             TIMESTAMPTZ NOT NULL,
+
+    reason                   TEXT,
+
+    -- Multi-vouch per the family's consensus_protocol (Registry-validated
+    -- per CIRISRegistry#52 Ask 2). JSON array of key_ids.
+    witness_set              JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(witness_set) = 'array'),
+
+    persist_row_hash         TEXT NOT NULL,
+
+    PRIMARY KEY (family_key_id, removed_identity_key_id)
+);
+
+CREATE INDEX IF NOT EXISTS federation_family_membership_revocations_effective
+    ON cirislens.federation_family_membership_revocations (effective_at);
+
+-- "which families has this identity been removed from?" (CallerAdmission
+-- family_key_ids honest-resolution filter).
+CREATE INDEX IF NOT EXISTS federation_family_membership_revocations_by_member
+    ON cirislens.federation_family_membership_revocations (removed_identity_key_id);
+
+-- ─── community membership revocations ──────────────────────────────
+--
+-- Symmetric to family. Removes one identity from a community roster.
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_community_membership_revocations (
+    community_key_id         TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+    removed_identity_key_id  TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+
+    removed_at               TIMESTAMPTZ NOT NULL,
+    effective_at             TIMESTAMPTZ NOT NULL,
+
+    reason                   TEXT,
+
+    witness_set              JSONB NOT NULL DEFAULT '[]'::jsonb
+        CHECK (jsonb_typeof(witness_set) = 'array'),
+
+    persist_row_hash         TEXT NOT NULL,
+
+    PRIMARY KEY (community_key_id, removed_identity_key_id)
+);
+
+CREATE INDEX IF NOT EXISTS federation_community_membership_revocations_effective
+    ON cirislens.federation_community_membership_revocations (effective_at);
+
+CREATE INDEX IF NOT EXISTS federation_community_membership_revocations_by_member
+    ON cirislens.federation_community_membership_revocations (removed_identity_key_id);

--- a/migrations/sqlite/lens/V067__ceg_11_7_membership_revocations.sql
+++ b/migrations/sqlite/lens/V067__ceg_11_7_membership_revocations.sql
@@ -1,0 +1,72 @@
+-- V067 — CEG §11.7.1 Option-A forward-secrecy removal/revocation
+--        substrate primitives (CIRISPersist#161 Asks 1-3, v4.8.0) —
+--        SQLite dialect. Postgres parity: postgres/lens/V067. See that
+--        file for the full design rationale + the V059 "withdraws
+--        suffices" reconciliation note.
+--
+-- Append-only, symmetric to the V059/V060 admission tables. A revocation
+-- is a NEW row that supersedes the binding; effective state =
+-- (admitted AND NOT EXISTS matching revocation with effective_at <= now).
+-- witness_set / timestamps are JSON TEXT / RFC-3339 TEXT (the SQLite
+-- convention; postgres uses JSONB / TIMESTAMPTZ). persist_row_hash is
+-- server-computed.
+--
+-- Refinery wraps this migration in its own transaction — no explicit
+-- BEGIN/COMMIT (matches the V059/V060 convention).
+
+-- ── identity_occurrence revocations ────────────────────────────────
+CREATE TABLE federation_identity_occurrence_revocations (
+    identity_key_id     TEXT NOT NULL REFERENCES federation_keys(key_id),
+    occurrence_key_id   TEXT NOT NULL REFERENCES federation_keys(key_id),
+    revoked_at          TEXT NOT NULL,   -- RFC-3339
+    effective_at        TEXT NOT NULL,   -- RFC-3339
+    reason              TEXT,
+    witness_set         TEXT NOT NULL DEFAULT '[]'   -- JSON array
+        CHECK (json_valid(witness_set) AND json_type(witness_set) = 'array'),
+    persist_row_hash    TEXT NOT NULL,
+    PRIMARY KEY (identity_key_id, occurrence_key_id)
+);
+
+CREATE INDEX federation_identity_occurrence_revocations_effective
+    ON federation_identity_occurrence_revocations (effective_at);
+
+CREATE INDEX federation_identity_occurrence_revocations_by_occurrence
+    ON federation_identity_occurrence_revocations (occurrence_key_id);
+
+-- ── family membership revocations ──────────────────────────────────
+CREATE TABLE federation_family_membership_revocations (
+    family_key_id            TEXT NOT NULL REFERENCES federation_keys(key_id),
+    removed_identity_key_id  TEXT NOT NULL REFERENCES federation_keys(key_id),
+    removed_at               TEXT NOT NULL,   -- RFC-3339
+    effective_at             TEXT NOT NULL,   -- RFC-3339
+    reason                   TEXT,
+    witness_set              TEXT NOT NULL DEFAULT '[]'   -- JSON array
+        CHECK (json_valid(witness_set) AND json_type(witness_set) = 'array'),
+    persist_row_hash         TEXT NOT NULL,
+    PRIMARY KEY (family_key_id, removed_identity_key_id)
+);
+
+CREATE INDEX federation_family_membership_revocations_effective
+    ON federation_family_membership_revocations (effective_at);
+
+CREATE INDEX federation_family_membership_revocations_by_member
+    ON federation_family_membership_revocations (removed_identity_key_id);
+
+-- ── community membership revocations ───────────────────────────────
+CREATE TABLE federation_community_membership_revocations (
+    community_key_id         TEXT NOT NULL REFERENCES federation_keys(key_id),
+    removed_identity_key_id  TEXT NOT NULL REFERENCES federation_keys(key_id),
+    removed_at               TEXT NOT NULL,   -- RFC-3339
+    effective_at             TEXT NOT NULL,   -- RFC-3339
+    reason                   TEXT,
+    witness_set              TEXT NOT NULL DEFAULT '[]'   -- JSON array
+        CHECK (json_valid(witness_set) AND json_type(witness_set) = 'array'),
+    persist_row_hash         TEXT NOT NULL,
+    PRIMARY KEY (community_key_id, removed_identity_key_id)
+);
+
+CREATE INDEX federation_community_membership_revocations_effective
+    ON federation_community_membership_revocations (effective_at);
+
+CREATE INDEX federation_community_membership_revocations_by_member
+    ON federation_community_membership_revocations (removed_identity_key_id);

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -134,10 +134,12 @@ pub use topology::{
     WithdrawalEntry, MAX_DELEGATION_DEPTH,
 };
 pub use types::{
-    Attestation, Community, CommunityMember, Family, FamilyMember, HybridPendingRow,
-    IdentityOccurrence, KeyRecord, PeerMetadataRow, PeerPolicyBlob, Revocation, SignedAttestation,
-    SignedCommunity, SignedFamily, SignedIdentityOccurrence, SignedKeyRecord, SignedRevocation,
-    TrustClass, TrustFilter, TrustGrant, TrustRelationship, TrustRow, TrustType,
+    Attestation, Community, CommunityMember, CommunityMembershipRevocation, Family, FamilyMember,
+    FamilyMembershipRevocation, HybridPendingRow, IdentityOccurrence, IdentityOccurrenceRevocation,
+    KeyRecord, PeerMetadataRow, PeerPolicyBlob, Revocation, SignedAttestation, SignedCommunity,
+    SignedCommunityMembershipRevocation, SignedFamily, SignedFamilyMembershipRevocation,
+    SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation, SignedKeyRecord,
+    SignedRevocation, TrustClass, TrustFilter, TrustGrant, TrustRelationship, TrustRow, TrustType,
 };
 
 /// Federation directory trait — the registry/lens/agent's read+write
@@ -474,6 +476,147 @@ pub trait FederationDirectory: Send + Sync {
         &self,
         member_identity_key_id: &str,
     ) -> Result<Vec<Community>, Error>;
+
+    // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — Option-A forward-
+    //     secrecy removal/revocation primitives. The `list_*_for` /
+    //     `list_*_for_member` methods above are the **full-history**
+    //     accessors (admit rows, no revocation filter). The
+    //     `list_*_active` default methods below compose them with the
+    //     revocation tables for the honest "currently-bound" view that
+    //     `build_caller_admission` (Ask 6) and the deferred forward-
+    //     secrecy key_grant gate (Ask 4) depend on.
+
+    /// v4.8.0 — record an identity-occurrence revocation (an occurrence
+    /// leaving a self-collective). Append-only; idempotent on the
+    /// `(identity_key_id, occurrence_key_id)` PK. Computes
+    /// `persist_row_hash` server-side. The V059 admission row is left
+    /// intact — effective state is the composition (see
+    /// [`Self::list_identity_occurrences_active`]).
+    async fn put_identity_occurrence_revocation(
+        &self,
+        revocation: SignedIdentityOccurrenceRevocation,
+    ) -> Result<(), Error>;
+
+    /// v4.8.0 — record a family-membership removal. Append-only;
+    /// idempotent on the `(family_key_id, removed_identity_key_id)` PK.
+    async fn put_family_membership_revocation(
+        &self,
+        revocation: SignedFamilyMembershipRevocation,
+    ) -> Result<(), Error>;
+
+    /// v4.8.0 — record a community-membership removal. Structural mirror
+    /// of [`Self::put_family_membership_revocation`].
+    async fn put_community_membership_revocation(
+        &self,
+        revocation: SignedCommunityMembershipRevocation,
+    ) -> Result<(), Error>;
+
+    /// v4.8.0 — all identity-occurrence revocations for `identity_key_id`
+    /// (no `effective_at` filter — full history). Keyed by the table's
+    /// leading PK column.
+    async fn list_identity_occurrence_revocations_for(
+        &self,
+        identity_key_id: &str,
+    ) -> Result<Vec<IdentityOccurrenceRevocation>, Error>;
+
+    /// v4.8.0 — all family-membership revocations for `family_key_id`.
+    async fn list_family_membership_revocations_for(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Vec<FamilyMembershipRevocation>, Error>;
+
+    /// v4.8.0 — all community-membership revocations for
+    /// `community_key_id`.
+    async fn list_community_membership_revocations_for(
+        &self,
+        community_key_id: &str,
+    ) -> Result<Vec<CommunityMembershipRevocation>, Error>;
+
+    /// v4.8.0 (#161 Ask 2) — occurrences of `identity_key_id` that are
+    /// **currently active**: admitted AND with no revocation whose
+    /// `effective_at <= now`. This is the honest view
+    /// [`build_caller_admission`](crate::scope::build_caller_admission)
+    /// resolves identity membership through; the deferred forward-
+    /// secrecy DEK cascade (#161 Ask 4) will fan out over it.
+    ///
+    /// Default impl composes [`Self::list_identity_occurrences_for`]
+    /// with [`Self::list_identity_occurrence_revocations_for`]; backends
+    /// need not override.
+    async fn list_identity_occurrences_active(
+        &self,
+        identity_key_id: &str,
+    ) -> Result<Vec<IdentityOccurrence>, Error> {
+        let revs = self
+            .list_identity_occurrence_revocations_for(identity_key_id)
+            .await?;
+        let now = chrono::Utc::now();
+        let revoked: std::collections::HashSet<&str> = revs
+            .iter()
+            .filter(|r| r.effective_at <= now)
+            .map(|r| r.occurrence_key_id.as_str())
+            .collect();
+        Ok(self
+            .list_identity_occurrences_for(identity_key_id)
+            .await?
+            .into_iter()
+            .filter(|o| !revoked.contains(o.occurrence_key_id.as_str()))
+            .collect())
+    }
+
+    /// v4.8.0 (#161 Ask 2) — families `member_identity_key_id` is
+    /// **currently** an active member of: a member of the roster AND not
+    /// removed by a revocation whose `effective_at <= now`. Default impl
+    /// composes [`Self::list_families_for_member`] with a per-family
+    /// [`Self::list_family_membership_revocations_for`] (family-count
+    /// cardinality is small — tens, not thousands).
+    async fn list_families_for_member_active(
+        &self,
+        member_identity_key_id: &str,
+    ) -> Result<Vec<Family>, Error> {
+        let now = chrono::Utc::now();
+        let families = self
+            .list_families_for_member(member_identity_key_id)
+            .await?;
+        let mut active = Vec::with_capacity(families.len());
+        for f in families {
+            let revs = self
+                .list_family_membership_revocations_for(&f.family_key_id)
+                .await?;
+            let removed = revs.iter().any(|r| {
+                r.removed_identity_key_id == member_identity_key_id && r.effective_at <= now
+            });
+            if !removed {
+                active.push(f);
+            }
+        }
+        Ok(active)
+    }
+
+    /// v4.8.0 (#161 Ask 2) — communities `member_identity_key_id` is
+    /// **currently** an active member of. Structural mirror of
+    /// [`Self::list_families_for_member_active`].
+    async fn list_communities_for_member_active(
+        &self,
+        member_identity_key_id: &str,
+    ) -> Result<Vec<Community>, Error> {
+        let now = chrono::Utc::now();
+        let communities = self
+            .list_communities_for_member(member_identity_key_id)
+            .await?;
+        let mut active = Vec::with_capacity(communities.len());
+        for c in communities {
+            let revs = self
+                .list_community_membership_revocations_for(&c.community_key_id)
+                .await?;
+            let removed = revs.iter().any(|r| {
+                r.removed_identity_key_id == member_identity_key_id && r.effective_at <= now
+            });
+            if !removed {
+                active.push(c);
+            }
+        }
+        Ok(active)
+    }
 
     /// v4.0 (CIRISPersist#160 comment 4, FSD §4.6) — AV-45 write-path
     /// cohort_scope admission gate, for write paths reachable through

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -962,6 +962,109 @@ pub struct SignedCommunity {
     pub community: Community,
 }
 
+// ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — Option-A forward-secrecy
+//     removal/revocation primitives. Append-only rows that SUPERSEDE a
+//     V059/V060 admission binding: effective membership =
+//     (admitted AND NOT revoked-with-effective_at<=now). The substrate's
+//     "this binding/membership is currently revoked" expression that the
+//     stop-wrapping rule (§11.7.1) and honest CallerAdmission depend on.
+
+/// Revokes a single V059 `(identity_key_id, occurrence_key_id)` binding
+/// (an occurrence leaving a self-collective). The admission row in
+/// `federation_identity_occurrences` is left intact; the active-state
+/// read excludes pairs with a matching revocation whose `effective_at`
+/// has passed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityOccurrenceRevocation {
+    /// The root identity's `federation_keys.key_id`.
+    pub identity_key_id: String,
+    /// The occurrence being revoked — a `federation_keys.key_id`.
+    pub occurrence_key_id: String,
+    /// When the revocation ceremony issued it (RFC-3339 per §0.5).
+    pub revoked_at: DateTime<Utc>,
+    /// When the revocation takes effect (may be future-dated). The
+    /// active-state filter is `effective_at <= now()`.
+    pub effective_at: DateTime<Utc>,
+    /// Optional operator/ceremony annotation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Vouch set (`federation_keys.key_id`s). Single-vouch for self per
+    /// §11.7.4 — the revoking occurrence OR the `identity_key_id`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub witness_set: Vec<String>,
+    /// **Server-computed.** See [`KeyRecord::persist_row_hash`].
+    pub persist_row_hash: String,
+}
+
+/// Wraps an [`IdentityOccurrenceRevocation`] for write submission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedIdentityOccurrenceRevocation {
+    /// The revocation being submitted.
+    pub identity_occurrence_revocation: IdentityOccurrenceRevocation,
+}
+
+/// Removes one identity from a V059 family roster. The family's
+/// `members` roster is left intact; the active-membership read filters
+/// against this table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FamilyMembershipRevocation {
+    /// The family's `federation_keys.key_id`.
+    pub family_key_id: String,
+    /// The removed member's identity `federation_keys.key_id`.
+    pub removed_identity_key_id: String,
+    /// When the removal ceremony issued it (RFC-3339 per §0.5).
+    pub removed_at: DateTime<Utc>,
+    /// When the removal takes effect. Active-state filter:
+    /// `effective_at <= now()`.
+    pub effective_at: DateTime<Utc>,
+    /// Optional operator/ceremony annotation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Vouch set — multi-vouch per the family's `consensus_protocol`
+    /// (Registry-validated, CIRISRegistry#52 Ask 2).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub witness_set: Vec<String>,
+    /// **Server-computed.** See [`KeyRecord::persist_row_hash`].
+    pub persist_row_hash: String,
+}
+
+/// Wraps a [`FamilyMembershipRevocation`] for write submission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedFamilyMembershipRevocation {
+    /// The revocation being submitted.
+    pub family_membership_revocation: FamilyMembershipRevocation,
+}
+
+/// Removes one identity from a V060 community roster. Structural mirror
+/// of [`FamilyMembershipRevocation`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommunityMembershipRevocation {
+    /// The community's `federation_keys.key_id`.
+    pub community_key_id: String,
+    /// The removed member's identity `federation_keys.key_id`.
+    pub removed_identity_key_id: String,
+    /// When the removal ceremony issued it (RFC-3339 per §0.5).
+    pub removed_at: DateTime<Utc>,
+    /// When the removal takes effect. Active-state filter:
+    /// `effective_at <= now()`.
+    pub effective_at: DateTime<Utc>,
+    /// Optional operator/ceremony annotation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Vouch set — multi-vouch per the community's `consensus_protocol`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub witness_set: Vec<String>,
+    /// **Server-computed.** See [`KeyRecord::persist_row_hash`].
+    pub persist_row_hash: String,
+}
+
+/// Wraps a [`CommunityMembershipRevocation`] for write submission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedCommunityMembershipRevocation {
+    /// The revocation being submitted.
+    pub community_membership_revocation: CommunityMembershipRevocation,
+}
+
 /// One hybrid-pending federation row — minimum fields the sweep
 /// needs to recompute the cold-path bound-signature input. Returned
 /// by [`super::FederationDirectory::list_hybrid_pending_keys`] /

--- a/src/scope/admission.rs
+++ b/src/scope/admission.rs
@@ -99,13 +99,22 @@ pub enum AdmissionError {
 ///
 /// 1. `occurrence_key_id → identity_key_id` via
 ///    [`lookup_identity_for_occurrence`](crate::federation::FederationDirectory::lookup_identity_for_occurrence)
-///    (V059 §5.6.8.8). On no binding, the §4.4 singleton fallback
-///    applies: `identity == occurrence`, empty family/community sets.
+///    (V059 §5.6.8.8). On no binding — OR an **active revocation** of the
+///    binding (v4.8.0, CIRISPersist#161 Ask 6, CEG §11.7.1) — the §4.4
+///    singleton fallback applies: `identity == occurrence`, empty
+///    family/community sets. A revoked occurrence speaks only for itself,
+///    never for the identity it was removed from.
 /// 2. `identity_key_id → family_key_ids` via
-///    [`list_families_for_member`](crate::federation::FederationDirectory::list_families_for_member)
-///    (V059 §5.6.8.9).
+///    [`list_families_for_member_active`](crate::federation::FederationDirectory::list_families_for_member_active)
+///    (V059 §5.6.8.9) — **active** membership only: families this identity
+///    has an effective revocation from are excluded.
 /// 3. `identity_key_id → community_key_ids` via
-///    `list_communities_for_member` (V060).
+///    `list_communities_for_member_active` (V060) — same revocation
+///    honesty.
+///
+/// Honoring revocation here is the substrate-side closure of the
+/// symmetric forge surface: without it, a removed member's read access
+/// would persist silently.
 ///
 /// Backend-gated: resolution goes through `Engine::federation_directory`,
 /// which only exists when a `postgres`/`sqlite` backend is compiled in.
@@ -115,32 +124,44 @@ pub async fn build_caller_admission(
     occurrence_key_id: &KeyId,
 ) -> Result<CallerAdmission, AdmissionError> {
     let directory = engine.federation_directory();
+    let now = chrono::Utc::now();
 
     // Step 1 — occurrence → identity. §4.4 singleton fallback when the
-    // occurrence key is not bound as an occurrence of any identity:
-    // the caller IS its own identity.
+    // occurrence key is not bound as an occurrence of any identity, OR
+    // (Ask 6) when the binding has an effective revocation: the caller
+    // IS its own identity, with no inherited family/community admission.
     let identity_key_id = match directory
         .lookup_identity_for_occurrence(occurrence_key_id)
         .await?
     {
-        Some(occurrence) => occurrence.identity_key_id,
+        Some(occurrence) => {
+            let revoked = directory
+                .list_identity_occurrence_revocations_for(&occurrence.identity_key_id)
+                .await?
+                .into_iter()
+                .any(|r| r.occurrence_key_id == *occurrence_key_id && r.effective_at <= now);
+            if revoked {
+                occurrence_key_id.clone()
+            } else {
+                occurrence.identity_key_id
+            }
+        }
         None => occurrence_key_id.clone(),
     };
 
-    // Step 2 — identity → families. Members are identity keys; the
-    // family's own key_id is the admission token.
+    // Step 2 — identity → ACTIVE families. Members are identity keys; the
+    // family's own key_id is the admission token. Revoked memberships
+    // are filtered (Ask 2 / Ask 6).
     let family_key_ids: BTreeSet<KeyId> = directory
-        .list_families_for_member(&identity_key_id)
+        .list_families_for_member_active(&identity_key_id)
         .await?
         .into_iter()
         .map(|family| family.family_key_id)
         .collect();
 
-    // Step 3 — identity → communities. Provided by Commit D; symmetric
-    // to families. Each community's `community_key_id` is the admission
-    // token.
+    // Step 3 — identity → ACTIVE communities. Symmetric to families.
     let community_key_ids: BTreeSet<KeyId> = directory
-        .list_communities_for_member(&identity_key_id)
+        .list_communities_for_member_active(&identity_key_id)
         .await?
         .into_iter()
         .map(|community| community.community_key_id)
@@ -204,5 +225,187 @@ impl CallerAdmission {
             community_key_ids: community_key_ids.into_iter().collect(),
             _seal: AdmissionSeal,
         }
+    }
+}
+
+/// v4.8.0 (CIRISPersist#161 Ask 6) — `build_caller_admission` honors
+/// revocation: a revoked occurrence falls through to the singleton
+/// fallback and a removed family member drops out of `family_key_ids`.
+#[cfg(all(test, feature = "sqlite"))]
+mod revocation_honesty_tests {
+    use crate::federation::{
+        FamilyMembershipRevocation, FederationDirectory, IdentityOccurrence,
+        IdentityOccurrenceRevocation, KeyRecord, SignedFamily, SignedFamilyMembershipRevocation,
+        SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation, SignedKeyRecord,
+    };
+    use crate::signing::LocalSigner;
+    use crate::Engine;
+    use ed25519_dalek::SigningKey;
+    use std::sync::Arc;
+
+    fn signer() -> Arc<LocalSigner> {
+        Arc::new(LocalSigner::from_parts(
+            SigningKey::from_bytes(&[0x11u8; 32]),
+            "admission-test".into(),
+            None,
+            None,
+        ))
+    }
+
+    fn key(k: &str) -> SignedKeyRecord {
+        SignedKeyRecord {
+            record: KeyRecord {
+                key_id: k.into(),
+                pubkey_ed25519_base64: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".into(),
+                pubkey_ml_dsa_65_base64: None,
+                algorithm: crate::federation::types::algorithm::HYBRID.into(),
+                identity_type: crate::federation::types::identity_type::PRIMITIVE.into(),
+                identity_ref: k.into(),
+                valid_from: "2026-05-01T00:00:00Z".parse().unwrap(),
+                valid_until: None,
+                registration_envelope: serde_json::json!({ "id": k }),
+                original_content_hash: "deadbeef".into(),
+                scrub_signature_classical: "c2ln".into(),
+                scrub_signature_pqc: None,
+                scrub_key_id: k.into(),
+                scrub_timestamp: "2026-05-01T00:00:00Z".parse().unwrap(),
+                pqc_completed_at: None,
+                persist_row_hash: String::new(),
+                roles: Vec::new(),
+                attestation_evidence: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn revoked_occurrence_falls_through_to_singleton() {
+        let engine = Engine::with_signer(signer(), "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        for k in ["alice-root", "alice-phone", "fam-1"] {
+            sq.put_public_key(key(k)).await.unwrap();
+        }
+        sq.put_identity_occurrence(SignedIdentityOccurrence {
+            identity_occurrence: IdentityOccurrence {
+                identity_key_id: "alice-root".into(),
+                occurrence_key_id: "alice-phone".into(),
+                device_class: crate::federation::types::device_class::PHONE.into(),
+                hardware_attestation: None,
+                asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                valid_until: None,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .unwrap();
+        sq.put_family(SignedFamily {
+            family: crate::federation::Family {
+                family_key_id: "fam-1".into(),
+                family_name: "Fam".into(),
+                members: vec![crate::federation::FamilyMember {
+                    key_id: "alice-root".into(),
+                    joined_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                    role: None,
+                }],
+                founded_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                consensus_protocol: "unanimous".into(),
+                consensus_protocol_entrenched: false,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .unwrap();
+
+        // Pre-revocation: alice-phone resolves to alice-root + fam-1.
+        let adm = super::build_caller_admission(&engine, &"alice-phone".to_string())
+            .await
+            .unwrap();
+        assert_eq!(adm.identity_key_id, "alice-root");
+        assert!(adm.family_key_ids.contains("fam-1"));
+
+        // Revoke the occurrence binding (effective in the past).
+        sq.put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation {
+            identity_occurrence_revocation: IdentityOccurrenceRevocation {
+                identity_key_id: "alice-root".into(),
+                occurrence_key_id: "alice-phone".into(),
+                revoked_at: "2026-06-02T00:00:00Z".parse().unwrap(),
+                effective_at: "2026-06-02T00:00:00Z".parse().unwrap(),
+                reason: None,
+                witness_set: vec!["alice-root".into()],
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .unwrap();
+
+        // Post-revocation: alice-phone speaks only for itself — singleton
+        // fallback, no inherited family admission.
+        let adm = super::build_caller_admission(&engine, &"alice-phone".to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            adm.identity_key_id, "alice-phone",
+            "revoked occurrence falls through to singleton identity"
+        );
+        assert!(
+            adm.family_key_ids.is_empty(),
+            "revoked occurrence inherits no family admission"
+        );
+    }
+
+    #[tokio::test]
+    async fn removed_family_member_drops_from_admission() {
+        let engine = Engine::with_signer(signer(), "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        for k in ["bob-root", "fam-1"] {
+            sq.put_public_key(key(k)).await.unwrap();
+        }
+        sq.put_family(SignedFamily {
+            family: crate::federation::Family {
+                family_key_id: "fam-1".into(),
+                family_name: "Fam".into(),
+                members: vec![crate::federation::FamilyMember {
+                    key_id: "bob-root".into(),
+                    joined_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                    role: None,
+                }],
+                founded_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                consensus_protocol: "unanimous".into(),
+                consensus_protocol_entrenched: false,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .unwrap();
+        // bob-root is a singleton identity (no occurrence binding) in fam-1.
+        let adm = super::build_caller_admission(&engine, &"bob-root".to_string())
+            .await
+            .unwrap();
+        assert!(adm.family_key_ids.contains("fam-1"));
+
+        sq.put_family_membership_revocation(SignedFamilyMembershipRevocation {
+            family_membership_revocation: FamilyMembershipRevocation {
+                family_key_id: "fam-1".into(),
+                removed_identity_key_id: "bob-root".into(),
+                removed_at: "2026-06-02T00:00:00Z".parse().unwrap(),
+                effective_at: "2026-06-02T00:00:00Z".parse().unwrap(),
+                reason: None,
+                witness_set: vec![],
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .unwrap();
+
+        let adm = super::build_caller_admission(&engine, &"bob-root".to_string())
+            .await
+            .unwrap();
+        assert!(
+            adm.family_key_ids.is_empty(),
+            "removed member loses family admission (forge surface closed)"
+        );
     }
 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -97,6 +97,14 @@ struct State {
     /// v4.0 (CEG 0.8 §8.1.13.3) — community rows keyed by
     /// `community_key_id`. Mirrors V060 PG/SQLite PK.
     federation_communities: HashMap<String, crate::federation::Community>,
+    /// v4.8.0 (CIRISPersist#161, CEG §11.7.1) — Option-A forward-secrecy
+    /// removal/revocation rows. Keyed by the V067 composite PKs.
+    federation_identity_occurrence_revocations:
+        HashMap<(String, String), crate::federation::IdentityOccurrenceRevocation>,
+    federation_family_membership_revocations:
+        HashMap<(String, String), crate::federation::FamilyMembershipRevocation>,
+    federation_community_membership_revocations:
+        HashMap<(String, String), crate::federation::CommunityMembershipRevocation>,
 }
 
 impl Default for MemoryBackend {
@@ -117,6 +125,9 @@ impl Default for MemoryBackend {
                 federation_identity_occurrences: HashMap::new(),
                 federation_families: HashMap::new(),
                 federation_communities: HashMap::new(),
+                federation_identity_occurrence_revocations: HashMap::new(),
+                federation_family_membership_revocations: HashMap::new(),
+                federation_community_membership_revocations: HashMap::new(),
                 blackhole_rules: HashMap::new(),
             }),
         }
@@ -929,6 +940,124 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .cloned()
             .collect();
         rows.sort_by(|a, b| a.community_key_id.cmp(&b.community_key_id));
+        Ok(rows)
+    }
+
+    // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
+
+    async fn put_identity_occurrence_revocation(
+        &self,
+        revocation: crate::federation::SignedIdentityOccurrenceRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.identity_occurrence_revocation;
+        let mut state = self.state.lock().expect("memory backend lock");
+        for k in [&row.identity_key_id, &row.occurrence_key_id] {
+            if !state.federation_keys.contains_key(k) {
+                return Err(crate::federation::Error::InvalidArgument(format!(
+                    "{k} does not exist in federation_keys"
+                )));
+            }
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        state.federation_identity_occurrence_revocations.insert(
+            (row.identity_key_id.clone(), row.occurrence_key_id.clone()),
+            row,
+        );
+        Ok(())
+    }
+
+    async fn put_family_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedFamilyMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.family_membership_revocation;
+        let mut state = self.state.lock().expect("memory backend lock");
+        for k in [&row.family_key_id, &row.removed_identity_key_id] {
+            if !state.federation_keys.contains_key(k) {
+                return Err(crate::federation::Error::InvalidArgument(format!(
+                    "{k} does not exist in federation_keys"
+                )));
+            }
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        state.federation_family_membership_revocations.insert(
+            (
+                row.family_key_id.clone(),
+                row.removed_identity_key_id.clone(),
+            ),
+            row,
+        );
+        Ok(())
+    }
+
+    async fn put_community_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedCommunityMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.community_membership_revocation;
+        let mut state = self.state.lock().expect("memory backend lock");
+        for k in [&row.community_key_id, &row.removed_identity_key_id] {
+            if !state.federation_keys.contains_key(k) {
+                return Err(crate::federation::Error::InvalidArgument(format!(
+                    "{k} does not exist in federation_keys"
+                )));
+            }
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        state.federation_community_membership_revocations.insert(
+            (
+                row.community_key_id.clone(),
+                row.removed_identity_key_id.clone(),
+            ),
+            row,
+        );
+        Ok(())
+    }
+
+    async fn list_identity_occurrence_revocations_for(
+        &self,
+        identity_key_id: &str,
+    ) -> Result<Vec<crate::federation::IdentityOccurrenceRevocation>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_identity_occurrence_revocations
+            .values()
+            .filter(|r| r.identity_key_id == identity_key_id)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| a.occurrence_key_id.cmp(&b.occurrence_key_id));
+        Ok(rows)
+    }
+
+    async fn list_family_membership_revocations_for(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Vec<crate::federation::FamilyMembershipRevocation>, crate::federation::Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_family_membership_revocations
+            .values()
+            .filter(|r| r.family_key_id == family_key_id)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| a.removed_identity_key_id.cmp(&b.removed_identity_key_id));
+        Ok(rows)
+    }
+
+    async fn list_community_membership_revocations_for(
+        &self,
+        community_key_id: &str,
+    ) -> Result<Vec<crate::federation::CommunityMembershipRevocation>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_community_membership_revocations
+            .values()
+            .filter(|r| r.community_key_id == community_key_id)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| a.removed_identity_key_id.cmp(&b.removed_identity_key_id));
         Ok(rows)
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2273,6 +2273,187 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         rows.into_iter().map(pg_row_to_community).collect()
     }
 
+    // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
+
+    async fn put_identity_occurrence_revocation(
+        &self,
+        revocation: crate::federation::SignedIdentityOccurrenceRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.identity_occurrence_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::json!(row.witness_set);
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.federation_identity_occurrence_revocations (\
+                    identity_key_id, occurrence_key_id, revoked_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &row.identity_key_id,
+                    &row.occurrence_key_id,
+                    &row.revoked_at,
+                    &row.effective_at,
+                    &row.reason,
+                    &witness,
+                    &row.persist_row_hash,
+                ],
+            )
+            .await
+            .map_err(map_revocation_pg_err("identity_occurrence_revocation"))?;
+        Ok(())
+    }
+
+    async fn put_family_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedFamilyMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.family_membership_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::json!(row.witness_set);
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.federation_family_membership_revocations (\
+                    family_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &row.family_key_id,
+                    &row.removed_identity_key_id,
+                    &row.removed_at,
+                    &row.effective_at,
+                    &row.reason,
+                    &witness,
+                    &row.persist_row_hash,
+                ],
+            )
+            .await
+            .map_err(map_revocation_pg_err("family_membership_revocation"))?;
+        Ok(())
+    }
+
+    async fn put_community_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedCommunityMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.community_membership_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::json!(row.witness_set);
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.federation_community_membership_revocations (\
+                    community_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                &[
+                    &row.community_key_id,
+                    &row.removed_identity_key_id,
+                    &row.removed_at,
+                    &row.effective_at,
+                    &row.reason,
+                    &witness,
+                    &row.persist_row_hash,
+                ],
+            )
+            .await
+            .map_err(map_revocation_pg_err("community_membership_revocation"))?;
+        Ok(())
+    }
+
+    async fn list_identity_occurrence_revocations_for(
+        &self,
+        identity_key_id: &str,
+    ) -> Result<Vec<crate::federation::IdentityOccurrenceRevocation>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT identity_key_id, occurrence_key_id, revoked_at, effective_at, \
+                    reason, witness_set, persist_row_hash \
+                 FROM cirislens.federation_identity_occurrence_revocations \
+                 WHERE identity_key_id = $1 ORDER BY occurrence_key_id ASC",
+                &[&identity_key_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!(
+                    "list_identity_occurrence_revocations_for: {e}"
+                ))
+            })?;
+        rows.into_iter()
+            .map(pg_row_to_identity_occurrence_revocation)
+            .collect()
+    }
+
+    async fn list_family_membership_revocations_for(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Vec<crate::federation::FamilyMembershipRevocation>, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT family_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash \
+                 FROM cirislens.federation_family_membership_revocations \
+                 WHERE family_key_id = $1 ORDER BY removed_identity_key_id ASC",
+                &[&family_key_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!(
+                    "list_family_membership_revocations_for: {e}"
+                ))
+            })?;
+        rows.into_iter()
+            .map(pg_row_to_family_membership_revocation)
+            .collect()
+    }
+
+    async fn list_community_membership_revocations_for(
+        &self,
+        community_key_id: &str,
+    ) -> Result<Vec<crate::federation::CommunityMembershipRevocation>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT community_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash \
+                 FROM cirislens.federation_community_membership_revocations \
+                 WHERE community_key_id = $1 ORDER BY removed_identity_key_id ASC",
+                &[&community_key_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!(
+                    "list_community_membership_revocations_for: {e}"
+                ))
+            })?;
+        rows.into_iter()
+            .map(pg_row_to_community_membership_revocation)
+            .collect()
+    }
+
     async fn attach_key_pqc_signature(
         &self,
         key_id: &str,
@@ -6439,6 +6620,92 @@ fn pg_row_to_community(
         founded_at: row.safe_get_with("founded_at", mk_err)?,
         consensus_protocol: row.safe_get_with("consensus_protocol", mk_err)?,
         policy_blob,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+// ─── v4.8.0 (CIRISPersist#161) — membership-revocation row decoders +
+//     a shared FK-aware error mapper for the three revocation inserts.
+
+/// Map a Postgres revocation-insert error: a FK violation (subject/
+/// removed key absent from federation_keys) → `InvalidArgument`, else
+/// `Backend`.
+fn map_revocation_pg_err(
+    op: &'static str,
+) -> impl FnOnce(tokio_postgres::Error) -> crate::federation::Error {
+    move |e| {
+        // tokio_postgres's Display is the terse "db error"; the FK signal
+        // lives in the structured DbError SQLSTATE (23503), not the string.
+        let is_fk = e
+            .as_db_error()
+            .map(|db| *db.code() == tokio_postgres::error::SqlState::FOREIGN_KEY_VIOLATION)
+            .unwrap_or(false);
+        let detail = e
+            .as_db_error()
+            .map(|db| db.message().to_owned())
+            .unwrap_or_else(|| e.to_string());
+        if is_fk {
+            crate::federation::Error::InvalidArgument(format!(
+                "FK constraint violated on {op} insert: {detail}"
+            ))
+        } else {
+            crate::federation::Error::Backend(format!("insert {op}: {detail}"))
+        }
+    }
+}
+
+/// Decode a JSONB `witness_set` array column → `Vec<String>`.
+fn pg_witness_set(row: &tokio_postgres::Row) -> Result<Vec<String>, crate::federation::Error> {
+    let v: serde_json::Value =
+        row.safe_get_with("witness_set", crate::federation::Error::Backend)?;
+    serde_json::from_value(v)
+        .map_err(|e| crate::federation::Error::Backend(format!("witness_set deserialize: {e}")))
+}
+
+fn pg_row_to_identity_occurrence_revocation(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::IdentityOccurrenceRevocation, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let witness_set = pg_witness_set(&row)?;
+    Ok(crate::federation::IdentityOccurrenceRevocation {
+        identity_key_id: row.safe_get_with("identity_key_id", mk_err)?,
+        occurrence_key_id: row.safe_get_with("occurrence_key_id", mk_err)?,
+        revoked_at: row.safe_get_with("revoked_at", mk_err)?,
+        effective_at: row.safe_get_with("effective_at", mk_err)?,
+        reason: row.safe_get_with("reason", mk_err)?,
+        witness_set,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+fn pg_row_to_family_membership_revocation(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::FamilyMembershipRevocation, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let witness_set = pg_witness_set(&row)?;
+    Ok(crate::federation::FamilyMembershipRevocation {
+        family_key_id: row.safe_get_with("family_key_id", mk_err)?,
+        removed_identity_key_id: row.safe_get_with("removed_identity_key_id", mk_err)?,
+        removed_at: row.safe_get_with("removed_at", mk_err)?,
+        effective_at: row.safe_get_with("effective_at", mk_err)?,
+        reason: row.safe_get_with("reason", mk_err)?,
+        witness_set,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+fn pg_row_to_community_membership_revocation(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::CommunityMembershipRevocation, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let witness_set = pg_witness_set(&row)?;
+    Ok(crate::federation::CommunityMembershipRevocation {
+        community_key_id: row.safe_get_with("community_key_id", mk_err)?,
+        removed_identity_key_id: row.safe_get_with("removed_identity_key_id", mk_err)?,
+        removed_at: row.safe_get_with("removed_at", mk_err)?,
+        effective_at: row.safe_get_with("effective_at", mk_err)?,
+        reason: row.safe_get_with("reason", mk_err)?,
+        witness_set,
         persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
     })
 }
@@ -20446,5 +20713,108 @@ mod tests {
             .try_get::<_, String>(0)
             .unwrap();
         assert_eq!(stored, "pubA", "rotation collision must not overwrite");
+    }
+
+    /// v4.8.0 (CIRISPersist#161) — live-PG round-trip for the membership
+    /// revocation tables: put → list_*_revocations_for (exercises the
+    /// JSONB `witness_set` encode/decode) → active-state filtering with a
+    /// past- vs future-effective revocation. Unique key_ids per run.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_membership_revocation_round_trip_and_active_filtering() {
+        use crate::federation::{
+            FederationDirectory, IdentityOccurrence, IdentityOccurrenceRevocation,
+            SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
+        };
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let root = format!("root-{}", uuid_like());
+        let phone = format!("phone-{}", uuid_like());
+        let laptop = format!("laptop-{}", uuid_like());
+        for (k, t) in [
+            (&root, crate::federation::types::identity_type::STEWARD),
+            (&phone, crate::federation::types::identity_type::PRIMITIVE),
+            (&laptop, crate::federation::types::identity_type::PRIMITIVE),
+        ] {
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord {
+                    record: pg_admission_key(k, k, t),
+                })
+                .await
+                .unwrap();
+        }
+        let occ = |o: &str| SignedIdentityOccurrence {
+            identity_occurrence: IdentityOccurrence {
+                identity_key_id: root.clone(),
+                occurrence_key_id: o.to_string(),
+                device_class: crate::federation::types::device_class::PHONE.into(),
+                hardware_attestation: None,
+                asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                valid_until: None,
+                persist_row_hash: String::new(),
+            },
+        };
+        backend.put_identity_occurrence(occ(&phone)).await.unwrap();
+        backend.put_identity_occurrence(occ(&laptop)).await.unwrap();
+
+        // Past-effective revocation of phone.
+        backend
+            .put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: IdentityOccurrenceRevocation {
+                    identity_key_id: root.clone(),
+                    occurrence_key_id: phone.clone(),
+                    revoked_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    effective_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    reason: Some("lost".into()),
+                    witness_set: vec![root.clone(), laptop.clone()],
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        let revs = backend
+            .list_identity_occurrence_revocations_for(&root)
+            .await
+            .unwrap();
+        assert_eq!(revs.len(), 1);
+        assert_eq!(revs[0].occurrence_key_id, phone);
+        assert_eq!(
+            revs[0].witness_set,
+            vec![root.clone(), laptop.clone()],
+            "JSONB witness_set round-trips in order"
+        );
+        assert!(!revs[0].persist_row_hash.is_empty());
+
+        let active = backend
+            .list_identity_occurrences_active(&root)
+            .await
+            .unwrap();
+        let ids: Vec<_> = active.iter().map(|o| o.occurrence_key_id.clone()).collect();
+        assert_eq!(ids, vec![laptop.clone()], "revoked phone excluded on PG");
+
+        // FK violation surfaces as InvalidArgument.
+        let err = backend
+            .put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: IdentityOccurrenceRevocation {
+                    identity_key_id: root.clone(),
+                    occurrence_key_id: format!("ghost-{}", uuid_like()),
+                    revoked_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    effective_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    reason: None,
+                    witness_set: vec![],
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("FK")),
+            "got: {err:?}"
+        );
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1974,6 +1974,178 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         .map_err(|e| crate::federation::Error::Backend(format!("list_communities_for_member: {e}")))
     }
 
+    // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
+
+    async fn put_identity_occurrence_revocation(
+        &self,
+        revocation: crate::federation::SignedIdentityOccurrenceRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.identity_occurrence_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::to_string(&row.witness_set)
+            .map_err(|e| crate::federation::Error::Backend(format!("witness_set encode: {e}")))?;
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO federation_identity_occurrence_revocations (\
+                    identity_key_id, occurrence_key_id, revoked_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    row.identity_key_id,
+                    row.occurrence_key_id,
+                    row.revoked_at.to_rfc3339(),
+                    row.effective_at.to_rfc3339(),
+                    row.reason,
+                    witness,
+                    row.persist_row_hash,
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(map_revocation_sqlite_err("identity_occurrence_revocation"))?;
+        Ok(())
+    }
+
+    async fn put_family_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedFamilyMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.family_membership_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::to_string(&row.witness_set)
+            .map_err(|e| crate::federation::Error::Backend(format!("witness_set encode: {e}")))?;
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO federation_family_membership_revocations (\
+                    family_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    row.family_key_id,
+                    row.removed_identity_key_id,
+                    row.removed_at.to_rfc3339(),
+                    row.effective_at.to_rfc3339(),
+                    row.reason,
+                    witness,
+                    row.persist_row_hash,
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(map_revocation_sqlite_err("family_membership_revocation"))?;
+        Ok(())
+    }
+
+    async fn put_community_membership_revocation(
+        &self,
+        revocation: crate::federation::SignedCommunityMembershipRevocation,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = revocation.community_membership_revocation;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let witness = serde_json::to_string(&row.witness_set)
+            .map_err(|e| crate::federation::Error::Backend(format!("witness_set encode: {e}")))?;
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO federation_community_membership_revocations (\
+                    community_key_id, removed_identity_key_id, removed_at, effective_at, \
+                    reason, witness_set, persist_row_hash\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    row.community_key_id,
+                    row.removed_identity_key_id,
+                    row.removed_at.to_rfc3339(),
+                    row.effective_at.to_rfc3339(),
+                    row.reason,
+                    witness,
+                    row.persist_row_hash,
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(map_revocation_sqlite_err("community_membership_revocation"))?;
+        Ok(())
+    }
+
+    async fn list_identity_occurrence_revocations_for(
+        &self,
+        identity_key_id: &str,
+    ) -> Result<Vec<crate::federation::IdentityOccurrenceRevocation>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let key = identity_key_id.to_owned();
+        (move || -> Result<Vec<_>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT identity_key_id, occurrence_key_id, revoked_at, effective_at, \
+                        reason, witness_set, persist_row_hash \
+                     FROM federation_identity_occurrence_revocations \
+                     WHERE identity_key_id = ?1 ORDER BY occurrence_key_id ASC",
+            )?;
+            let rows = stmt.query_map([&key], sqlite_row_to_identity_occurrence_revocation)?;
+            rows.collect()
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!(
+                "list_identity_occurrence_revocations_for: {e}"
+            ))
+        })
+    }
+
+    async fn list_family_membership_revocations_for(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Vec<crate::federation::FamilyMembershipRevocation>, crate::federation::Error> {
+        let conn = self.conn.clone();
+        let key = family_key_id.to_owned();
+        (move || -> Result<Vec<_>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT family_key_id, removed_identity_key_id, removed_at, effective_at, \
+                        reason, witness_set, persist_row_hash \
+                     FROM federation_family_membership_revocations \
+                     WHERE family_key_id = ?1 ORDER BY removed_identity_key_id ASC",
+            )?;
+            let rows = stmt.query_map([&key], sqlite_row_to_family_membership_revocation)?;
+            rows.collect()
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!(
+                "list_family_membership_revocations_for: {e}"
+            ))
+        })
+    }
+
+    async fn list_community_membership_revocations_for(
+        &self,
+        community_key_id: &str,
+    ) -> Result<Vec<crate::federation::CommunityMembershipRevocation>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let key = community_key_id.to_owned();
+        (move || -> Result<Vec<_>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT community_key_id, removed_identity_key_id, removed_at, effective_at, \
+                        reason, witness_set, persist_row_hash \
+                     FROM federation_community_membership_revocations \
+                     WHERE community_key_id = ?1 ORDER BY removed_identity_key_id ASC",
+            )?;
+            let rows = stmt.query_map([&key], sqlite_row_to_community_membership_revocation)?;
+            rows.collect()
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!(
+                "list_community_membership_revocations_for: {e}"
+            ))
+        })
+    }
+
     async fn attach_key_pqc_signature(
         &self,
         key_id: &str,
@@ -6463,6 +6635,89 @@ fn sqlite_row_to_community(
         founded_at: parse_rfc3339(&founded_at),
         consensus_protocol: row.get("consensus_protocol")?,
         policy_blob,
+        persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+// ─── v4.8.0 (CIRISPersist#161) — membership-revocation row decoders +
+//     a shared FK-aware error mapper for the three revocation inserts.
+
+/// Map a SQLite revocation-insert error: a FK violation (subject/removed
+/// key absent from federation_keys) → `InvalidArgument`, else `Backend`.
+fn map_revocation_sqlite_err(
+    op: &'static str,
+) -> impl FnOnce(rusqlite::Error) -> crate::federation::Error {
+    move |e| {
+        let msg = e.to_string();
+        if msg.contains("FOREIGN KEY") {
+            crate::federation::Error::InvalidArgument(format!(
+                "FK constraint violated on {op} insert: {msg}"
+            ))
+        } else {
+            crate::federation::Error::Backend(format!("insert {op}: {msg}"))
+        }
+    }
+}
+
+/// Decode a JSON-TEXT `witness_set` array column (col index `idx` for
+/// the error report).
+fn decode_witness_set(text: &str, idx: usize) -> rusqlite::Result<Vec<String>> {
+    serde_json::from_str(text).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            idx,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+        )
+    })
+}
+
+fn sqlite_row_to_identity_occurrence_revocation(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::IdentityOccurrenceRevocation> {
+    let revoked_at: String = row.get("revoked_at")?;
+    let effective_at: String = row.get("effective_at")?;
+    let witness_text: String = row.get("witness_set")?;
+    Ok(crate::federation::IdentityOccurrenceRevocation {
+        identity_key_id: row.get("identity_key_id")?,
+        occurrence_key_id: row.get("occurrence_key_id")?,
+        revoked_at: parse_rfc3339(&revoked_at),
+        effective_at: parse_rfc3339(&effective_at),
+        reason: row.get("reason")?,
+        witness_set: decode_witness_set(&witness_text, 5)?,
+        persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+fn sqlite_row_to_family_membership_revocation(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::FamilyMembershipRevocation> {
+    let removed_at: String = row.get("removed_at")?;
+    let effective_at: String = row.get("effective_at")?;
+    let witness_text: String = row.get("witness_set")?;
+    Ok(crate::federation::FamilyMembershipRevocation {
+        family_key_id: row.get("family_key_id")?,
+        removed_identity_key_id: row.get("removed_identity_key_id")?,
+        removed_at: parse_rfc3339(&removed_at),
+        effective_at: parse_rfc3339(&effective_at),
+        reason: row.get("reason")?,
+        witness_set: decode_witness_set(&witness_text, 5)?,
+        persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+fn sqlite_row_to_community_membership_revocation(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::CommunityMembershipRevocation> {
+    let removed_at: String = row.get("removed_at")?;
+    let effective_at: String = row.get("effective_at")?;
+    let witness_text: String = row.get("witness_set")?;
+    Ok(crate::federation::CommunityMembershipRevocation {
+        community_key_id: row.get("community_key_id")?,
+        removed_identity_key_id: row.get("removed_identity_key_id")?,
+        removed_at: parse_rfc3339(&removed_at),
+        effective_at: parse_rfc3339(&effective_at),
+        reason: row.get("reason")?,
+        witness_set: decode_witness_set(&witness_text, 5)?,
         persist_row_hash: row.get("persist_row_hash")?,
     })
 }
@@ -11101,6 +11356,170 @@ mod tests {
             consensus_protocol_entrenched: false,
             persist_row_hash: String::new(),
         }
+    }
+
+    // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — revocation tests ─────
+
+    /// Revocation round-trip + active-state filtering: a past-effective
+    /// occurrence revocation excludes the binding from
+    /// `list_identity_occurrences_active`; a future-effective one does
+    /// NOT. Family/community removals filter `list_*_for_member_active`.
+    #[tokio::test]
+    async fn membership_revocation_round_trip_and_active_filtering() {
+        use crate::federation::{
+            FamilyMembershipRevocation, IdentityOccurrenceRevocation,
+            SignedFamilyMembershipRevocation, SignedIdentityOccurrenceRevocation,
+        };
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        for k in [
+            "alice-root",
+            "alice-phone",
+            "alice-laptop",
+            "fam-1",
+            "bob-root",
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key(k, k, k),
+                })
+                .await
+                .unwrap();
+        }
+        // Two occurrences of alice-root.
+        for occ in ["alice-phone", "alice-laptop"] {
+            backend
+                .put_identity_occurrence(crate::federation::SignedIdentityOccurrence {
+                    identity_occurrence: fed_identity_occurrence(
+                        "alice-root",
+                        occ,
+                        crate::federation::types::device_class::PHONE,
+                    ),
+                })
+                .await
+                .unwrap();
+        }
+        // Family with alice-root + bob-root.
+        backend
+            .put_family(crate::federation::SignedFamily {
+                family: fed_family("fam-1", "Fam", vec!["alice-root", "bob-root"], "unanimous"),
+            })
+            .await
+            .unwrap();
+
+        // Revoke alice-phone, effective in the past.
+        backend
+            .put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: IdentityOccurrenceRevocation {
+                    identity_key_id: "alice-root".into(),
+                    occurrence_key_id: "alice-phone".into(),
+                    revoked_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    effective_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    reason: Some("lost device".into()),
+                    witness_set: vec!["alice-root".into()],
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // list_*_revocations_for round-trips the row.
+        let revs = backend
+            .list_identity_occurrence_revocations_for("alice-root")
+            .await
+            .unwrap();
+        assert_eq!(revs.len(), 1);
+        assert_eq!(revs[0].occurrence_key_id, "alice-phone");
+        assert_eq!(revs[0].witness_set, vec!["alice-root".to_string()]);
+        assert!(!revs[0].persist_row_hash.is_empty(), "hash computed");
+
+        // active excludes the revoked occurrence; _for keeps both (history).
+        let active = backend
+            .list_identity_occurrences_active("alice-root")
+            .await
+            .unwrap();
+        let active_ids: Vec<_> = active
+            .iter()
+            .map(|o| o.occurrence_key_id.as_str())
+            .collect();
+        assert_eq!(active_ids, vec!["alice-laptop"], "revoked phone excluded");
+        assert_eq!(
+            backend
+                .list_identity_occurrences_for("alice-root")
+                .await
+                .unwrap()
+                .len(),
+            2,
+            "_for is the full-history accessor"
+        );
+
+        // Future-effective revocation does NOT exclude.
+        backend
+            .put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: IdentityOccurrenceRevocation {
+                    identity_key_id: "alice-root".into(),
+                    occurrence_key_id: "alice-laptop".into(),
+                    revoked_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                    effective_at: "2099-01-01T00:00:00Z".parse().unwrap(),
+                    reason: None,
+                    witness_set: vec![],
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+        let active = backend
+            .list_identity_occurrences_active("alice-root")
+            .await
+            .unwrap();
+        assert_eq!(
+            active.len(),
+            1,
+            "future-dated revocation must not take effect yet"
+        );
+
+        // Family removal: bob-root removed, effective in the past.
+        backend
+            .put_family_membership_revocation(SignedFamilyMembershipRevocation {
+                family_membership_revocation: FamilyMembershipRevocation {
+                    family_key_id: "fam-1".into(),
+                    removed_identity_key_id: "bob-root".into(),
+                    removed_at: "2026-06-06T00:00:00Z".parse().unwrap(),
+                    effective_at: "2026-06-06T00:00:00Z".parse().unwrap(),
+                    reason: Some("left household".into()),
+                    witness_set: vec!["alice-root".into()],
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+        // bob-root no longer an active member; alice-root still is.
+        assert!(
+            backend
+                .list_families_for_member_active("bob-root")
+                .await
+                .unwrap()
+                .is_empty(),
+            "removed member drops out of active families"
+        );
+        assert_eq!(
+            backend
+                .list_families_for_member_active("alice-root")
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "remaining member still active"
+        );
+        // _for_member (history) still shows bob in the roster.
+        assert_eq!(
+            backend
+                .list_families_for_member("bob-root")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     /// Round-trip an identity_occurrence: write → list_for → reverse


### PR DESCRIPTION
V059 (identity_occurrence + family) and V060 (community) landed membership **admission** append-only, with no way to express "this binding/membership is currently revoked." A removed member's read access therefore persisted silently — `build_caller_admission` resolved every roster row regardless of revocation. This cut adds the revocation expression and the honest resolution that closes the forge surface.

Implements **#161 Phases 1–3**. Phase 4 (producer stop-wrapping gate) deferred — see below.

## V067 migration (PG + SQLite)
Three append-only revocation tables symmetric to V059/V060: `federation_{identity_occurrence,family_membership,community_membership}_revocations`. Each: subject + removed id, `revoked_at`/`removed_at`, `effective_at`, `reason`, `witness_set` (JSONB / JSON-TEXT array — single-vouch self per §11.7.4, multi-vouch per `consensus_protocol`), `persist_row_hash`; composite PK + `effective_at` + by-removed indexes. **Supersedes V059's "occurrence withdraws rides `federation_revocations`" note** — that table revokes a *key* globally and has no `witness_set`, so it can't express a binding/membership removal.

## Surface (Asks 1–2)
- 3 revocation row types + `Signed*` wrappers.
- `FederationDirectory::put_*_revocation` + `list_*_revocations_for` on **all three backends**. Append-only, **non-destructive**; `persist_row_hash` server-computed; FK violation → `InvalidArgument` (PG via SQLSTATE 23503, not the terse `Display`).
- `list_*_active` **default trait methods** (admitted AND no revocation with `effective_at <= now`); existing `list_*_for` remain full-history accessors.

## Honest CallerAdmission (Ask 6 — the forge-surface closure)
`build_caller_admission` now honors revocation: a **revoked occurrence falls through to the §4.4 singleton fallback** (speaks only for itself), and `family_key_ids`/`community_key_ids` resolve through the `_active` reads.

## Design note — additive, not a breaking rename
#161 Ask 2 suggested renaming `list_*` → `list_*_active`. Chose additive `_active` methods + wiring the one security-critical caller instead — the accessors are widely used, full-history is the documented contract, and no current caller is left unsafe (the DEK-cascade caller is Ask 4, deferred). Same security property, no gratuitous breakage.

## Deferred — Ask 4 / Ask 5
The producer-side "stop wrapping new `key_grant`s to a removed party" gate at `put_blob_signing` (Ask 4) + reserved-prefix `*_membership_change` emission on removal (Ask 5) gate on the at-rest **ADD** key_grant cascade (#152), which isn't in persist yet — there's no ADD cascade to make symmetric. Lands when #152 does.

## Tests
SQLite + live-PG round-trips (put/list, active filtering incl. future-dated no-op, JSONB `witness_set` order-preserving, FK→`InvalidArgument`) + two Ask-6 `build_caller_admission` honesty tests (revoked occurrence → singleton; removed family member → dropped). **1056 lib green on SQLite, 754 on live PG**; `-D warnings` + clippy clean across the matrix.

Advances #161 (Phases 1–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)