### PR TITLE
v4.12.0 — at-rest crypto-tier dispatch: negative-default classifier (#152/#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.12.0] — 2026-06-10
+
+**At-rest crypto-tier dispatch — the negative-default `cohort_scope` → tier classifier (CIRISPersist#152 / #188; CEG 0.17 §8.1.13.3 / §10.1.4).**
+
+The foundation of the at-rest DEK cascade (#152, FSD accepted on PR #185): the three-way dispatch every later phase keys off, landed first as a pure, tested classifier so the encryption-into-`put_blob_signing` cut builds on a conformant spine. No encryption wired yet — this is the decision function.
+
+### Added — `federation::types::cohort_scope`
+- **`CryptoTier`** — `InvisibleEncrypted` (`self`/`family`: per-write DEK, structurally invisible) · `CommunityDek` (`community`/`affiliations`: shared per-community DEK = the §10.5.3 epoch-DEK cascade, `holds_bytes` + provenance, **mandatory**) · `Plaintext` (Commons + the `cohort_subkind: infrastructure` governance carve-out + anything unrecognized). Orthogonal to `suppresses_holds_bytes`.
+- **`crypto_tier(cohort_scope, cohort_subkind) -> CryptoTier`** — **negative-default (#188)**: only `self`/`family` and `community`/`affiliations` encrypt; *everything else, including unknown future scopes, falls through to plaintext* (no new tier silently encrypts-or-leaks). `cohort_subkind: infrastructure` communities route to plaintext-Commons (the trust root must be inspectable).
+
+Resolves the #188 dispatch-shape decision (negative-default, not a scope allowlist) flagged by the CIRISNodeCore review on #152.
+
+### Tests
+Pure classifier coverage: self/family → invisible-encrypted (subkind-irrelevant), community/affiliations → community-DEK, infrastructure-subkind → plaintext carve-out, Commons + unknown scopes → plaintext negative-default. `-D warnings` + clippy clean.
+
 ## [4.11.0] — 2026-06-09
 
 **Geographic `cohort_subkind` community admission + `communities_containing` — closes CIRISPersist#154 (CEG 0.8 §8.1.13.2 / §0.8.2).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.11.0"
+version = "4.12.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -604,6 +604,98 @@ pub mod cohort_scope {
     pub fn suppresses_holds_bytes(s: &str) -> bool {
         matches!(s, SELF | FAMILY)
     }
+
+    /// v4.12.0 (CIRISPersist#152 / #188, CEG 0.17 §8.1.13.3 / §10.1.4) —
+    /// the at-rest crypto tier a `cohort_scope` resolves to. **Orthogonal
+    /// to [`suppresses_holds_bytes`]**: self/family are encrypted AND
+    /// suppressed; community/affiliations are encrypted but still emit
+    /// `holds_bytes` (with cleartext provenance); Commons is plaintext.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum CryptoTier {
+        /// `self` / `family` — per-write fresh DEK wrapped to every active
+        /// occurrence/member; structurally invisible (no `holds_bytes`).
+        /// **Opt-in / default-off** (defense-in-depth over already-invisible
+        /// bytes; the v1 migration posture). #152.
+        InvisibleEncrypted,
+        /// `community` / `affiliations` — a shared per-community DEK (the
+        /// §10.5.3 epoch-DEK cascade with the roster as subscriber set),
+        /// rotated on membership change; emits `holds_bytes:*` **with**
+        /// cleartext provenance. **Mandatory** (the DEK is community
+        /// content's sole confidentiality boundary). CEG 0.17 §8.1.13.3.
+        CommunityDek,
+        /// Commons (`species` / `biosphere` / `federation`), the
+        /// `cohort_subkind: infrastructure` governance carve-out, and any
+        /// **unrecognized** scope — plaintext, `holds_bytes` normally.
+        Plaintext,
+    }
+
+    /// The §8.1.13.3 / §10.1.4 at-rest dispatch — **NEGATIVE-DEFAULT
+    /// (#188)**: only `self`/`family` and `community`/`affiliations` are
+    /// encrypted; *everything else, including unknown future scopes, falls
+    /// through to plaintext*. A `community` whose `cohort_subkind` is
+    /// `"infrastructure"` (e.g. `ciris-canonical` governance) is the
+    /// plaintext-Commons carve-out — the trust root must be inspectable.
+    pub fn crypto_tier(cohort_scope: &str, cohort_subkind: Option<&str>) -> CryptoTier {
+        match cohort_scope {
+            SELF | FAMILY => CryptoTier::InvisibleEncrypted,
+            COMMUNITY | AFFILIATIONS if cohort_subkind != Some("infrastructure") => {
+                CryptoTier::CommunityDek
+            }
+            // Negative default: Commons, infrastructure communities, and
+            // any scope this build doesn't recognize → plaintext. New
+            // tiers never silently encrypt-or-leak by falling through.
+            _ => CryptoTier::Plaintext,
+        }
+    }
+
+    #[cfg(test)]
+    mod crypto_tier_tests {
+        use super::*;
+
+        #[test]
+        fn self_family_are_invisible_encrypted() {
+            assert_eq!(crypto_tier(SELF, None), CryptoTier::InvisibleEncrypted);
+            assert_eq!(crypto_tier(FAMILY, None), CryptoTier::InvisibleEncrypted);
+            // subkind is irrelevant for self/family.
+            assert_eq!(
+                crypto_tier(SELF, Some("infrastructure")),
+                CryptoTier::InvisibleEncrypted
+            );
+        }
+
+        #[test]
+        fn community_affiliations_are_community_dek() {
+            assert_eq!(crypto_tier(COMMUNITY, None), CryptoTier::CommunityDek);
+            assert_eq!(crypto_tier(AFFILIATIONS, None), CryptoTier::CommunityDek);
+            assert_eq!(
+                crypto_tier(COMMUNITY, Some("geographic")),
+                CryptoTier::CommunityDek
+            );
+        }
+
+        #[test]
+        fn infrastructure_community_is_plaintext_carveout() {
+            assert_eq!(
+                crypto_tier(COMMUNITY, Some("infrastructure")),
+                CryptoTier::Plaintext
+            );
+            assert_eq!(
+                crypto_tier(AFFILIATIONS, Some("infrastructure")),
+                CryptoTier::Plaintext
+            );
+        }
+
+        #[test]
+        fn commons_and_unknown_are_plaintext_negative_default() {
+            for s in [SPECIES, BIOSPHERE, FEDERATION] {
+                assert_eq!(crypto_tier(s, None), CryptoTier::Plaintext);
+            }
+            // The #188 point: an unrecognized scope must NOT fall into an
+            // encrypted arm — negative default.
+            assert_eq!(crypto_tier("planet", None), CryptoTier::Plaintext);
+            assert_eq!(crypto_tier("some_future_tier", None), CryptoTier::Plaintext);
+        }
+    }
 }
 
 impl Attestation {


### PR DESCRIPTION
The **foundation** of the #152 at-rest DEK cascade (FSD accepted on PR #185) — the three-way `cohort_scope → tier` dispatch every later phase keys off, landed first as a pure, tested classifier so the encryption-into-`put_blob_signing` cut builds on a conformant spine. **No encryption wired yet** — this is the decision function.

## Added — `federation::types::cohort_scope`
- **`CryptoTier`** — `InvisibleEncrypted` (self/family: per-write DEK, structurally invisible) · `CommunityDek` (community/affiliations: shared per-community DEK = the §10.5.3 epoch-DEK cascade, `holds_bytes` + provenance, **mandatory**) · `Plaintext` (Commons + `cohort_subkind: infrastructure` carve-out + unrecognized). Orthogonal to `suppresses_holds_bytes`.
- **`crypto_tier(cohort_scope, cohort_subkind)`** — **negative-default (#188)**: only self/family + community/affiliations encrypt; *everything else, including unknown future scopes, falls through to plaintext* — no new tier silently encrypts-or-leaks. `infrastructure` communities → plaintext Commons (trust root must be inspectable).

Resolves the **#188** dispatch-shape decision (negative-default, not a scope allowlist) flagged by the CIRISNodeCore review on #152. Closes #188.

## Tests
Classifier coverage: self/family → invisible-encrypted (subkind-irrelevant), community/affiliations → community-DEK, infrastructure-subkind → plaintext carve-out, Commons + unknown → plaintext negative-default. **1075 lib green on SQLite**; `-D warnings` + clippy clean. (Pure function, zero SQL impact — backend behavior unchanged.)

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)