### PR TITLE
v4.10.0 — location_proof + H3 rough-only (#154) + fix conformance-blocking ciris-verify pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.10.0] — 2026-06-09
+
+**`location_proof` substrate + H3 rough-only enforcement — the CEG 0.8 §0.8.1 normative privacy primitive (CIRISPersist#154).**
+
+CEG 0.8's load-bearing wire-format rule: a subject's geographic claim is bounded to **H3 resolution ≤ 7** ("rough-only"), enforced at the substrate so a producer cannot over-share precise location even if client UI gating fails — the substrate is the second line of defense. This lands that primitive; the community substrate half of #154 shipped in v4.0.1 (V060).
+
+### Added
+- **V068 migration** (PG + SQLite) — `federation_location_proofs`: `subject_key_id` (FK → `federation_keys`), `cell_id` (H3 lowercase hex), `cell_resolution`, `asserted_at`, `valid_until`, `attestation_evidence` (BYTEA/BLOB, optional hardware blob), `withdrawn_at` (append-only; null = in force), `persist_row_hash`; PK `(subject_key_id, asserted_at)` + by-subject-live + by-cell indexes. Standalone (no `source_attestation_id` FK — the proof row *is* the record).
+- **`LocationProof` / `SignedLocationProof`** types.
+- **`FederationDirectory::put_location_proof` / `list_location_proofs_for`** on all three backends. `put_location_proof` runs the §0.8 + §0.8.1 admission gate before write.
+- **`federation::location`** module (pure-Rust [`h3o`], not a crypto dep — MISSION §1.4 unaffected): `validate_location_cell` (§0.8 canonical-form: lowercase hex + valid H3 cell + resolution-redundancy; §0.8.1 rough-only ≤ 7) and `h3_cell_contained` (§0.8.2 parent/child containment). An over-precise or malformed cell is **refused** (`InvalidArgument`) — the refusal *is* the privacy enforcement.
+
+### Deferred — #154 residual (Ask 4)
+The `cohort_subkind: geographic` community-admission dispatch (gate new members on a valid containing `location_proof`) is left open on #154 — it couples to the `put_community` write path + needs the geographic constraint pinned in the community `policy_blob`. The `h3_cell_contained` helper it will use is shipped here. Everything else in #154 is now landed (community substrate v4.0.1 + this).
+
+### Tests
+`federation::location` unit tests (valid res-7 admit, resolution-redundancy mismatch, over-precise refused, uppercase/garbage refused, containment parent/child + disjoint + invalid-input) + SQLite and live-PG round-trips (valid admit, BYTEA `attestation_evidence` round-trip, rough-only rejection, rejections don't write, FK holds). **1067 lib green on SQLite, 763 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full; clippy + cargo-deny clean (h3o + transitives).
+
 ## [4.9.0] — 2026-06-09
 
 **PyO3 `attestation_promote` binding — the local→federation transition for the agent's 2.9.6 community-server opt-in (CIRISPersist#171 phase 2, CEG §10.1.5).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The `cohort_subkind: geographic` community-admission dispatch (gate new members 
 ### Tests
 `federation::location` unit tests (valid res-7 admit, resolution-redundancy mismatch, over-precise refused, uppercase/garbage refused, containment parent/child + disjoint + invalid-input) + SQLite and live-PG round-trips (valid admit, BYTEA `attestation_evidence` round-trip, rough-only rejection, rejections don't write, FK holds). **1067 lib green on SQLite, 763 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full; clippy + cargo-deny clean (h3o + transitives).
 
+### Fixed — `pyproject.toml` `ciris-verify` pin blocked the conformance matrix
+The Python wheel's `Requires-Dist` stayed at `ciris-verify>=4.4.2,<5` after the v4.6.1 Rust pin moved to verify v5.0.0 — the same Requires-Dist drift the v2.0.1 hotfix fixed once before. The effect: `pip install ciris-persist` refused `ciris-verify==5.0.0`, so **CIRISConformance could not put verify 5.0 (the `jcs_canonicalize` binding, CIRISVerify#61) into its matrix alongside persist.** Bumped to `>=5.0.0,<6`, coherent with the Rust crates' v5.0.0 pin.
+
 ## [4.9.0] — 2026-06-09
 
 **PyO3 `attestation_promote` binding — the local→federation transition for the agent's 2.9.6 community-server opt-in (CIRISPersist#171 phase 2, CEG §10.1.5).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.9.0"
+version = "4.10.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -528,6 +528,13 @@ thiserror     = "2"
 tracing       = "0.1"
 base64        = "0.22"
 hex           = "0.4"
+# v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8) — pure-Rust H3 geospatial
+# index for location_proof cell canonicalization + containment. h3o is
+# pure Rust (no libh3 C bindings), so it cross-compiles to the iOS /
+# Android / wasm wheel targets the same as the rest of the tree. NOT a
+# crypto dep — the §1.4 "never rolls its own crypto" invariant is
+# unaffected (H3 is geospatial indexing, not key material).
+h3o           = "0.7"
 # v0.4.3 (CIRISPersist#18) — UUID type for cirislens_derived
 # .detection_events.detection_id. v4 generation lives at the
 # caller (lens-core); persist just stores. tokio-postgres's

--- a/migrations/postgres/lens/V068__ceg_08_location_proofs.sql
+++ b/migrations/postgres/lens/V068__ceg_08_location_proofs.sql
@@ -1,0 +1,55 @@
+-- V068 — CEG 0.8 §5.6.8.11 + §0.8.1 location_proof substrate
+--        (CIRISPersist#154 Asks 1/2/3, v4.10.0).
+--
+-- The §0.8.1-normative privacy primitive: a subject's coarse geographic
+-- claim, bounded to H3 resolution ≤ 7 ("rough-only") at admission so the
+-- substrate is the second line of defense after client UI gating — a
+-- producer cannot over-share precise location even if the client fails.
+-- cell_id is the H3 lowercase-hex index (§0.8); the admission gate
+-- (put_location_proof) validates canonical form + resolution-redundancy
+-- via h3o and rejects resolution > 7 before insert.
+--
+-- Standalone (no source_attestation_id FK) — the proof row IS the record;
+-- subject_key_id FK-anchors to federation_keys like V059/V067. Append-
+-- only; withdrawn_at marks a proof no longer in force (null = current).
+-- Community content does NOT get holds_bytes suppression or a DEK cascade
+-- (the CEG 0.8 community default, distinct from CEG 0.7 self/family).
+
+CREATE TABLE IF NOT EXISTS cirislens.federation_location_proofs (
+    subject_key_id        TEXT NOT NULL
+        REFERENCES cirislens.federation_keys(key_id),
+
+    -- H3 cell index, lowercase hex (§0.8). Canonical form + validity +
+    -- resolution-redundancy are admission-gate enforced (h3o).
+    cell_id               TEXT NOT NULL,
+    -- 0-15 at the column; the §0.8.1 rough-only gate rejects > 7 at
+    -- admission (kept as a SMALLINT range backstop, not the ≤7 rule —
+    -- the gate emits the resolution-violation, the DB just sanity-bounds).
+    cell_resolution       SMALLINT NOT NULL
+        CHECK (cell_resolution BETWEEN 0 AND 15),
+
+    asserted_at           TIMESTAMPTZ NOT NULL,
+    valid_until           TIMESTAMPTZ,
+
+    -- Optional TPM / Secure Enclave / StrongBox attestation blob backing
+    -- the location claim. NULL for software-only proofs.
+    attestation_evidence  BYTEA,
+
+    -- null = currently in force; set = withdrawn (append-only, no DELETE).
+    withdrawn_at          TIMESTAMPTZ,
+
+    persist_row_hash      TEXT NOT NULL,
+
+    PRIMARY KEY (subject_key_id, asserted_at)
+);
+
+-- "current location proofs for this subject" — the latest_valid lookup
+-- the geographic-subkind admission predicate (Ask 4, deferred) walks.
+CREATE INDEX IF NOT EXISTS federation_location_proofs_by_subject_live
+    ON cirislens.federation_location_proofs (subject_key_id)
+    WHERE withdrawn_at IS NULL;
+
+-- "who is in this cell" — the containment / communities_containing(cell)
+-- cascade read.
+CREATE INDEX IF NOT EXISTS federation_location_proofs_by_cell
+    ON cirislens.federation_location_proofs (cell_id);

--- a/migrations/sqlite/lens/V068__ceg_08_location_proofs.sql
+++ b/migrations/sqlite/lens/V068__ceg_08_location_proofs.sql
@@ -1,0 +1,27 @@
+-- V068 — CEG 0.8 §5.6.8.11 + §0.8.1 location_proof substrate
+--        (CIRISPersist#154, v4.10.0) — SQLite dialect. Postgres parity:
+--        postgres/lens/V068. See that file for the full rationale.
+--
+-- BYTEA → BLOB; TIMESTAMPTZ → TEXT (RFC-3339); the §0.8.1 rough-only
+-- (resolution ≤ 7) + H3 canonical-form gate live in put_location_proof
+-- (h3o), not the DDL. Refinery wraps this in its own transaction.
+
+CREATE TABLE federation_location_proofs (
+    subject_key_id        TEXT NOT NULL REFERENCES federation_keys(key_id),
+    cell_id               TEXT NOT NULL,
+    cell_resolution       INTEGER NOT NULL
+        CHECK (cell_resolution BETWEEN 0 AND 15),
+    asserted_at           TEXT NOT NULL,   -- RFC-3339
+    valid_until           TEXT,            -- RFC-3339
+    attestation_evidence  BLOB,
+    withdrawn_at          TEXT,            -- null = in force
+    persist_row_hash      TEXT NOT NULL,
+    PRIMARY KEY (subject_key_id, asserted_at)
+);
+
+CREATE INDEX federation_location_proofs_by_subject_live
+    ON federation_location_proofs (subject_key_id)
+    WHERE withdrawn_at IS NULL;
+
+CREATE INDEX federation_location_proofs_by_cell
+    ON federation_location_proofs (cell_id);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,18 @@ classifiers = [
 # fixes that metadata. The Python `ciris-verify` package on PATH
 # is now the v3.x major (build-sign / build-verify CLIs); pin to
 # `<4` to follow semver-major.
+#
+# v4.10.0 (CIRISPersist#154 cut) — bumped floor to v5.0.0 (`<6`). The
+# Rust-side Cargo.toml moved to ciris-verify-core/keyring/crypto v5.0.0
+# in the v4.6.1 cut, but THIS Python wheel Requires-Dist stayed at `<5`
+# — the same drift the v2.0.1 hotfix above describes. The mismatch
+# meant `pip install ciris-persist` refused `ciris-verify==5.0.0`, so
+# CIRISConformance could not put verify 5.0 (the `jcs_canonicalize`
+# Python binding, CIRISVerify#61) into its matrix alongside persist.
+# Floor is v5.0.0 to require the JCS-cutover line, coherent with the
+# Rust pin.
 dependencies = [
-    "ciris-verify>=4.4.2,<5",
+    "ciris-verify>=5.0.0,<6",
 ]
 dynamic = ["version"]
 

--- a/src/federation/location.rs
+++ b/src/federation/location.rs
@@ -1,0 +1,192 @@
+//! v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8 / §0.8.1 / §0.8.2) — H3
+//! geospatial canonicalization, the §0.8.1 rough-only privacy gate, and
+//! cell containment.
+//!
+//! # Mission alignment (MISSION.md §1.4)
+//!
+//! H3 is geospatial indexing, **not** crypto — the "never rolls its own
+//! crypto" invariant is unaffected. We use the pure-Rust [`h3o`] crate
+//! (no libh3 C bindings), so this cross-compiles to the iOS / Android /
+//! wasm wheel targets like the rest of the tree.
+//!
+//! The load-bearing rule is §0.8.1 **rough-only**: a `location_proof`'s
+//! `cell_resolution` MUST be ≤ 7. The substrate is the second line of
+//! defense after client UI gating — a producer cannot over-share precise
+//! location even if the client fails. `validate_location_cell` enforces
+//! it at admission, before the row is written.
+
+use std::str::FromStr;
+
+use h3o::CellIndex;
+
+use super::Error;
+
+/// §0.8.1 — the maximum H3 resolution a `location_proof` may carry.
+/// Finer than this over-shares; the substrate refuses it.
+pub const MAX_LOCATION_PROOF_RESOLUTION: u8 = 7;
+
+/// Parse + validate an H3 `cell_id` per CEG 0.8 §0.8:
+///
+/// 1. lowercase hex (the canonical wire form — uppercase is rejected),
+/// 2. a valid H3 cell index (h3o parses the `u64` and checks structure),
+/// 3. resolution-redundancy: the cell's own encoded resolution MUST equal
+///    the asserted `cell_resolution`.
+///
+/// Returns the parsed [`CellIndex`] on success.
+pub fn parse_canonical_cell(cell_id: &str, cell_resolution: u8) -> Result<CellIndex, Error> {
+    // §0.8 rule 1 — lowercase hex only (canonical form). Reject uppercase
+    // up front so two encodings of the same cell can't both admit.
+    if cell_id.is_empty() || cell_id.chars().any(|c| c.is_ascii_uppercase()) {
+        return Err(Error::InvalidArgument(format!(
+            "location_proof cell_id must be lowercase hex (got {cell_id:?})"
+        )));
+    }
+    let raw = u64::from_str_radix(cell_id, 16).map_err(|_| {
+        Error::InvalidArgument(format!("location_proof cell_id is not hex: {cell_id:?}"))
+    })?;
+    // §0.8 rule 2 — structurally valid H3 cell. (h3o validates the
+    // mode/reserved bits + digit ranges; `from_str` also works but
+    // requires the exact canonical string — go through the u64 so a
+    // valid-but-non-15-char hex still resolves.)
+    let cell = CellIndex::try_from(raw).map_err(|_| {
+        Error::InvalidArgument(format!(
+            "location_proof cell_id is not a valid H3 cell: {cell_id:?}"
+        ))
+    })?;
+    // §0.8 rule 3 — resolution redundancy: the asserted resolution must
+    // match the cell's own encoded resolution (no lying about coarseness).
+    let actual = u8::from(cell.resolution());
+    if actual != cell_resolution {
+        return Err(Error::InvalidArgument(format!(
+            "location_proof cell_resolution {cell_resolution} disagrees with cell_id's encoded \
+             resolution {actual}"
+        )));
+    }
+    Ok(cell)
+}
+
+/// Full §0.8 + §0.8.1 admission gate for a `location_proof`: canonical
+/// form + resolution-redundancy ([`parse_canonical_cell`]) **and** the
+/// rough-only bound (`cell_resolution <= 7`). Returns the violation as an
+/// [`Error::InvalidArgument`] (the substrate's refusal IS the privacy
+/// enforcement); callers may additionally emit the §7.8
+/// `hard_case:location_proof_resolution_violation` telemetry.
+pub fn validate_location_cell(cell_id: &str, cell_resolution: u8) -> Result<(), Error> {
+    parse_canonical_cell(cell_id, cell_resolution)?;
+    if cell_resolution > MAX_LOCATION_PROOF_RESOLUTION {
+        return Err(Error::InvalidArgument(format!(
+            "location_proof resolution {cell_resolution} exceeds the §0.8.1 rough-only bound \
+             ({MAX_LOCATION_PROOF_RESOLUTION}) — over-precise location is refused"
+        )));
+    }
+    Ok(())
+}
+
+/// CEG 0.8 §0.8.2 — is `contained` geographically inside `container`?
+/// True iff `contained` is at the same or finer resolution and its
+/// ancestor at the container's resolution IS the container cell. Invalid
+/// cell strings → `false` (a malformed claim contains nothing). Used by
+/// the geographic-subkind community admission predicate (#154 Ask 4) and
+/// the `communities_containing(cell)` cascade read.
+pub fn h3_cell_contained(contained_cell_id: &str, container_cell_id: &str) -> bool {
+    let (Ok(contained), Ok(container)) = (
+        CellIndex::from_str(contained_cell_id),
+        CellIndex::from_str(container_cell_id),
+    ) else {
+        return false;
+    };
+    if contained.resolution() < container.resolution() {
+        return false; // coarser than the container can't be inside it
+    }
+    contained.parent(container.resolution()) == Some(container)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A known-valid H3 res-7 cell + its res-1 ancestor, computed from h3o
+    // so the test is self-consistent with the linked crate version.
+    fn res7_cell() -> String {
+        // lat/lng → res-7 cell, lowercased hex.
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        ll.to_cell(h3o::Resolution::Seven).to_string()
+    }
+
+    #[test]
+    fn valid_res7_cell_admits() {
+        let c = res7_cell();
+        assert!(validate_location_cell(&c, 7).is_ok());
+    }
+
+    #[test]
+    fn resolution_redundancy_mismatch_rejected() {
+        let c = res7_cell();
+        // Assert the wrong resolution for a res-7 cell.
+        let err = validate_location_cell(&c, 5).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidArgument(ref m) if m.contains("resolution")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn over_precise_resolution_refused() {
+        // res-9 cell → fails the §0.8.1 rough-only bound (≤7).
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let c9 = ll.to_cell(h3o::Resolution::Nine).to_string();
+        let err = validate_location_cell(&c9, 9).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidArgument(ref m) if m.contains("rough-only")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn uppercase_hex_rejected() {
+        let c = res7_cell().to_uppercase();
+        let err = validate_location_cell(&c, 7).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidArgument(ref m) if m.contains("lowercase")),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn garbage_cell_rejected() {
+        assert!(validate_location_cell("not-hex", 7).is_err());
+        assert!(validate_location_cell("ffffffffffffffff", 7).is_err());
+    }
+
+    #[test]
+    fn containment_parent_child() {
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let fine = ll.to_cell(h3o::Resolution::Seven).to_string();
+        let coarse = ll.to_cell(h3o::Resolution::Three).to_string();
+        assert!(
+            h3_cell_contained(&fine, &coarse),
+            "res7 inside its res3 parent"
+        );
+        assert!(!h3_cell_contained(&coarse, &fine), "coarse not inside fine");
+        assert!(h3_cell_contained(&fine, &fine), "a cell contains itself");
+    }
+
+    #[test]
+    fn containment_disjoint_cells() {
+        let a = h3o::LatLng::new(37.0, -122.0)
+            .unwrap()
+            .to_cell(h3o::Resolution::Seven)
+            .to_string();
+        let b = h3o::LatLng::new(-33.8, 151.2) // Sydney — far from California
+            .unwrap()
+            .to_cell(h3o::Resolution::Three)
+            .to_string();
+        assert!(!h3_cell_contained(&a, &b));
+    }
+
+    #[test]
+    fn containment_invalid_input_is_false() {
+        assert!(!h3_cell_contained("garbage", &res7_cell()));
+        assert!(!h3_cell_contained(&res7_cell(), "garbage"));
+    }
+}

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -41,6 +41,7 @@ pub mod blobs;
 pub mod emit;
 pub mod goal;
 pub mod hardware_attestation;
+pub mod location;
 pub mod perceptual_hash;
 pub mod precedence;
 #[cfg(feature = "cirisaudit")]
@@ -136,10 +137,11 @@ pub use topology::{
 pub use types::{
     Attestation, Community, CommunityMember, CommunityMembershipRevocation, Family, FamilyMember,
     FamilyMembershipRevocation, HybridPendingRow, IdentityOccurrence, IdentityOccurrenceRevocation,
-    KeyRecord, PeerMetadataRow, PeerPolicyBlob, Revocation, SignedAttestation, SignedCommunity,
-    SignedCommunityMembershipRevocation, SignedFamily, SignedFamilyMembershipRevocation,
-    SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation, SignedKeyRecord,
-    SignedRevocation, TrustClass, TrustFilter, TrustGrant, TrustRelationship, TrustRow, TrustType,
+    KeyRecord, LocationProof, PeerMetadataRow, PeerPolicyBlob, Revocation, SignedAttestation,
+    SignedCommunity, SignedCommunityMembershipRevocation, SignedFamily,
+    SignedFamilyMembershipRevocation, SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
+    SignedKeyRecord, SignedLocationProof, SignedRevocation, TrustClass, TrustFilter, TrustGrant,
+    TrustRelationship, TrustRow, TrustType,
 };
 
 /// Federation directory trait — the registry/lens/agent's read+write
@@ -531,6 +533,25 @@ pub trait FederationDirectory: Send + Sync {
         &self,
         community_key_id: &str,
     ) -> Result<Vec<CommunityMembershipRevocation>, Error>;
+
+    /// v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8.1) — record a
+    /// `location_proof`. Runs the §0.8 H3 canonicalization gate +
+    /// §0.8.1 **rough-only** bound (`cell_resolution <= 7`) via
+    /// [`location::validate_location_cell`](crate::federation::location::validate_location_cell)
+    /// before computing `persist_row_hash` and inserting — an over-precise
+    /// or malformed cell is **refused** (the substrate is the second line
+    /// of defense after client UI gating). Append-only on the
+    /// `(subject_key_id, asserted_at)` PK.
+    async fn put_location_proof(&self, proof: SignedLocationProof) -> Result<(), Error>;
+
+    /// v4.10.0 — every stored `location_proof` for `subject_key_id`
+    /// (in-force and withdrawn — full history; callers filter on
+    /// `withdrawn_at` / `valid_until` per their freshness policy, same
+    /// shape as `list_identity_occurrences_for`).
+    async fn list_location_proofs_for(
+        &self,
+        subject_key_id: &str,
+    ) -> Result<Vec<LocationProof>, Error>;
 
     /// v4.8.0 (#161 Ask 2) — occurrences of `identity_key_id` that are
     /// **currently active**: admitted AND with no revocation whose

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -1065,6 +1065,44 @@ pub struct SignedCommunityMembershipRevocation {
     pub community_membership_revocation: CommunityMembershipRevocation,
 }
 
+/// v4.10.0 (CIRISPersist#154, CEG 0.8 §5.6.8.11 / §0.8.1) — a subject's
+/// coarse geographic claim. The §0.8.1-normative privacy primitive:
+/// `cell_resolution` is bounded to **≤ 7** ("rough-only") at admission
+/// (see [`crate::federation::location::validate_location_cell`]) so the
+/// substrate refuses an over-precise claim even if client UI gating
+/// fails. Append-only; `withdrawn_at` marks a proof no longer in force.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocationProof {
+    /// The subject's `federation_keys.key_id`.
+    pub subject_key_id: String,
+    /// H3 cell index, lowercase hex (§0.8). Canonical form + validity +
+    /// resolution-redundancy are admission-gate enforced.
+    pub cell_id: String,
+    /// H3 resolution (0-15). The §0.8.1 gate rejects `> 7` at admission.
+    pub cell_resolution: u8,
+    /// When the proof was asserted (RFC-3339 per §0.5).
+    pub asserted_at: DateTime<Utc>,
+    /// When the proof expires. `None` = indefinite.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<DateTime<Utc>>,
+    /// Optional hardware attestation blob (TPM / Secure Enclave /
+    /// StrongBox) backing the claim. `None` for software-only proofs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation_evidence: Option<Vec<u8>>,
+    /// `None` = currently in force; set = withdrawn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub withdrawn_at: Option<DateTime<Utc>>,
+    /// **Server-computed.** See [`KeyRecord::persist_row_hash`].
+    pub persist_row_hash: String,
+}
+
+/// Wraps a [`LocationProof`] for write submission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedLocationProof {
+    /// The location proof being submitted.
+    pub location_proof: LocationProof,
+}
+
 /// One hybrid-pending federation row — minimum fields the sweep
 /// needs to recompute the cold-path bound-signature input. Returned
 /// by [`super::FederationDirectory::list_hybrid_pending_keys`] /

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -105,6 +105,10 @@ struct State {
         HashMap<(String, String), crate::federation::FamilyMembershipRevocation>,
     federation_community_membership_revocations:
         HashMap<(String, String), crate::federation::CommunityMembershipRevocation>,
+    /// v4.10.0 (CIRISPersist#154) — location_proofs keyed by the V068
+    /// `(subject_key_id, asserted_at)` PK.
+    federation_location_proofs:
+        HashMap<(String, chrono::DateTime<chrono::Utc>), crate::federation::LocationProof>,
 }
 
 impl Default for MemoryBackend {
@@ -128,6 +132,7 @@ impl Default for MemoryBackend {
                 federation_identity_occurrence_revocations: HashMap::new(),
                 federation_family_membership_revocations: HashMap::new(),
                 federation_community_membership_revocations: HashMap::new(),
+                federation_location_proofs: HashMap::new(),
                 blackhole_rules: HashMap::new(),
             }),
         }
@@ -1058,6 +1063,44 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .cloned()
             .collect();
         rows.sort_by(|a, b| a.removed_identity_key_id.cmp(&b.removed_identity_key_id));
+        Ok(rows)
+    }
+
+    // ─── v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8.1) — location proofs.
+
+    async fn put_location_proof(
+        &self,
+        proof: crate::federation::SignedLocationProof,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = proof.location_proof;
+        // §0.8 canonicalization + §0.8.1 rough-only gate before write.
+        crate::federation::location::validate_location_cell(&row.cell_id, row.cell_resolution)?;
+        let mut state = self.state.lock().expect("memory backend lock");
+        if !state.federation_keys.contains_key(&row.subject_key_id) {
+            return Err(crate::federation::Error::InvalidArgument(format!(
+                "subject_key_id {} does not exist in federation_keys",
+                row.subject_key_id
+            )));
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        state
+            .federation_location_proofs
+            .insert((row.subject_key_id.clone(), row.asserted_at), row);
+        Ok(())
+    }
+
+    async fn list_location_proofs_for(
+        &self,
+        subject_key_id: &str,
+    ) -> Result<Vec<crate::federation::LocationProof>, crate::federation::Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_location_proofs
+            .values()
+            .filter(|p| p.subject_key_id == subject_key_id)
+            .cloned()
+            .collect();
+        rows.sort_by_key(|p| p.asserted_at);
         Ok(rows)
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2454,6 +2454,65 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .collect()
     }
 
+    // ─── v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8.1) — location proofs.
+
+    async fn put_location_proof(
+        &self,
+        proof: crate::federation::SignedLocationProof,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = proof.location_proof;
+        crate::federation::location::validate_location_cell(&row.cell_id, row.cell_resolution)?;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let resolution = i16::from(row.cell_resolution);
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.federation_location_proofs (\
+                    subject_key_id, cell_id, cell_resolution, asserted_at, valid_until, \
+                    attestation_evidence, withdrawn_at, persist_row_hash\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    &row.subject_key_id,
+                    &row.cell_id,
+                    &resolution,
+                    &row.asserted_at,
+                    &row.valid_until,
+                    &row.attestation_evidence,
+                    &row.withdrawn_at,
+                    &row.persist_row_hash,
+                ],
+            )
+            .await
+            .map_err(map_revocation_pg_err("location_proof"))?;
+        Ok(())
+    }
+
+    async fn list_location_proofs_for(
+        &self,
+        subject_key_id: &str,
+    ) -> Result<Vec<crate::federation::LocationProof>, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT subject_key_id, cell_id, cell_resolution, asserted_at, valid_until, \
+                    attestation_evidence, withdrawn_at, persist_row_hash \
+                 FROM cirislens.federation_location_proofs \
+                 WHERE subject_key_id = $1 ORDER BY asserted_at ASC",
+                &[&subject_key_id],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("list_location_proofs_for: {e}"))
+            })?;
+        rows.into_iter().map(pg_row_to_location_proof).collect()
+    }
+
     async fn attach_key_pqc_signature(
         &self,
         key_id: &str,
@@ -6706,6 +6765,23 @@ fn pg_row_to_community_membership_revocation(
         effective_at: row.safe_get_with("effective_at", mk_err)?,
         reason: row.safe_get_with("reason", mk_err)?,
         witness_set,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+fn pg_row_to_location_proof(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::LocationProof, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let resolution: i16 = row.safe_get_with("cell_resolution", mk_err)?;
+    Ok(crate::federation::LocationProof {
+        subject_key_id: row.safe_get_with("subject_key_id", mk_err)?,
+        cell_id: row.safe_get_with("cell_id", mk_err)?,
+        cell_resolution: resolution as u8,
+        asserted_at: row.safe_get_with("asserted_at", mk_err)?,
+        valid_until: row.safe_get_with("valid_until", mk_err)?,
+        attestation_evidence: row.safe_get_with("attestation_evidence", mk_err)?,
+        withdrawn_at: row.safe_get_with("withdrawn_at", mk_err)?,
         persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
     })
 }
@@ -20814,6 +20890,79 @@ mod tests {
             .unwrap_err();
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("FK")),
+            "got: {err:?}"
+        );
+    }
+
+    /// v4.10.0 (CIRISPersist#154) — live-PG location_proof round-trip:
+    /// SMALLINT `cell_resolution` + BYTEA `attestation_evidence` binding,
+    /// valid res-7 admits, over-precise res-9 refused (§0.8.1).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_location_proof_round_trip_and_rough_only_gate() {
+        use crate::federation::{FederationDirectory, LocationProof, SignedLocationProof};
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let subj = format!("subj-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &subj,
+                    &subj,
+                    crate::federation::types::identity_type::PRIMITIVE,
+                ),
+            })
+            .await
+            .unwrap();
+
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let cell7 = ll.to_cell(h3o::Resolution::Seven).to_string();
+        backend
+            .put_location_proof(SignedLocationProof {
+                location_proof: LocationProof {
+                    subject_key_id: subj.clone(),
+                    cell_id: cell7.clone(),
+                    cell_resolution: 7,
+                    asserted_at: "2026-06-09T00:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    attestation_evidence: Some(vec![0xDEu8, 0xAD, 0xBE, 0xEF]),
+                    withdrawn_at: None,
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+        let rows = backend.list_location_proofs_for(&subj).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cell_id, cell7);
+        assert_eq!(rows[0].cell_resolution, 7);
+        assert_eq!(
+            rows[0].attestation_evidence.as_deref(),
+            Some(&[0xDEu8, 0xAD, 0xBE, 0xEF][..])
+        );
+
+        let cell9 = ll.to_cell(h3o::Resolution::Nine).to_string();
+        let err = backend
+            .put_location_proof(SignedLocationProof {
+                location_proof: LocationProof {
+                    subject_key_id: subj.clone(),
+                    cell_id: cell9,
+                    cell_resolution: 9,
+                    asserted_at: "2026-06-09T01:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    attestation_evidence: None,
+                    withdrawn_at: None,
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("rough-only")),
             "got: {err:?}"
         );
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2146,6 +2146,60 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         })
     }
 
+    // ─── v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8.1) — location proofs.
+
+    async fn put_location_proof(
+        &self,
+        proof: crate::federation::SignedLocationProof,
+    ) -> Result<(), crate::federation::Error> {
+        let mut row = proof.location_proof;
+        crate::federation::location::validate_location_cell(&row.cell_id, row.cell_resolution)?;
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO federation_location_proofs (\
+                    subject_key_id, cell_id, cell_resolution, asserted_at, valid_until, \
+                    attestation_evidence, withdrawn_at, persist_row_hash\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    row.subject_key_id,
+                    row.cell_id,
+                    row.cell_resolution as i64,
+                    row.asserted_at.to_rfc3339(),
+                    row.valid_until.map(|t| t.to_rfc3339()),
+                    row.attestation_evidence,
+                    row.withdrawn_at.map(|t| t.to_rfc3339()),
+                    row.persist_row_hash,
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(map_revocation_sqlite_err("location_proof"))?;
+        Ok(())
+    }
+
+    async fn list_location_proofs_for(
+        &self,
+        subject_key_id: &str,
+    ) -> Result<Vec<crate::federation::LocationProof>, crate::federation::Error> {
+        let conn = self.conn.clone();
+        let key = subject_key_id.to_owned();
+        (move || -> Result<Vec<_>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT subject_key_id, cell_id, cell_resolution, asserted_at, valid_until, \
+                        attestation_evidence, withdrawn_at, persist_row_hash \
+                     FROM federation_location_proofs \
+                     WHERE subject_key_id = ?1 ORDER BY asserted_at ASC",
+            )?;
+            let rows = stmt.query_map([&key], sqlite_row_to_location_proof)?;
+            rows.collect()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("list_location_proofs_for: {e}")))
+    }
+
     async fn attach_key_pqc_signature(
         &self,
         key_id: &str,
@@ -6718,6 +6772,25 @@ fn sqlite_row_to_community_membership_revocation(
         effective_at: parse_rfc3339(&effective_at),
         reason: row.get("reason")?,
         witness_set: decode_witness_set(&witness_text, 5)?,
+        persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+fn sqlite_row_to_location_proof(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::LocationProof> {
+    let asserted_at: String = row.get("asserted_at")?;
+    let valid_until: Option<String> = row.get("valid_until")?;
+    let withdrawn_at: Option<String> = row.get("withdrawn_at")?;
+    let cell_resolution: i64 = row.get("cell_resolution")?;
+    Ok(crate::federation::LocationProof {
+        subject_key_id: row.get("subject_key_id")?,
+        cell_id: row.get("cell_id")?,
+        cell_resolution: cell_resolution as u8,
+        asserted_at: parse_rfc3339(&asserted_at),
+        valid_until: valid_until.as_deref().map(parse_rfc3339),
+        attestation_evidence: row.get("attestation_evidence")?,
+        withdrawn_at: withdrawn_at.as_deref().map(parse_rfc3339),
         persist_row_hash: row.get("persist_row_hash")?,
     })
 }
@@ -11356,6 +11429,71 @@ mod tests {
             consensus_protocol_entrenched: false,
             persist_row_hash: String::new(),
         }
+    }
+
+    // ─── v4.10.0 (CIRISPersist#154, CEG 0.8 §0.8.1) — location proof ───
+
+    /// A valid res-7 cell admits + round-trips; an over-precise (res-9)
+    /// proof is refused at admission (§0.8.1 rough-only); a malformed cell
+    /// is refused; the FK to federation_keys holds.
+    #[tokio::test]
+    async fn location_proof_round_trip_and_rough_only_gate() {
+        use crate::federation::{LocationProof, SignedLocationProof};
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("subj", "subj", "subj"),
+            })
+            .await
+            .unwrap();
+
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let cell7 = ll.to_cell(h3o::Resolution::Seven).to_string();
+        let proof = |cell: &str, res: u8| SignedLocationProof {
+            location_proof: LocationProof {
+                subject_key_id: "subj".into(),
+                cell_id: cell.into(),
+                cell_resolution: res,
+                asserted_at: "2026-06-09T00:00:00Z".parse().unwrap(),
+                valid_until: None,
+                attestation_evidence: None,
+                withdrawn_at: None,
+                persist_row_hash: String::new(),
+            },
+        };
+
+        // Valid res-7 admits + round-trips.
+        backend.put_location_proof(proof(&cell7, 7)).await.unwrap();
+        let rows = backend.list_location_proofs_for("subj").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].cell_id, cell7);
+        assert_eq!(rows[0].cell_resolution, 7);
+        assert!(!rows[0].persist_row_hash.is_empty(), "hash computed");
+
+        // Over-precise res-9 → refused (§0.8.1 rough-only).
+        let cell9 = ll.to_cell(h3o::Resolution::Nine).to_string();
+        let mut input = proof(&cell9, 9);
+        input.location_proof.asserted_at = "2026-06-09T01:00:00Z".parse().unwrap();
+        let err = backend.put_location_proof(input).await.unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("rough-only")),
+            "got: {err:?}"
+        );
+        // Malformed cell → refused.
+        let mut bad = proof("not-a-cell", 7);
+        bad.location_proof.asserted_at = "2026-06-09T02:00:00Z".parse().unwrap();
+        assert!(backend.put_location_proof(bad).await.is_err());
+
+        // Still exactly one stored row (rejections didn't write).
+        assert_eq!(
+            backend
+                .list_location_proofs_for("subj")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — revocation tests ─────


### PR DESCRIPTION
Two things in this cut:

## 1. `location_proof` substrate + H3 rough-only enforcement (#154)
The CEG 0.8 §0.8.1 normative privacy primitive — a geographic claim bounded to H3 resolution ≤ 7, enforced at the substrate so a producer can't over-share precise location even if client UI gating fails.

- **V068** `federation_location_proofs` (PG + SQLite): subject FK, `cell_id` (H3 hex), `cell_resolution`, `asserted_at`, `valid_until`, `attestation_evidence` (BYTEA/BLOB), `withdrawn_at`, `persist_row_hash`.
- `LocationProof`/`SignedLocationProof` + `put_location_proof`/`list_location_proofs_for` on all 3 backends.
- `federation::location` (pure-Rust **h3o** — geospatial, not crypto, MISSION §1.4 unaffected): `validate_location_cell` (§0.8 canonical-form + resolution-redundancy; §0.8.1 ≤7) + `h3_cell_contained` (§0.8.2). Over-precise/malformed → `InvalidArgument`; the refusal *is* the enforcement.
- **Deferred** (#154 residual, Ask 4): the `cohort_subkind:geographic` community-admission dispatch couples to `put_community` + the `policy_blob` constraint shape; the `h3_cell_contained` helper it needs ships here.

## 2. Fixed — `pyproject.toml` pin blocked the conformance matrix
The Python wheel `Requires-Dist` stayed at `ciris-verify>=4.4.2,<5` after the v4.6.1 Rust pin moved to verify v5.0.0 (the same drift the v2.0.1 hotfix fixed once). `pip install ciris-persist` therefore refused `ciris-verify==5.0.0`, so **CIRISConformance couldn't put verify 5.0 (the `jcs_canonicalize` binding, CIRISVerify#61) into its matrix alongside persist.** Bumped to `>=5.0.0,<6`, coherent with the Rust pin. **Shipping this to PyPI is what unblocks the matrix.**

## Verification
**1067 lib green on SQLite, 763 on live PG**; `-D warnings` clean across no-default / `test-panic,pyo3` / full; clippy + **cargo-deny clean** (h3o + transitives: const-random, float_eq, tiny-keccak — advisories/licenses/sources all ok).

Advances #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)