### PR TITLE
v4.11.0 — geographic community admission + communities_containing (closes #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.11.0] — 2026-06-09
+
+**Geographic `cohort_subkind` community admission + `communities_containing` — closes CIRISPersist#154 (CEG 0.8 §8.1.13.2 / §0.8.2).**
+
+Completes #154's residual (Asks 4–5), consuming the `location_proof` + H3 primitives from v4.10.0. The community substrate (V060) and the location_proof primitive (V068) were already in; this wires the geographic-subkind admission predicate and the containment read.
+
+### Added
+- **Geographic community admission** — `put_community` now runs the §8.1.13.2 geographic predicate: when a community's `policy_blob` is `{"cohort_subkind": "geographic", "geographic_constraint": {"cell_id": …}}`, **every** member of the submitted roster MUST hold an in-force, unexpired `location_proof` whose cell is H3-contained within the constraint cell — else the community is refused (`InvalidArgument`). Non-geographic communities pass through (admit on `consensus_protocol` alone — the dispatcher's default arm). Enforced on all three backends; the location-proof reads run before the write (lock-safe).
+- **`FederationDirectory::communities_containing(cell_id)`** (Ask 5, §0.8.2) — the emergency-broadcast cascade read: geographic communities whose constraint cell **contains** `cell_id`. PG/SQLite prefilter to `cohort_subkind = 'geographic'` (JSONB `->>'` / `json_extract`), then H3-filter in Rust.
+- **`federation::location`** helpers: `geographic_constraint_cell` (read the constraint from `policy_blob`), `member_in_geographic_constraint` (in-force + unexpired + contained), `check_geographic_community_admission` (the shared admission step).
+
+### Deferred (noted)
+The full §8.1.13.2 dispatcher also composes `consensus_protocol` *signature-counting* (Step 1) — that membership-ceremony consensus enforcement is the separate #153 lifecycle-track piece (CIRISRegistry#52), not yet built; this cut lands the subkind predicate (Step 2). Operator-defined non-geographic subkinds admit on consensus alone for now.
+
+### Tests
+`location` unit tests (constraint-cell parse, member admission: in-force/withdrawn/expired/outside/no-proof) + SQLite and live-PG integration (geographic community refuses a member without a contained proof, admits with one; `communities_containing` finds the community for an inside cell, not a far one). **1071 lib green on SQLite, 766 on live PG**; `-D warnings` + clippy + cargo-deny clean.
+
+**#154 is now fully closed** (community substrate v4.0.1 + location_proof/H3 v4.10.0 + this).
+
 ## [4.10.0] — 2026-06-09
 
 **`location_proof` substrate + H3 rough-only enforcement — the CEG 0.8 §0.8.1 normative privacy primitive (CIRISPersist#154).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.10.0"
+version = "4.11.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/FSD/SELF_FAMILY_DEK_CASCADE.md
+++ b/FSD/SELF_FAMILY_DEK_CASCADE.md
@@ -1,0 +1,74 @@
+# FSD: Self/Family DEK Cascade — at-rest key_grant delivery for `cohort_scope: self | family` (CIRISPersist#152)
+
+**Status:** **PROPOSED — needs the 4-impl nod on the who-wraps decision (§2).** This is a CEG-fabric architecture call (CIRISAgent / NodeCore / LensCore / Registry all read/write the same substrate), not a persist-internal one.
+**Author:** Eric Moore (CIRIS Team) with Claude Opus 4.8
+**Created:** 2026-06-09
+**Repo:** `~/CIRISPersist`
+**Normative anchor:** CEG §11.7.1 (Option-A forward secrecy), §8.1.12.4 (self DEK cascade), §5.6.8.4 (`key_grant` wire).
+**Builds on:** `FSD/ENCRYPTED_AT_REST.md` (the locked, unilateral at-rest content-encryption design — persist is the sole DB opener and encrypts content under a master key, keeping a scoreable projection). This FSD adds the **per-recipient DEK delivery** layer for the `self`/`family` cohorts, so occurrences/members *other than the writer* can decrypt.
+**Driving context:** the keystone under **#161 Asks 4–5** (forward-secrecy producer gate), **#183** (Self-at-login Self-DEK cascade + occurrence re-key), and **#153's** remaining at-rest half. Resolving §2 unblocks all three.
+
+---
+
+## 0. TL;DR for reviewers
+
+`ENCRYPTED_AT_REST.md` settled that **persist encrypts content at rest** (master-key, application-layer, backend-agnostic, sole-DB-opener → unilateral). This FSD answers the one question that layer left open for the *shared* cohorts: when content lands at `cohort_scope: self | family`, **who wraps the content DEK to each recipient occurrence/member, and who re-wraps on membership change?**
+
+**The decision (§2): default = the substrate wraps; zero-trust-of-host = an opt-in where the producer wraps in a hardware enclave and persist stores the wrap opaque.** This is the secrets-path model (persist already AES-GCM-encrypts secrets at rest by *calling* CIRISVerify primitives — MISSION §1.4 forbids reimplementing crypto, not orchestrating it) generalized to blob content. It is **not** "every producer re-orchestrates the cascade" — that was an over-generalization of the C3b streaming precedent (corrected on #152), and it would replicate a security-critical path across N consumers, the opposite of why the substrate exists.
+
+Persist already owns the two pieces the default tier needs: the **recipient enumeration** (`list_identity_occurrences_active` / `list_families_for_member_active`, shipped v4.8.0 / #161) and the **wrap primitive** (`ciris_verify_core` `wrap_dek_for_recipient`, exposed today as a stateless helper). The cascade is "enumerate active recipients → wrap the DEK to each → record the `key_grant` rows."
+
+---
+
+## 1. Why this exists
+
+CEWP's structural-invisibility promise (no `holds_bytes:*` broadcast for self/family) hides *existence* from federation peers. `ENCRYPTED_AT_REST.md` adds confidentiality of *content* against the host (operator shell, lost device, leaked backup). But self/family content has a third requirement neither covers: **the user's *other* devices, and family members, must be able to read it.** A phone writes a `cohort_scope: self` note; the user's laptop + agent occurrence must decrypt it. That requires the content DEK delivered to each recipient — the §5.6.8.4 `key_grant` (HPKE-wrapped DEK per recipient pubkey).
+
+And membership is not static (§11.7.1): a new occurrence is admitted (must get retroactive grants for existing content), or one is revoked (must stop receiving grants for *new* content — forward secrecy). #161 shipped the substrate's expression of revocation + the `list_*_active` enumeration; this FSD is the wrap/delivery that consumes it.
+
+## 2. The who-wraps decision (the call this FSD exists to settle)
+
+**Default tier — the substrate wraps (host-trusted, defense-in-depth).** On a `cohort_scope: self | family` write, persist (inside the `put_blob_signing` content-encryption path that `ENCRYPTED_AT_REST.md` already establishes):
+
+1. generates / reuses the content DEK and AES-GCM-encrypts the body (existing at-rest path);
+2. **enumerates active recipients** — `list_identity_occurrences_active(attesting_identity)` for `self`, `list_families_for_member_active(family_id)` for `family` (#161, v4.8.0);
+3. **wraps the DEK to each** recipient pubkey via `ciris_verify_core::wrap_dek_for_recipient` (HPKE; v2 hybrid x25519+ML-KEM) — *calling* the CIRISVerify authority, never reimplementing (MISSION §1.4);
+4. **records** the resulting `key_grant` rows (the existing `list_key_grants_for*` surface).
+
+Consumers write `cohort_scope: self` and read back via a new `get_blob_for_viewer(sha, viewer_key_id)` — they deal with **zero crypto**. This is the secrets-path posture (`src/secrets/crypto.rs`) generalized.
+
+**Opt-in tier — zero-trust-of-host (only when the consumer needs it).** A consumer that requires the host to *never* hold the DEK supplies enclave-wrapped grants itself (the stateless `wrap_dek_for_recipient` helper + the producer's hardware enclave) and persist stores them **opaque** — persist never sees the DEK, the C3b model. This is the *only* path where wrap-orchestration surfaces upward, and only for the consumer that asked.
+
+**Why default-absorbs, not producer-orchestrates (the correction).** The C3b streaming epoch-DEK cascade locked "persist records opaque wraps, doesn't wrap" — correct *there* (a high-throughput producer already managing epoch DEKs). Generalizing it to *all* self/family content would make every producer (agent, edge, lens) reimplement enumerate-wrap-cascade-on-change — a security-critical path duplicated N times. The substrate's reason for being (MISSION §1.3, "lowest stateful substrate") is that consumers don't reimplement this. The host-trust cost (persist holds the DEK in the default tier) is a strict improvement over today's plaintext-at-rest and is the same trust model the secrets path already accepts; the stronger property is the opt-in tier.
+
+## 3. Architecture (default tier)
+
+- **`Ask 1` produce — `put_blob_signing` cohort branch.** `self|family` → encrypt + cascade (steps §2.1–4). `community|partnered|global` → status quo (community content federates plaintext per CEG 0.8, no suppression, no cascade — confirmed #154).
+- **`Ask 1` consume — `Engine.get_blob_for_viewer(sha, viewer_key_id) -> Bytes` (+ PyO3).** Looks up the latest `key_grant` for `(content_sha, viewer_key_id)`, unwraps the DEK (defer to the viewer's `ciris-keyring` hardware backend where present), AES-GCM-decrypts. Returns `NotGranted` if the viewer holds no grant (a revoked/never-member recipient).
+- **`Ask 2` membership-change cascade (persist-driven in the default tier).** A background watcher (the `EvictionSweeper` pattern) observes occurrence/family admissions + revocations:
+  - **ADD** → walk `cohort_scope: self|family` content for the affected identity/family, wrap the DEK to the new recipient, record grants (retroactive access).
+  - **REMOVE** → **stop** wrapping for that recipient on subsequent content. Because the producer-side enumeration in §2.2 reads `list_*_active`, the removed recipient simply drops out of the recipient set — **this IS #161 Ask 4**, and persist can *enforce* it (not merely detect) precisely because persist is the one wrapping.
+
+## 4. What it unblocks
+
+- **#161 Asks 4–5** — the "stop wrapping new `key_grant`s to a removed party" gate is `§3 Ask 2 REMOVE` + the `list_*_active` enumeration in `§2.2`. Persist enforces it. Ask 5's `*_membership_change`-on-removal reserved-prefix emission rides the same watcher.
+- **#183 (Self-at-login)** — the Self-DEK cascade to *both* the app and agent occurrences of one identity is exactly `§2` over `list_identity_occurrences_active`; the occurrence-withdraw re-key is `§3 Ask 2 REMOVE`.
+- **#153** — closes its remaining at-rest half.
+
+## 5. Open questions for the 4-impl review
+
+- **OQ-1 — who wraps (the §2 decision).** Default-absorbs vs. producer-orchestrates. This FSD argues default-absorbs with a zero-trust-of-host opt-in. **Needs the agent / NodeCore / LensCore / Registry nod.**
+- **OQ-2 — does the membership-ADD retroactive cascade run in the default tier, or is retroactive access deliberately *not* granted** (forward-secrecy-symmetric: a new member sees only content from after they joined)? §11.7.1 says removed parties *retain* historical grants; it is silent on whether *new* members *gain* historical access. Default proposal: cascade retroactively for `self` (it's the same user's devices), gate behind family `consensus_protocol` for `family`.
+- **OQ-3 — DEK lifecycle on REMOVE.** Forward secrecy stops *new* wraps; does it also *rotate* the DEK for *future* content (so the removed party's retained grant can't decrypt new content sharing an old DEK)? Proposal: per-write fresh DEK (no cross-content DEK reuse) makes this automatic — the removed party's grant only ever decrypted the content it was granted.
+- **OQ-4 — `get_blob_for_viewer` hardware-unwrap boundary.** Default tier: persist can unwrap (it holds the DEK). Zero-trust tier: persist returns the wrapped DEK + ciphertext and the viewer unwraps in-enclave. One method with a mode flag, or two methods?
+
+## 6. Phasing
+
+| Phase | Work | Gate |
+|---|---|---|
+| 1 | This FSD + OQ resolution | the 4-impl nod on §2 / OQ-1 |
+| 2 | Default-tier produce (`Ask 1` encrypt + cascade) + `get_blob_for_viewer` | Phase 1 + `ENCRYPTED_AT_REST.md` Phase landed |
+| 3 | Membership-change watcher (`Ask 2`) = #161 Ask 4–5 enforcement | Phase 2 |
+| 4 | Zero-trust-of-host opt-in (opaque-store path) | Phase 2 |
+
+Phases 2–3 are the keystone for #161/#183. Phase 4 is additive.

--- a/src/federation/location.rs
+++ b/src/federation/location.rs
@@ -101,6 +101,77 @@ pub fn h3_cell_contained(contained_cell_id: &str, container_cell_id: &str) -> bo
     contained.parent(container.resolution()) == Some(container)
 }
 
+/// v4.11.0 (CIRISPersist#154 Ask 4) — read a geographic community's
+/// containment cell from its `policy_blob`. Returns `Some(cell_id)` iff
+/// `policy_blob.cohort_subkind == "geographic"` and a
+/// `geographic_constraint.cell_id` string is present. `None` for any
+/// non-geographic (or absent) policy — those admit on consensus_protocol
+/// alone (the §8.1.13.2 dispatcher's default arm).
+///
+/// Shape: `{"cohort_subkind": "geographic",
+///          "geographic_constraint": {"cell_id": "<h3>", "cell_resolution": N}}`.
+pub fn geographic_constraint_cell(policy_blob: Option<&serde_json::Value>) -> Option<String> {
+    let blob = policy_blob?;
+    if blob.get("cohort_subkind").and_then(|v| v.as_str()) != Some("geographic") {
+        return None;
+    }
+    blob.get("geographic_constraint")?
+        .get("cell_id")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// v4.11.0 (CIRISPersist#154 Ask 4 / §8.1.13.2 geographic predicate) —
+/// is `member_proofs` sufficient to admit a member into a geographic
+/// community bounded by `constraint_cell`? True iff the member has at
+/// least one **in-force** (`withdrawn_at` unset), **unexpired**
+/// (`valid_until` unset or `> now`) `location_proof` whose cell is
+/// [`h3_cell_contained`] within `constraint_cell`. No valid contained
+/// proof → not admissible (the §8.1.13.2 `return Ok(false)` path).
+pub fn member_in_geographic_constraint(
+    constraint_cell: &str,
+    member_proofs: &[crate::federation::LocationProof],
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    member_proofs.iter().any(|p| {
+        p.withdrawn_at.is_none()
+            && p.valid_until.map_or(true, |vu| vu > now)
+            && h3_cell_contained(&p.cell_id, constraint_cell)
+    })
+}
+
+/// v4.11.0 (CIRISPersist#154 Ask 4, CEG 0.8 §8.1.13.2) — the geographic
+/// `cohort_subkind` admission predicate, run on `put_community`. For a
+/// geographic community (per [`geographic_constraint_cell`]), **every**
+/// member of the submitted roster MUST hold an in-force, contained
+/// `location_proof` ([`member_in_geographic_constraint`]) — else the
+/// community is refused. Non-geographic communities pass through (admit
+/// on `consensus_protocol` alone). Reads each member's proofs through the
+/// directory, so it runs before the write on every backend.
+pub async fn check_geographic_community_admission<D>(
+    dir: &D,
+    community: &crate::federation::Community,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), Error>
+where
+    D: crate::federation::FederationDirectory + ?Sized,
+{
+    let Some(constraint_cell) = geographic_constraint_cell(community.policy_blob.as_ref()) else {
+        return Ok(());
+    };
+    for m in &community.members {
+        let proofs = dir.list_location_proofs_for(&m.key_id).await?;
+        if !member_in_geographic_constraint(&constraint_cell, &proofs, now) {
+            return Err(Error::InvalidArgument(format!(
+                "geographic community member {} has no in-force location_proof contained in the \
+                 constraint cell {constraint_cell} (CEG §8.1.13.2)",
+                m.key_id
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,6 +253,72 @@ mod tests {
             .to_cell(h3o::Resolution::Three)
             .to_string();
         assert!(!h3_cell_contained(&a, &b));
+    }
+
+    #[test]
+    fn geographic_constraint_cell_reads_geographic_policy() {
+        let geo = serde_json::json!({
+            "cohort_subkind": "geographic",
+            "geographic_constraint": {"cell_id": "abc", "cell_resolution": 3}
+        });
+        assert_eq!(
+            geographic_constraint_cell(Some(&geo)),
+            Some("abc".to_string())
+        );
+        // Non-geographic / absent → None (admit on consensus alone).
+        let other = serde_json::json!({"cohort_subkind": "operator_defined"});
+        assert_eq!(geographic_constraint_cell(Some(&other)), None);
+        assert_eq!(geographic_constraint_cell(None), None);
+    }
+
+    #[test]
+    fn member_admission_requires_in_force_contained_unexpired_proof() {
+        use crate::federation::LocationProof;
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let constraint = ll.to_cell(h3o::Resolution::Three).to_string();
+        let inside7 = ll.to_cell(h3o::Resolution::Seven).to_string();
+        let now: chrono::DateTime<chrono::Utc> = "2026-06-09T00:00:00Z".parse().unwrap();
+        let proof =
+            |cell: &str, withdrawn: Option<&str>, valid_until: Option<&str>| LocationProof {
+                subject_key_id: "m".into(),
+                cell_id: cell.into(),
+                cell_resolution: 7,
+                asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                valid_until: valid_until.map(|s| s.parse().unwrap()),
+                attestation_evidence: None,
+                withdrawn_at: withdrawn.map(|s| s.parse().unwrap()),
+                persist_row_hash: String::new(),
+            };
+        // in-force, contained, unexpired → admit.
+        assert!(member_in_geographic_constraint(
+            &constraint,
+            &[proof(&inside7, None, None)],
+            now
+        ));
+        // withdrawn → not.
+        assert!(!member_in_geographic_constraint(
+            &constraint,
+            &[proof(&inside7, Some("2026-06-05T00:00:00Z"), None)],
+            now
+        ));
+        // expired → not.
+        assert!(!member_in_geographic_constraint(
+            &constraint,
+            &[proof(&inside7, None, Some("2026-06-05T00:00:00Z"))],
+            now
+        ));
+        // outside the constraint (Sydney res-7) → not.
+        let outside = h3o::LatLng::new(-33.8, 151.2)
+            .unwrap()
+            .to_cell(h3o::Resolution::Seven)
+            .to_string();
+        assert!(!member_in_geographic_constraint(
+            &constraint,
+            &[proof(&outside, None, None)],
+            now
+        ));
+        // no proofs → not.
+        assert!(!member_in_geographic_constraint(&constraint, &[], now));
     }
 
     #[test]

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -553,6 +553,15 @@ pub trait FederationDirectory: Send + Sync {
         subject_key_id: &str,
     ) -> Result<Vec<LocationProof>, Error>;
 
+    /// v4.11.0 (CIRISPersist#154 Ask 5, CEG 0.8 §0.8.2) — geographic
+    /// communities whose constraint cell **contains** `cell_id` (the
+    /// emergency-broadcast cascade read: "which geo-communities does this
+    /// location fall within?"). Scans communities with
+    /// `policy_blob.cohort_subkind == "geographic"` and returns those where
+    /// [`location::h3_cell_contained`](crate::federation::location::h3_cell_contained)`(cell_id, constraint_cell)`.
+    /// Non-geographic communities are never returned.
+    async fn communities_containing(&self, cell_id: &str) -> Result<Vec<Community>, Error>;
+
     /// v4.8.0 (#161 Ask 2) — occurrences of `identity_key_id` that are
     /// **currently active**: admitted AND with no revocation whose
     /// `effective_at <= now`. This is the honest view

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -911,6 +911,16 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // v4.0 — value-validation admission (consensus_protocol
         // canonical form). Mirrors put_family.
         crate::federation::check_consensus_protocol_form(&row.consensus_protocol)?;
+        // v4.11.0 (#154 Ask 4) — geographic cohort_subkind admission. Runs
+        // BEFORE the state lock below: it reads via list_location_proofs_for
+        // (which locks state itself), so calling it under the lock would
+        // deadlock. No-op for non-geographic communities.
+        crate::federation::location::check_geographic_community_admission(
+            self,
+            &row,
+            chrono::Utc::now(),
+        )
+        .await?;
         let mut state = self.state.lock().expect("memory backend lock");
         if !state.federation_keys.contains_key(&row.community_key_id) {
             return Err(crate::federation::Error::InvalidArgument(format!(
@@ -1101,6 +1111,26 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .cloned()
             .collect();
         rows.sort_by_key(|p| p.asserted_at);
+        Ok(rows)
+    }
+
+    async fn communities_containing(
+        &self,
+        cell_id: &str,
+    ) -> Result<Vec<crate::federation::Community>, crate::federation::Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_communities
+            .values()
+            .filter(|c| {
+                crate::federation::location::geographic_constraint_cell(c.policy_blob.as_ref())
+                    .is_some_and(|constraint| {
+                        crate::federation::location::h3_cell_contained(cell_id, &constraint)
+                    })
+            })
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| a.community_key_id.cmp(&b.community_key_id));
         Ok(rows)
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2188,6 +2188,13 @@ impl crate::federation::FederationDirectory for PostgresBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = community.community;
         crate::federation::check_consensus_protocol_form(&row.consensus_protocol)?;
+        // v4.11.0 (#154 Ask 4) — geographic cohort_subkind admission.
+        crate::federation::location::check_geographic_community_admission(
+            self,
+            &row,
+            chrono::Utc::now(),
+        )
+        .await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let members_value = serde_json::to_value(&row.members)
             .map_err(|e| crate::federation::Error::Backend(format!("members serialize: {e}")))?;
@@ -2511,6 +2518,43 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 crate::federation::Error::Backend(format!("list_location_proofs_for: {e}"))
             })?;
         rows.into_iter().map(pg_row_to_location_proof).collect()
+    }
+
+    async fn communities_containing(
+        &self,
+        cell_id: &str,
+    ) -> Result<Vec<crate::federation::Community>, crate::federation::Error> {
+        // Prefilter to geographic communities (JSONB), h3-filter in Rust.
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT community_key_id, community_name, members, founded_at, \
+                    consensus_protocol, policy_blob, persist_row_hash \
+                 FROM cirislens.federation_communities \
+                 WHERE policy_blob->>'cohort_subkind' = 'geographic' \
+                 ORDER BY community_key_id ASC",
+                &[],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("communities_containing: {e}"))
+            })?;
+        let all: Vec<crate::federation::Community> = rows
+            .into_iter()
+            .map(pg_row_to_community)
+            .collect::<Result<_, _>>()?;
+        Ok(all
+            .into_iter()
+            .filter(|c| {
+                crate::federation::location::geographic_constraint_cell(c.policy_blob.as_ref())
+                    .is_some_and(|constraint| {
+                        crate::federation::location::h3_cell_contained(cell_id, &constraint)
+                    })
+            })
+            .collect())
     }
 
     async fn attach_key_pqc_signature(
@@ -20965,5 +21009,92 @@ mod tests {
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("rough-only")),
             "got: {err:?}"
         );
+    }
+
+    /// v4.11.0 (#154 Ask 4/5) — live-PG geographic community admission +
+    /// `communities_containing` (exercises the JSONB
+    /// `policy_blob->>'cohort_subkind'` query). Unique keys per run.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_geographic_community_admission_and_containing() {
+        use crate::federation::{
+            Community, CommunityMember, FederationDirectory, LocationProof, SignedCommunity,
+            SignedLocationProof,
+        };
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let comm = format!("geo-{}", uuid_like());
+        let alice = format!("alice-{}", uuid_like());
+        let bob = format!("bob-{}", uuid_like());
+        for k in [&comm, &alice, &bob] {
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord {
+                    record: pg_admission_key(
+                        k,
+                        k,
+                        crate::federation::types::identity_type::PRIMITIVE,
+                    ),
+                })
+                .await
+                .unwrap();
+        }
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let constraint = ll.to_cell(h3o::Resolution::Three).to_string();
+        let inside = ll.to_cell(h3o::Resolution::Seven).to_string();
+        backend
+            .put_location_proof(SignedLocationProof {
+                location_proof: LocationProof {
+                    subject_key_id: alice.clone(),
+                    cell_id: inside.clone(),
+                    cell_resolution: 7,
+                    asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    attestation_evidence: None,
+                    withdrawn_at: None,
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+        let geo_policy = serde_json::json!({
+            "cohort_subkind": "geographic",
+            "geographic_constraint": {"cell_id": constraint, "cell_resolution": 3}
+        });
+        let mk = |members: Vec<&str>| SignedCommunity {
+            community: Community {
+                community_key_id: comm.clone(),
+                community_name: "Geo".into(),
+                members: members
+                    .into_iter()
+                    .map(|k| CommunityMember {
+                        key_id: k.to_string(),
+                        joined_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                        role: None,
+                    })
+                    .collect(),
+                founded_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                consensus_protocol: "unanimous".into(),
+                policy_blob: Some(geo_policy.clone()),
+                persist_row_hash: String::new(),
+            },
+        };
+        // bob lacks a contained proof → refused.
+        let err = backend
+            .put_community(mk(vec![&alice, &bob]))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("location_proof")),
+            "got: {err:?}"
+        );
+        // alice-only admits.
+        backend.put_community(mk(vec![&alice])).await.unwrap();
+        // containing finds it via the JSONB prefilter + h3 containment.
+        let hit = backend.communities_containing(&inside).await.unwrap();
+        assert!(hit.iter().any(|c| c.community_key_id == comm));
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1885,6 +1885,15 @@ impl crate::federation::FederationDirectory for SqliteBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = community.community;
         crate::federation::check_consensus_protocol_form(&row.consensus_protocol)?;
+        // v4.11.0 (#154 Ask 4) — geographic cohort_subkind admission: every
+        // member must hold an in-force contained location_proof. Reads run
+        // before the write lock below. No-op for non-geographic communities.
+        crate::federation::location::check_geographic_community_admission(
+            self,
+            &row,
+            chrono::Utc::now(),
+        )
+        .await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let members_json = serde_json::to_string(&row.members)
             .map_err(|e| crate::federation::Error::Backend(format!("members serialize: {e}")))?;
@@ -2198,6 +2207,40 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             rows.collect()
         })()
         .map_err(|e| crate::federation::Error::Backend(format!("list_location_proofs_for: {e}")))
+    }
+
+    async fn communities_containing(
+        &self,
+        cell_id: &str,
+    ) -> Result<Vec<crate::federation::Community>, crate::federation::Error> {
+        // Prefilter to geographic communities in SQL, then h3-filter in
+        // Rust (community cardinality is small; no spatial index).
+        let conn = self.conn.clone();
+        let all: Vec<crate::federation::Community> =
+            (move || -> Result<Vec<_>, rusqlite::Error> {
+                let conn = conn.lock();
+                let mut stmt = conn.prepare(
+                    "SELECT community_key_id, community_name, members, founded_at, \
+                        consensus_protocol, policy_blob, persist_row_hash \
+                     FROM federation_communities \
+                     WHERE json_extract(policy_blob, '$.cohort_subkind') = 'geographic' \
+                     ORDER BY community_key_id ASC",
+                )?;
+                let rows = stmt.query_map([], sqlite_row_to_community)?;
+                rows.collect()
+            })()
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("communities_containing: {e}"))
+            })?;
+        Ok(all
+            .into_iter()
+            .filter(|c| {
+                crate::federation::location::geographic_constraint_cell(c.policy_blob.as_ref())
+                    .is_some_and(|constraint| {
+                        crate::federation::location::h3_cell_contained(cell_id, &constraint)
+                    })
+            })
+            .collect())
     }
 
     async fn attach_key_pqc_signature(
@@ -11494,6 +11537,99 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    /// v4.11.0 (#154 Ask 4/5) — geographic community admission gates each
+    /// member on an in-force contained location_proof; `communities_
+    /// containing` finds the community for a cell inside its constraint.
+    #[tokio::test]
+    async fn geographic_community_admission_and_containing() {
+        use crate::federation::{
+            Community, CommunityMember, LocationProof, SignedCommunity, SignedLocationProof,
+        };
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        for k in ["geo-comm", "alice", "bob"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key(k, k, k),
+                })
+                .await
+                .unwrap();
+        }
+        let ll = h3o::LatLng::new(37.0, -122.0).unwrap();
+        let constraint = ll.to_cell(h3o::Resolution::Three).to_string();
+        let inside = ll.to_cell(h3o::Resolution::Seven).to_string();
+
+        // alice has an in-force contained proof; bob has none.
+        backend
+            .put_location_proof(SignedLocationProof {
+                location_proof: LocationProof {
+                    subject_key_id: "alice".into(),
+                    cell_id: inside.clone(),
+                    cell_resolution: 7,
+                    asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    attestation_evidence: None,
+                    withdrawn_at: None,
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        let geo_policy = serde_json::json!({
+            "cohort_subkind": "geographic",
+            "geographic_constraint": {"cell_id": constraint, "cell_resolution": 3}
+        });
+        let community = |members: Vec<&str>| SignedCommunity {
+            community: Community {
+                community_key_id: "geo-comm".into(),
+                community_name: "Geo".into(),
+                members: members
+                    .into_iter()
+                    .map(|k| CommunityMember {
+                        key_id: k.into(),
+                        joined_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                        role: None,
+                    })
+                    .collect(),
+                founded_at: "2026-06-01T00:00:00Z".parse().unwrap(),
+                consensus_protocol: "unanimous".into(),
+                policy_blob: Some(geo_policy.clone()),
+                persist_row_hash: String::new(),
+            },
+        };
+
+        // bob (no contained proof) → refused.
+        let err = backend
+            .put_community(community(vec!["alice", "bob"]))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("location_proof")),
+            "got: {err:?}"
+        );
+        // alice-only → admits.
+        backend
+            .put_community(community(vec!["alice"]))
+            .await
+            .unwrap();
+
+        // communities_containing: a cell inside the constraint finds it.
+        let hit = backend.communities_containing(&inside).await.unwrap();
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].community_key_id, "geo-comm");
+        // A far-away cell does not.
+        let far = h3o::LatLng::new(-33.8, 151.2)
+            .unwrap()
+            .to_cell(h3o::Resolution::Seven)
+            .to_string();
+        assert!(backend
+            .communities_containing(&far)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — revocation tests ─────


### PR DESCRIPTION
Closes **#154**'s residual (Asks 4–5), consuming the `location_proof` + H3 primitives from v4.10.0.

## Added
- **Geographic community admission** — `put_community` runs the §8.1.13.2 geographic predicate: for a community whose `policy_blob` is `{"cohort_subkind":"geographic","geographic_constraint":{"cell_id":…}}`, **every** member must hold an in-force, unexpired `location_proof` H3-contained in the constraint cell, else refused (`InvalidArgument`). Non-geographic communities admit on `consensus_protocol` alone (the dispatcher's default arm). All 3 backends; the location reads run **before** the write (lock-safe — incl. avoiding the memory-backend re-lock deadlock).
- **`FederationDirectory::communities_containing(cell_id)`** (Ask 5, §0.8.2) — emergency-broadcast read: geographic communities whose constraint cell **contains** `cell_id`. PG/SQLite JSONB prefilter (`policy_blob->>'cohort_subkind'` / `json_extract`) + H3 filter in Rust.
- `federation::location` helpers: `geographic_constraint_cell`, `member_in_geographic_constraint`, `check_geographic_community_admission`.

## Deferred (noted)
The full §8.1.13.2 dispatcher also composes `consensus_protocol` *signature-counting* (Step 1) — that membership-ceremony consensus enforcement is the separate #153 / CIRISRegistry#52 lifecycle piece, not yet built. This cut lands the Step-2 subkind predicate; operator-defined non-geographic subkinds admit on consensus alone.

## Tests
`location` unit tests (constraint parse; member admission across in-force/withdrawn/expired/outside/no-proof) + SQLite & live-PG integration (geo community refuses a member without a contained proof, admits with one; `communities_containing` finds an inside cell, not a far one). **1071 lib green on SQLite, 766 on live PG**; `-D warnings` + clippy + cargo-deny clean.

**#154 is now fully closed** (community substrate v4.0.1 + location_proof/H3 v4.10.0 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)