### PR TITLE
v4.12.1 — embed version literal in the cdylib (#189)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 *.abi3.so
 .pytest_cache/
 .venv/
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.12.1] — 2026-06-10
+
+**Embedded version literal in the cdylib — for the agent Trust-page / bundle-refresh integrity check (CIRISPersist#189).**
+
+CIRISAgent's Trust page displays each fabric component's version + canonical-build-hash, and its `tools/update_android_libs.py` greps each per-ABI `.so` for the literal version to confirm the binary matches the pinned wheel. ciris-verify embeds its version; persist did not (`strings libciris_persist.so | grep <version>` returned nothing).
+
+### Added
+- **`CIRIS_PERSIST_BUILD_VERSION`** — a `#[used]` static `"ciris-persist <CARGO_PKG_VERSION>\0"` literal that survives `strip`/LTO (strip drops the symbol table, not the rodata bytes), so `strings libciris_persist.so | grep <version>` succeeds on the release cdylib. **Verified** on the stripped release build.
+
+### Why a `#[used]` static, not Verify's `#[no_mangle]` C accessor
+persist is crate-level **`#![deny(unsafe_code)]`** (hard-locked, audited) — a hand-written `#[no_mangle]` FFI export trips that lint. ciris-verify exposes its accessor from a dedicated FFI crate that permits unsafe; persist does not. The agent's two consumers are both served without breaking the no-unsafe posture: the **static-grep** integrity check by this literal, and the **runtime** version read by the PyO3 `__version__` the wheel already exports (the agent loads persist as a Python module, so `ciris_persist.__version__` IS the binary's self-reported version). The native non-Python C accessor (Verify's "ideal") is the only part deferred — flagged on #189.
+
 ## [4.12.0] — 2026-06-10
 
 **At-rest crypto-tier dispatch — the negative-default `cohort_scope` → tier classifier (CIRISPersist#152 / #188; CEG 0.17 §8.1.13.3 / §10.1.4).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.12.0"
+version = "4.12.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,45 @@ pub mod verify;
 #[cfg(feature = "cirislens_wa_cert")]
 pub mod wa_cert;
 
+/// v4.12.1 (CIRISPersist#189) — verify-style embedded version literal for
+/// the agent Trust-page / bundle-refresh integrity check.
+///
+/// `#[used]` keeps this static through dead-code elimination; the literal
+/// bytes live in the binary's read-only data, which `strip` does **not**
+/// remove (strip drops the symbol *table*, not the data sections). So
+/// `strings libciris_persist.so | grep <version>` succeeds on the
+/// stripped release cdylib — the integrity grep CIRISAgent's
+/// `tools/update_android_libs.py` runs per-ABI `.so`.
+///
+/// **Why a `#[used]` static, not the `#[no_mangle]` C accessor ciris-verify
+/// uses:** persist is crate-level `#![deny(unsafe_code)]` (hard-locked,
+/// audited) — a hand-written `#[no_mangle]` FFI export trips that lint.
+/// ciris-verify exposes its accessor from a dedicated FFI crate that
+/// permits unsafe; persist does not. The **runtime** read (the Trust-page
+/// `binary == pip == registry` check) is served by the PyO3 `__version__`
+/// the wheel already exports — the agent loads persist as a Python module,
+/// so `ciris_persist.__version__` IS the binary's self-reported version.
+/// This static covers the static-grep consumer without breaking the
+/// no-unsafe posture.
+#[used]
+static CIRIS_PERSIST_BUILD_VERSION: &[u8] =
+    concat!("ciris-persist ", env!("CARGO_PKG_VERSION"), "\0").as_bytes();
+
+#[cfg(test)]
+mod build_version_tests {
+    /// The embedded literal carries the live `CARGO_PKG_VERSION` and is
+    /// NUL-terminated (so `strings | grep <version>` finds a clean token).
+    /// Strip-survival itself is verified on the release cdylib at build
+    /// time; this just locks the content.
+    #[test]
+    fn embedded_version_matches_cargo_pkg_version() {
+        let s = std::str::from_utf8(super::CIRIS_PERSIST_BUILD_VERSION).unwrap();
+        assert!(s.contains(env!("CARGO_PKG_VERSION")), "got {s:?}");
+        assert!(s.ends_with('\0'), "must be NUL-terminated: {s:?}");
+        assert!(s.starts_with("ciris-persist "), "grep-identifiable: {s:?}");
+    }
+}
+
 #[cfg(all(feature = "cirisaudit", any(feature = "postgres", feature = "sqlite")))]
 pub use engine::AuditDispatch;
 #[cfg(all(feature = "cirisnode", any(feature = "postgres", feature = "sqlite")))]


### PR DESCRIPTION
CIRISAgent's Trust page displays each fabric component's version + canonical-build-hash, and `tools/update_android_libs.py` greps each per-ABI `.so` for the literal version to confirm the binary matches the pinned wheel. ciris-verify embeds it; persist didn't (`strings libciris_persist.so | grep <version>` returned nothing).

## Added
- **`CIRIS_PERSIST_BUILD_VERSION`** — a `#[used]` static `"ciris-persist <CARGO_PKG_VERSION>\0"` literal that survives `strip`/LTO (strip drops the symbol table, not the rodata bytes). **Verified:** `strings target/release/libciris_persist.so | grep "ciris-persist 4.12"` → `ciris-persist 4.12.0` on the stripped release build.

## Why a `#[used]` static, not Verify's `#[no_mangle]` C accessor
persist is crate-level **`#![deny(unsafe_code)]`** (hard-locked, audited) — a hand-written `#[no_mangle]` FFI export trips that lint. ciris-verify exposes its accessor from a dedicated FFI crate that permits unsafe; persist deliberately does not. The agent's two consumers are both served without breaking the no-unsafe posture:
- **static-grep integrity** (`update_android_libs.py`) → this literal;
- **runtime version** (Trust-page `binary == pip == registry`) → the PyO3 `__version__` the wheel already exports (the agent loads persist as a Python module, so `ciris_persist.__version__` IS the binary's self-reported version).

The native non-Python C accessor (Verify's "ideal") is the only part deferred — flagged on #189 for the team to weigh against the no-unsafe policy.

Closes #189 (minimum + runtime; native-C-accessor noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)