### PR TITLE
v4.13.0 — recipient content-encryption pubkeys on identity_occurrence (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [4.13.0] — 2026-06-10
+
+**Recipient content-encryption pubkeys on `identity_occurrence` — the substrate-wraps DEK-cascade prerequisite (CIRISPersist#192; CEG 0.18 §5.6.8.8 / §10.1.4; CIRISRegistry#69).**
+
+Building the #152 at-rest DEK cascade surfaced a load-bearing gap the FSD review missed: substrate-wraps (CEG §10.1.4-mandated) needs each recipient's **x25519 + ML-KEM-768 encryption** pubkeys, but `federation_keys` stores only **signing** keys (ed25519 + ML-DSA-65) — and ML-KEM can't be derived from a signing key, and C3b is *producer*-wraps. CEG 0.18 ruled the encryption keys ride the existing `identity_occurrence` subject_kind (self-certified, hybrid-signed, supersedes-rotatable, already cross-region replicated). This lands persist's half.
+
+### Added
+- **V069 migration** (PG + SQLite) — nullable `pubkey_x25519_base64` + `pubkey_ml_kem_768_base64` on `federation_identity_occurrences`.
+- **`EncryptionPubkeys { x25519_base64, ml_kem_768_base64 }`** + `IdentityOccurrence.encryption_pubkeys: Option<…>` — the `wrap_algorithm: v2` recipient inputs (a fresh content-KEM pair, distinct from the signing keys and the Reticulum transport x25519). Both halves present together or neither.
+- **`FederationDirectory::resolve_encryption_keys(occurrence_key_id)`** — the cascade's per-recipient key lookup: the within-validity occurrence's keys, or `None` ⇒ **fail-secure excluded** from v2 grants (§10.1.4 — never a plaintext fallback). Default trait method over `lookup_identity_for_occurrence`. Round-trips on all three backends.
+- **`check_encryption_pubkeys`** admission — each half MUST base64-decode to its exact raw length (x25519 = 32 B, ML-KEM-768 = 1184 B); a malformed key is refused at admit.
+
+### What this unblocks
+The #152 default-tier cascade can now wrap to recipients with registered encryption keys; #161 Asks 4–5 + #183's Self-DEK inherit it. **Still gated:** producers (agent) must actually register encryption keys (parallel work), and the `ENCRYPTED_AT_REST` at-rest content-encryption foundation is still unbuilt.
+
+### Tests
+SQLite + live-PG: encryption-pubkeys round-trip, `resolve_encryption_keys` (present → keys; absent / unknown → `None` fail-secure), admission length-gate rejection. **1078 lib green on SQLite, 772 on live PG**; `-D warnings` + clippy + cargo-deny clean.
+
 ## [4.12.1] — 2026-06-10
 
 **Embedded version literal in the cdylib — for the agent Trust-page / bundle-refresh integrity check (CIRISPersist#189).**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "4.12.1"
+version = "4.13.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V069__ceg_018_occurrence_encryption_pubkeys.sql
+++ b/migrations/postgres/lens/V069__ceg_018_occurrence_encryption_pubkeys.sql
@@ -1,0 +1,27 @@
+-- V069 — CEG 0.18 §5.6.8.8 recipient content-encryption pubkeys on
+--        identity_occurrence (CIRISPersist#192; CIRISRegistry#69).
+--
+-- The substrate-wraps DEK cascade (#152, §10.1.4) wraps the content DEK to
+-- each recipient's *content-encryption* keys (x25519 + ML-KEM-768, the
+-- `wrap_algorithm: v2` inputs) — which are DISTINCT from the signing keys
+-- (ed25519 + ML-DSA-65 in federation_keys) and from the Reticulum
+-- transport x25519 in transport_destination. ML-KEM cannot be derived from
+-- ML-DSA, so they must be registered as their own material.
+--
+-- CEG 0.18 rules them an OPTIONAL field-set on the existing
+-- identity_occurrence subject_kind (parallel to transport_destination):
+-- self-certified (admit requires attesting == identity or a current
+-- occurrence), hybrid-signed, rotatable via `supersedes`, and already
+-- cross-region replicated inside the occurrence envelope — so no new
+-- subject_kind, no new replication EnvelopeKind. The occurrence is the
+-- per-identity, per-region, supersedes-rotatable presence record; the
+-- encryption keys are its natural home.
+--
+-- Nullable (hybrid-pending shape, like pubkey_ml_dsa_65_base64). An
+-- occurrence with no valid ML-KEM-768 key is **fail-secure excluded** from
+-- v2 grants (§10.1.4) — never a plaintext fallback; the cascade enforces
+-- that at wrap time. Both halves present together or neither.
+
+ALTER TABLE cirislens.federation_identity_occurrences
+    ADD COLUMN IF NOT EXISTS pubkey_x25519_base64     TEXT,
+    ADD COLUMN IF NOT EXISTS pubkey_ml_kem_768_base64 TEXT;

--- a/migrations/sqlite/lens/V069__ceg_018_occurrence_encryption_pubkeys.sql
+++ b/migrations/sqlite/lens/V069__ceg_018_occurrence_encryption_pubkeys.sql
@@ -1,0 +1,12 @@
+-- V069 — CEG 0.18 §5.6.8.8 recipient content-encryption pubkeys on
+--        identity_occurrence (CIRISPersist#192) — SQLite dialect.
+--        Postgres parity: postgres/lens/V069. See that file for rationale.
+--
+-- x25519 + ML-KEM-768 content-encryption pubkeys (the wrap_algorithm: v2
+-- recipient inputs), distinct from signing + transport keys. Nullable,
+-- hybrid-pending shape; an occurrence lacking a valid ML-KEM key is
+-- fail-secure excluded from v2 grants (cascade-enforced). SQLite ALTER
+-- adds one column per statement.
+
+ALTER TABLE federation_identity_occurrences ADD COLUMN pubkey_x25519_base64 TEXT;
+ALTER TABLE federation_identity_occurrences ADD COLUMN pubkey_ml_kem_768_base64 TEXT;

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -843,6 +843,34 @@ pub fn check_capacity_not_self_attested(
     Ok(())
 }
 
+/// v4.13.0 (CIRISPersist#192, CEG 0.18 §5.6.8.8) — validate an
+/// occurrence's optional content-encryption pubkeys on admit: each half
+/// MUST base64-decode to its exact raw length (x25519 = 32 bytes,
+/// ML-KEM-768 = 1184 bytes, FIPS 203). `Ok(())` when absent. A
+/// malformed-length key would silently break `wrap_algorithm: v2`, so it
+/// is refused at the boundary.
+pub fn check_encryption_pubkeys(
+    keys: Option<&crate::federation::types::EncryptionPubkeys>,
+) -> Result<(), Error> {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+    let Some(k) = keys else { return Ok(()) };
+    let check = |label: &str, b64: &str, want: usize| -> Result<(), Error> {
+        let raw = B64.decode(b64).map_err(|e| {
+            Error::InvalidArgument(format!("encryption_pubkeys.{label} not valid base64: {e}"))
+        })?;
+        if raw.len() != want {
+            return Err(Error::InvalidArgument(format!(
+                "encryption_pubkeys.{label} must be {want} raw bytes, got {}",
+                raw.len()
+            )));
+        }
+        Ok(())
+    };
+    check("x25519_base64", &k.x25519_base64, 32)?;
+    check("ml_kem_768_base64", &k.ml_kem_768_base64, 1184)?;
+    Ok(())
+}
+
 /// v3.11.0 (CIRISPersist#143, CIRISVerify FEDERATION_THREAT_MODEL
 /// §3.3.2 R1) — admission-gate validation of the producer-side
 /// `observed_region` field on a revocation.

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -89,9 +89,10 @@ pub(crate) mod serde_bytes_b64 {
 }
 
 pub use admission::{
-    check_cohort_scope, check_consensus_protocol_form, check_device_class, check_observed_region,
-    AttestationLadderTransitionPolicy, DimensionAdmissionPolicy, DimensionRejectionReason,
-    ReservedPrefixRule, ATTESTATION_LADDER_MECHANISMS,
+    check_cohort_scope, check_consensus_protocol_form, check_device_class,
+    check_encryption_pubkeys, check_observed_region, AttestationLadderTransitionPolicy,
+    DimensionAdmissionPolicy, DimensionRejectionReason, ReservedPrefixRule,
+    ATTESTATION_LADDER_MECHANISMS,
 };
 pub use blackhole::{BlackholeRecord, BlackholeRules, RETICULUM_IDENTITY_HASH_LEN};
 pub use blobs::{
@@ -135,13 +136,13 @@ pub use topology::{
     WithdrawalEntry, MAX_DELEGATION_DEPTH,
 };
 pub use types::{
-    Attestation, Community, CommunityMember, CommunityMembershipRevocation, Family, FamilyMember,
-    FamilyMembershipRevocation, HybridPendingRow, IdentityOccurrence, IdentityOccurrenceRevocation,
-    KeyRecord, LocationProof, PeerMetadataRow, PeerPolicyBlob, Revocation, SignedAttestation,
-    SignedCommunity, SignedCommunityMembershipRevocation, SignedFamily,
-    SignedFamilyMembershipRevocation, SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
-    SignedKeyRecord, SignedLocationProof, SignedRevocation, TrustClass, TrustFilter, TrustGrant,
-    TrustRelationship, TrustRow, TrustType,
+    Attestation, Community, CommunityMember, CommunityMembershipRevocation, EncryptionPubkeys,
+    Family, FamilyMember, FamilyMembershipRevocation, HybridPendingRow, IdentityOccurrence,
+    IdentityOccurrenceRevocation, KeyRecord, LocationProof, PeerMetadataRow, PeerPolicyBlob,
+    Revocation, SignedAttestation, SignedCommunity, SignedCommunityMembershipRevocation,
+    SignedFamily, SignedFamilyMembershipRevocation, SignedIdentityOccurrence,
+    SignedIdentityOccurrenceRevocation, SignedKeyRecord, SignedLocationProof, SignedRevocation,
+    TrustClass, TrustFilter, TrustGrant, TrustRelationship, TrustRow, TrustType,
 };
 
 /// Federation directory trait — the registry/lens/agent's read+write
@@ -411,6 +412,32 @@ pub trait FederationDirectory: Send + Sync {
         &self,
         occurrence_key_id: &str,
     ) -> Result<Option<IdentityOccurrence>, Error>;
+
+    /// v4.13.0 (CIRISPersist#192, CEG 0.18 §5.6.8.8 / §10.1.4) — resolve
+    /// an occurrence's **current** content-encryption pubkeys (the
+    /// `wrap_algorithm: v2` recipient inputs for the #152 DEK cascade).
+    ///
+    /// Returns the `encryption_pubkeys` of the occurrence bound to
+    /// `occurrence_key_id` iff it exists, is within validity
+    /// (`valid_until` unset or future), and registered the keys. `None` ⇒
+    /// the recipient is **fail-secure excluded** from v2 grants — the
+    /// cascade MUST NOT fall back to plaintext (§10.1.4). Revocation
+    /// filtering is the enumeration's job
+    /// ([`Self::list_identity_occurrences_active`]); this is the
+    /// per-occurrence key lookup. Default impl over
+    /// [`Self::lookup_identity_for_occurrence`]; backends need not
+    /// override.
+    async fn resolve_encryption_keys(
+        &self,
+        occurrence_key_id: &str,
+    ) -> Result<Option<EncryptionPubkeys>, Error> {
+        let now = chrono::Utc::now();
+        Ok(self
+            .lookup_identity_for_occurrence(occurrence_key_id)
+            .await?
+            .filter(|o| o.valid_until.map_or(true, |vu| vu > now))
+            .and_then(|o| o.encryption_pubkeys))
+    }
 
     /// v3.12.0 (CIRISPersist#153 Ask 2, CEG 0.7 §5.6.8.9) — admit a
     /// `family` row.

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -913,8 +913,30 @@ pub struct IdentityOccurrence {
     /// When the binding expires. `None` = indefinite.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub valid_until: Option<DateTime<Utc>>,
+    /// v4.13.0 (CIRISPersist#192, CEG 0.18 §5.6.8.8) — the occurrence's
+    /// **content-encryption** pubkeys (the `wrap_algorithm: v2` recipient
+    /// inputs). `None` ⇒ this occurrence is **not** a wrap target and is
+    /// fail-secure excluded from v2 grants (§10.1.4). Distinct from the
+    /// signing keys (`federation_keys`) and the transport x25519. Present
+    /// ⇒ both halves present (the field-set is meaningful only as a pair).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption_pubkeys: Option<EncryptionPubkeys>,
     /// **Server-computed.** See [`KeyRecord::persist_row_hash`].
     pub persist_row_hash: String,
+}
+
+/// v4.13.0 (CIRISPersist#192, CEG 0.18 §5.6.8.8) — the hybrid
+/// content-encryption pubkey pair an [`IdentityOccurrence`] registers as
+/// a wrap target. Both halves are required together: the §5.6.8.4
+/// `wrap_algorithm: v2` (`x25519_mlkem768_aes256_gcm_hkdf_sha256`) needs
+/// both. These are a **fresh content-KEM** keypair — never the signing
+/// keys, never the Reticulum transport x25519.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptionPubkeys {
+    /// Classical KEM half — base64 x25519 public key (32 bytes raw).
+    pub x25519_base64: String,
+    /// PQC KEM half — base64 ML-KEM-768 public key (FIPS 203; 1184 bytes raw).
+    pub ml_kem_768_base64: String,
 }
 
 /// Wraps an [`IdentityOccurrence`] payload for write submission.

--- a/src/scope/admission.rs
+++ b/src/scope/admission.rs
@@ -294,6 +294,7 @@ mod revocation_honesty_tests {
                 hardware_attestation: None,
                 asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
                 valid_until: None,
+                encryption_pubkeys: None,
                 persist_row_hash: String::new(),
             },
         })

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -810,6 +810,8 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // v3.12.0 — value-validation admission (closed-set
         // device_class). Trust-graph admission per §5.6.8.8 is v3.13+.
         crate::federation::check_device_class(&row.device_class)?;
+        // v4.13.0 (#192) — validate optional content-encryption pubkeys.
+        crate::federation::check_encryption_pubkeys(row.encryption_pubkeys.as_ref())?;
         let mut state = self.state.lock().expect("memory backend lock");
         if !state.federation_keys.contains_key(&row.identity_key_id) {
             return Err(crate::federation::Error::InvalidArgument(format!(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2008,7 +2008,15 @@ impl crate::federation::FederationDirectory for PostgresBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = occurrence.identity_occurrence;
         crate::federation::check_device_class(&row.device_class)?;
+        crate::federation::check_encryption_pubkeys(row.encryption_pubkeys.as_ref())?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let (enc_x25519, enc_ml_kem) = match &row.encryption_pubkeys {
+            Some(k) => (
+                Some(k.x25519_base64.clone()),
+                Some(k.ml_kem_768_base64.clone()),
+            ),
+            None => (None, None),
+        };
         let client = self
             .get_client()
             .await
@@ -2017,8 +2025,9 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             .execute(
                 "INSERT INTO cirislens.federation_identity_occurrences (\
                     identity_key_id, occurrence_key_id, device_class, \
-                    hardware_attestation, asserted_at, valid_until, persist_row_hash\
-                 ) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                    pubkey_x25519_base64, pubkey_ml_kem_768_base64\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                 &[
                     &row.identity_key_id,
                     &row.occurrence_key_id,
@@ -2027,6 +2036,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     &row.asserted_at,
                     &row.valid_until,
                     &row.persist_row_hash,
+                    &enc_x25519,
+                    &enc_ml_kem,
                 ],
             )
             .await
@@ -2054,7 +2065,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         let rows = client
             .query(
                 "SELECT identity_key_id, occurrence_key_id, device_class, \
-                    hardware_attestation, asserted_at, valid_until, persist_row_hash \
+                    hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                    pubkey_x25519_base64, pubkey_ml_kem_768_base64 \
                  FROM cirislens.federation_identity_occurrences \
                  WHERE identity_key_id = $1 \
                  ORDER BY occurrence_key_id ASC",
@@ -2080,7 +2092,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         let row_opt = client
             .query_opt(
                 "SELECT identity_key_id, occurrence_key_id, device_class, \
-                    hardware_attestation, asserted_at, valid_until, persist_row_hash \
+                    hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                    pubkey_x25519_base64, pubkey_ml_kem_768_base64 \
                  FROM cirislens.federation_identity_occurrences \
                  WHERE occurrence_key_id = $1 LIMIT 1",
                 &[&occurrence_key_id],
@@ -6675,6 +6688,8 @@ fn pg_row_to_identity_occurrence(
     row: tokio_postgres::Row,
 ) -> Result<crate::federation::IdentityOccurrence, crate::federation::Error> {
     let mk_err = crate::federation::Error::Backend;
+    let enc_x25519: Option<String> = row.safe_get_with("pubkey_x25519_base64", mk_err)?;
+    let enc_ml_kem: Option<String> = row.safe_get_with("pubkey_ml_kem_768_base64", mk_err)?;
     Ok(crate::federation::IdentityOccurrence {
         identity_key_id: row.safe_get_with("identity_key_id", mk_err)?,
         occurrence_key_id: row.safe_get_with("occurrence_key_id", mk_err)?,
@@ -6682,6 +6697,15 @@ fn pg_row_to_identity_occurrence(
         hardware_attestation: row.safe_get_with("hardware_attestation", mk_err)?,
         asserted_at: row.safe_get_with("asserted_at", mk_err)?,
         valid_until: row.safe_get_with("valid_until", mk_err)?,
+        encryption_pubkeys: match (enc_x25519, enc_ml_kem) {
+            (Some(x25519_base64), Some(ml_kem_768_base64)) => {
+                Some(crate::federation::EncryptionPubkeys {
+                    x25519_base64,
+                    ml_kem_768_base64,
+                })
+            }
+            _ => None,
+        },
         persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
     })
 }
@@ -20875,6 +20899,7 @@ mod tests {
                 hardware_attestation: None,
                 asserted_at: "2026-06-01T00:00:00Z".parse().unwrap(),
                 valid_until: None,
+                encryption_pubkeys: None,
                 persist_row_hash: String::new(),
             },
         };
@@ -21096,5 +21121,61 @@ mod tests {
         // containing finds it via the JSONB prefilter + h3 containment.
         let hit = backend.communities_containing(&inside).await.unwrap();
         assert!(hit.iter().any(|c| c.community_key_id == comm));
+    }
+
+    /// v4.13.0 (#192, CEG 0.18) — live-PG occurrence encryption-pubkeys
+    /// round-trip + `resolve_encryption_keys` (V069 columns).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_occurrence_encryption_pubkeys_round_trip_and_resolve() {
+        use crate::federation::{EncryptionPubkeys, FederationDirectory, SignedIdentityOccurrence};
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let root = format!("root-{}", uuid_like());
+        let occ = format!("occ-{}", uuid_like());
+        for k in [&root, &occ] {
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord {
+                    record: pg_admission_key(
+                        k,
+                        k,
+                        crate::federation::types::identity_type::PRIMITIVE,
+                    ),
+                })
+                .await
+                .unwrap();
+        }
+        let x25519 = B64.encode([7u8; 32]);
+        let ml_kem = B64.encode([9u8; 1184]);
+        backend
+            .put_identity_occurrence(SignedIdentityOccurrence {
+                identity_occurrence: crate::federation::IdentityOccurrence {
+                    identity_key_id: root.clone(),
+                    occurrence_key_id: occ.clone(),
+                    device_class: crate::federation::types::device_class::AGENT.into(),
+                    hardware_attestation: None,
+                    asserted_at: "2026-06-10T00:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    encryption_pubkeys: Some(EncryptionPubkeys {
+                        x25519_base64: x25519.clone(),
+                        ml_kem_768_base64: ml_kem.clone(),
+                    }),
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+        let resolved = backend
+            .resolve_encryption_keys(&occ)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.x25519_base64, x25519);
+        assert_eq!(resolved.ml_kem_768_base64, ml_kem);
     }
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1710,15 +1710,24 @@ impl crate::federation::FederationDirectory for SqliteBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = occurrence.identity_occurrence;
         crate::federation::check_device_class(&row.device_class)?;
+        crate::federation::check_encryption_pubkeys(row.encryption_pubkeys.as_ref())?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+        let (enc_x25519, enc_ml_kem) = match &row.encryption_pubkeys {
+            Some(k) => (
+                Some(k.x25519_base64.clone()),
+                Some(k.ml_kem_768_base64.clone()),
+            ),
+            None => (None, None),
+        };
         let conn = self.conn.clone();
         (move || -> Result<(), rusqlite::Error> {
             let conn = conn.lock();
             conn.execute(
                 "INSERT INTO federation_identity_occurrences (\
                     identity_key_id, occurrence_key_id, device_class, \
-                    hardware_attestation, asserted_at, valid_until, persist_row_hash\
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                    hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                    pubkey_x25519_base64, pubkey_ml_kem_768_base64\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 rusqlite::params![
                     row.identity_key_id,
                     row.occurrence_key_id,
@@ -1727,6 +1736,8 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     row.asserted_at.to_rfc3339(),
                     row.valid_until.map(|t| t.to_rfc3339()),
                     row.persist_row_hash,
+                    enc_x25519,
+                    enc_ml_kem,
                 ],
             )?;
             Ok(())
@@ -1754,7 +1765,8 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             let conn = conn.lock();
             let mut stmt = conn.prepare(
                 "SELECT identity_key_id, occurrence_key_id, device_class, \
-                        hardware_attestation, asserted_at, valid_until, persist_row_hash \
+                        hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                        pubkey_x25519_base64, pubkey_ml_kem_768_base64 \
                      FROM federation_identity_occurrences \
                      WHERE identity_key_id = ?1 \
                      ORDER BY occurrence_key_id ASC",
@@ -1777,7 +1789,8 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             let conn = conn.lock();
             conn.query_row(
                 "SELECT identity_key_id, occurrence_key_id, device_class, \
-                        hardware_attestation, asserted_at, valid_until, persist_row_hash \
+                        hardware_attestation, asserted_at, valid_until, persist_row_hash, \
+                        pubkey_x25519_base64, pubkey_ml_kem_768_base64 \
                      FROM federation_identity_occurrences \
                      WHERE occurrence_key_id = ?1 LIMIT 1",
                 [&key],
@@ -6663,6 +6676,8 @@ fn sqlite_row_to_identity_occurrence(
 ) -> rusqlite::Result<crate::federation::IdentityOccurrence> {
     let asserted_at: String = row.get("asserted_at")?;
     let valid_until: Option<String> = row.get("valid_until")?;
+    let enc_x25519: Option<String> = row.get("pubkey_x25519_base64")?;
+    let enc_ml_kem: Option<String> = row.get("pubkey_ml_kem_768_base64")?;
     Ok(crate::federation::IdentityOccurrence {
         identity_key_id: row.get("identity_key_id")?,
         occurrence_key_id: row.get("occurrence_key_id")?,
@@ -6670,8 +6685,26 @@ fn sqlite_row_to_identity_occurrence(
         hardware_attestation: row.get("hardware_attestation")?,
         asserted_at: parse_rfc3339(&asserted_at),
         valid_until: valid_until.as_deref().map(parse_rfc3339),
+        encryption_pubkeys: encryption_pubkeys_from_cols(enc_x25519, enc_ml_kem),
         persist_row_hash: row.get("persist_row_hash")?,
     })
+}
+
+/// v4.13.0 (#192) — reassemble the optional [`EncryptionPubkeys`] from its
+/// two nullable columns: present only when **both** halves are stored.
+fn encryption_pubkeys_from_cols(
+    x25519: Option<String>,
+    ml_kem: Option<String>,
+) -> Option<crate::federation::EncryptionPubkeys> {
+    match (x25519, ml_kem) {
+        (Some(x25519_base64), Some(ml_kem_768_base64)) => {
+            Some(crate::federation::EncryptionPubkeys {
+                x25519_base64,
+                ml_kem_768_base64,
+            })
+        }
+        _ => None,
+    }
 }
 
 /// v3.12.0 (CIRISPersist#153 Ask 2) — SQLite row →
@@ -11446,6 +11479,7 @@ mod tests {
             hardware_attestation: None,
             asserted_at: "2026-06-04T00:00:00Z".parse().unwrap(),
             valid_until: None,
+            encryption_pubkeys: None,
             persist_row_hash: String::new(),
         }
     }
@@ -11793,6 +11827,103 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    /// v4.13.0 (#192, CEG 0.18) — occurrence content-encryption pubkeys
+    /// round-trip + `resolve_encryption_keys` + admission length-gate.
+    #[tokio::test]
+    async fn occurrence_encryption_pubkeys_round_trip_and_resolve() {
+        use crate::federation::{EncryptionPubkeys, FederationDirectory};
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        for k in ["root", "occ-enc", "occ-bare"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key(k, k, k),
+                })
+                .await
+                .unwrap();
+        }
+        let x25519 = B64.encode([7u8; 32]); // valid 32-byte x25519
+        let ml_kem = B64.encode([9u8; 1184]); // valid 1184-byte ML-KEM-768
+        let occ =
+            |k: &str, enc: Option<EncryptionPubkeys>| crate::federation::SignedIdentityOccurrence {
+                identity_occurrence: crate::federation::IdentityOccurrence {
+                    identity_key_id: "root".into(),
+                    occurrence_key_id: k.into(),
+                    device_class: crate::federation::types::device_class::AGENT.into(),
+                    hardware_attestation: None,
+                    asserted_at: "2026-06-10T00:00:00Z".parse().unwrap(),
+                    valid_until: None,
+                    encryption_pubkeys: enc,
+                    persist_row_hash: String::new(),
+                },
+            };
+
+        // Occurrence WITH encryption keys → round-trips + resolves.
+        backend
+            .put_identity_occurrence(occ(
+                "occ-enc",
+                Some(EncryptionPubkeys {
+                    x25519_base64: x25519.clone(),
+                    ml_kem_768_base64: ml_kem.clone(),
+                }),
+            ))
+            .await
+            .unwrap();
+        let got = backend
+            .lookup_identity_for_occurrence("occ-enc")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            got.encryption_pubkeys,
+            Some(EncryptionPubkeys {
+                x25519_base64: x25519.clone(),
+                ml_kem_768_base64: ml_kem.clone()
+            })
+        );
+        let resolved = backend
+            .resolve_encryption_keys("occ-enc")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.x25519_base64, x25519);
+        assert_eq!(resolved.ml_kem_768_base64, ml_kem);
+
+        // Occurrence WITHOUT keys → resolve = None (fail-secure exclusion).
+        backend
+            .put_identity_occurrence(occ("occ-bare", None))
+            .await
+            .unwrap();
+        assert!(backend
+            .resolve_encryption_keys("occ-bare")
+            .await
+            .unwrap()
+            .is_none());
+        // Unknown occurrence → None.
+        assert!(backend
+            .resolve_encryption_keys("nope")
+            .await
+            .unwrap()
+            .is_none());
+
+        // Admission rejects a wrong-length key.
+        let err = backend
+            .put_identity_occurrence(occ(
+                "occ-enc",
+                Some(EncryptionPubkeys {
+                    x25519_base64: B64.encode([0u8; 16]), // too short
+                    ml_kem_768_base64: ml_kem,
+                }),
+            ))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("x25519_base64")),
+            "got: {err:?}"
         );
     }
 


### PR DESCRIPTION
The persist half of **#192** — the recipient-encryption-key dependency that building #152 surfaced. Substrate-wraps (CEG §10.1.4-mandated) needs each recipient's **x25519 + ML-KEM-768 encryption** keys; `federation_keys` has only **signing** keys (ed25519 + ML-DSA-65), ML-KEM can't be derived from a signing key, and C3b is *producer*-wraps. **CEG 0.18 (CIRISRegistry#69)** ruled the encryption keys ride the existing `identity_occurrence` subject_kind (self-certified, hybrid-signed, supersedes-rotatable, already cross-region replicated — zero new subject_kind / replication kind).

## Added
- **V069** (PG + SQLite) — nullable `pubkey_x25519_base64` + `pubkey_ml_kem_768_base64` on `federation_identity_occurrences`.
- **`EncryptionPubkeys`** + `IdentityOccurrence.encryption_pubkeys: Option<…>` — the `wrap_algorithm: v2` recipient inputs (a fresh content-KEM pair, distinct from signing keys and the Reticulum transport x25519). Both halves present together or neither.
- **`resolve_encryption_keys(occurrence_key_id)`** — the cascade's per-recipient lookup; the within-validity occurrence's keys, or `None` ⇒ **fail-secure excluded** from v2 grants (§10.1.4 — never plaintext fallback). Default trait method, all three backends.
- **`check_encryption_pubkeys`** admission — each half must base64-decode to its exact raw length (x25519 = 32 B, ML-KEM-768 = 1184 B).

## Unblocks / still gated
Unblocks the #152 default-tier wrap for recipients **with** registered keys; #161 Asks 4–5 + #183's Self-DEK inherit it. **Still gated:** producers (agent) actually registering encryption keys (parallel work), and the `ENCRYPTED_AT_REST` content-encryption foundation (unbuilt).

## Tests
SQLite + live-PG: encryption-pubkeys round-trip, `resolve_encryption_keys` (present → keys; absent/unknown → `None`), admission length-gate rejection. **1078 lib green on SQLite, 772 on live PG**; `-D warnings` + clippy + cargo-deny clean.

Advances #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)