### PR TITLE
v6.0.0 — pyo3 0.29 lockstep cut (ceiling-firewall) — #201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [6.0.0] — 2026-06-12
+
+### Changed (BREAKING — dependency ABI) — pyo3 0.28 → 0.29 lockstep; chain-head of the CIRIS wheel family (CIRISPersist#201)
+
+persist is the head of the pyo3-version lockstep chain (**persist → edge → lens-core**). Two pyo3 minors cannot coexist in one Python process — the per-cdylib FFI tables / interpreter state are not ABI-compatible across minors — so a process that loads a pyo3-0.29 persist `.so` alongside a pyo3-0.28 edge `.so` crashes. This is a **cohabitation break**, which is why it lands as a **major** version, not a minor.
+
+**The `<6` ceiling is the firewall.** ciris-edge ≤ 2.1.2 pins `ciris-persist<6,>=5.2.0`. Cutting this as **6.0.0** means an existing edge install's own constraint *excludes* it — `pip install -U ciris-persist` in an edge-2.1.2 env cannot pull the 0.29 wheel, so the break can't happen by accident. There is **no publish-ordering dependency**: persist leads, edge 2.2.0 opts in deliberately with `ciris-persist>=6,<7` + its own pyo3 0.29, lens-core follows. (A 5.6.0 cut would have slipped *under* edge's `<6` and broken naive upgrades — the major bump is load-bearing, not cosmetic.)
+
+**Code (mechanical, FFI surface only — no behavior change):**
+- `src/ffi/pyo3.rs` — the 7 capsule exporters move `PyCapsule::new` (deprecated in 0.29) → `new_with_value`. The name argument type changed `Option<CString>` → `&'static CStr`, so each runtime `CString::new("ciris_persist::…")` is replaced by a compile-time `c"ciris_persist::…"` literal.
+- `src/ffi/executor_capsule.rs` — `new_with_destructor` → `new_with_value_and_destructor`, same `&'static CStr` name fix; the single-fire GC destructor (Box reclaim → vtable drop) is unchanged.
+
+**MSRV 1.75 → 1.83.** pyo3 0.29 sets `rust-version = "1.83"`; `Cargo.toml` + `clippy.toml` (whose MSRV is pinned *to* `Cargo.toml`'s, deliberately) move together. As that pin's own comment predicts, raising the lint floor surfaced 12 `clippy::unnecessary_map_or` findings (`Option::is_none_or` stabilized in 1.82) — applied via `clippy --fix` across `store/memory.rs`, `federation/location.rs`, `federation/mod.rs`. All are `map_or(true, f)` → `is_none_or(f)`, semantically identical.
+
+### Security — RUSTSEC-2026-0176 + RUSTSEC-2026-0177 genuinely cleared (no longer ignored)
+Both advisories are pyo3 `< 0.29.0` and are **fixed** in 0.29.0, so the two `deny.toml` ignores added in v5.5.2 (the `nth`/`nth_back` OOB read and the `new_closure` `Sync` bound — both verified unreachable in persist, but ignored to unblock the gate) are **removed**. cargo-deny now passes on `advisories ok` without them — the vulnerable code is gone from the tree, not merely walled off.
+
+### Tests
+Full local gate green under pyo3 0.29: build (pyo3,server) · `cargo fmt --check` · clippy `-D warnings` ×3 feature sets (pyo3+server, sqlite-only, postgres+server+pyo3) · backend-less `RUSTFLAGS=-D warnings cargo test --features server --no-run` · `cargo check --no-default-features` · `cargo deny` (advisories ok, ignores dropped) · sqlite lib suite (786) · live-PG lib suite (727) · maturin wheel build + `import ciris_persist` + pytest FFI (9) + capsule runtime smoke (6/8 exporters return a live `PyCapsule`; `local_signer`/`trust_scoring` hit their pre-capsule domain guards on a bare in-memory engine, as designed).
+
 ## [5.5.3] — 2026-06-12
 
 ### Changed — Postgres: bounded retry on connection acquisition (resilience)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "5.5.3"
+version = "6.0.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
 repository = "https://github.com/CIRISAI/CIRISPersist"
 authors = ["CIRIS AI <hello@ciris.ai>"]
-rust-version = "1.75"
+rust-version = "1.83"
 publish = false
 
 # Status: Phase 1 in flight (TDD + MDD; see MISSION.md).
@@ -592,7 +592,7 @@ url     = { version = "2.5", optional = true }
 # it is a separate top-level crate feature (`extension-module`) that
 # maturin turns on for the wheel build. See the `[features]` section.
 # This keeps `cargo test --features pyo3` linking libpython normally.
-pyo3 = { version = "0.28", features = ["abi3-py310"], optional = true }
+pyo3 = { version = "0.29", features = ["abi3-py310"], optional = true }
 
 # v0.6.0 (CIRISPersist#19) — post-ingest filter pipeline deps.
 # Light deps (regex) gate `scrub` + `extract`; heavy ML deps below

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,7 +10,7 @@
 # Pinning to our declared MSRV (`Cargo.toml`'s `rust-version`)
 # means clippy applies the lint set as it was at that toolchain,
 # even when the runner is newer.
-msrv = "1.75"
+msrv = "1.83"
 
 # We don't override `cognitive-complexity-threshold` etc. — clippy
 # defaults are reasonable for this crate's size. If a future

--- a/deny.toml
+++ b/deny.toml
@@ -77,17 +77,6 @@ ignore = [
     # unmaintained ignores above. Re-evaluate when candle/ort upgrade.
     "RUSTSEC-2025-0119",  # number_prefix unmaintained — transitive via indicatif → hf-hub
     "RUSTSEC-2024-0436",  # paste unmaintained — transitive via candle / ort macros
-
-    # v5.5.2 — two pyo3 0.28.x advisories, both fixed in pyo3 0.29.0, both
-    # newly published (began failing the cargo-deny gate). Both vulnerable
-    # paths are UNREACHABLE in persist (verified by grep): persist's FFI
-    # never uses `new_closure`/`PyCFunction::new`, and it only *builds*
-    # PyLists (`PyList::empty` + append) — it never `.nth()`/`.nth_back()`/
-    # `.skip()`-iterates an incoming Python list/tuple. Lifting these
-    # requires the pyo3 0.28→0.29 breaking-API migration, tracked
-    # separately; ignored here because neither is exploitable in persist.
-    "RUSTSEC-2026-0176",  # pyo3 nth/nth_back OOB read on PyList/PyTuple — adapter unused by persist
-    "RUSTSEC-2026-0177",  # pyo3 new_closure Sync bound — API unused by persist
 ]
 
 [sources]

--- a/src/federation/location.rs
+++ b/src/federation/location.rs
@@ -135,7 +135,7 @@ pub fn member_in_geographic_constraint(
 ) -> bool {
     member_proofs.iter().any(|p| {
         p.withdrawn_at.is_none()
-            && p.valid_until.map_or(true, |vu| vu > now)
+            && p.valid_until.is_none_or(|vu| vu > now)
             && h3_cell_contained(&p.cell_id, constraint_cell)
     })
 }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -449,7 +449,7 @@ pub trait FederationDirectory: Send + Sync {
         Ok(self
             .lookup_identity_for_occurrence(occurrence_key_id)
             .await?
-            .filter(|o| o.valid_until.map_or(true, |vu| vu > now))
+            .filter(|o| o.valid_until.is_none_or(|vu| vu > now))
             .and_then(|o| o.encryption_pubkeys))
     }
 

--- a/src/ffi/executor_capsule.rs
+++ b/src/ffi/executor_capsule.rs
@@ -305,27 +305,30 @@ pub fn build_capsule_with_destructor<'py>(
     let executor = build_persist_executor(runtime);
     let boxed_executor: Box<AsyncExecutor> = Box::new(executor);
     let raw: *mut AsyncExecutor = Box::into_raw(boxed_executor);
-    let name = std::ffi::CString::new("ciris_persist::executor_capsule_v1")
-        .expect("static name has no NUL bytes");
     // SAFETY: `raw` was just produced by `Box::into_raw`; we hand it
     // to PyCapsule, which calls the destructor exactly once at GC.
     // The destructor reconstructs the Box (recovering ownership)
     // before invoking vtable.drop on the inner data pointer.
     unsafe {
-        PyCapsule::new_with_destructor(py, raw as usize, Some(name), |raw_usize, _ctx| {
-            let raw_ptr = raw_usize as *mut AsyncExecutor;
-            if raw_ptr.is_null() {
-                return;
-            }
-            // SAFETY: raw_ptr is the pointer we Box::into_raw'd. It
-            // has not been observed by anyone else (the only path
-            // into this destructor is PyCapsule's single-fire GC).
-            let executor: Box<AsyncExecutor> = Box::from_raw(raw_ptr);
-            // Dispatch through the vtable's drop function (lives
-            // inside persist's .so; decrements the Arc<Runtime>).
-            (executor.vtable.drop)(executor.data);
-            // Box deallocates the AsyncExecutor envelope here.
-        })
+        PyCapsule::new_with_value_and_destructor(
+            py,
+            raw as usize,
+            c"ciris_persist::executor_capsule_v1",
+            |raw_usize, _ctx| {
+                let raw_ptr = raw_usize as *mut AsyncExecutor;
+                if raw_ptr.is_null() {
+                    return;
+                }
+                // SAFETY: raw_ptr is the pointer we Box::into_raw'd. It
+                // has not been observed by anyone else (the only path
+                // into this destructor is PyCapsule's single-fire GC).
+                let executor: Box<AsyncExecutor> = Box::from_raw(raw_ptr);
+                // Dispatch through the vtable's drop function (lives
+                // inside persist's .so; decrements the Arc<Runtime>).
+                (executor.vtable.drop)(executor.data);
+                // Box deallocates the AsyncExecutor envelope here.
+            },
+        )
     }
 }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -17826,11 +17826,10 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => b.clone(),
         };
-        let name = std::ffi::CString::new("ciris_persist::federation_directory")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, arc, Some(name)).map_err(|e| {
-            PyErr::new::<LensQueryError, _>(format!("federation_directory_capsule: {e}"))
-        })
+        pyo3::types::PyCapsule::new_with_value(py, arc, c"ciris_persist::federation_directory")
+            .map_err(|e| {
+                PyErr::new::<LensQueryError, _>(format!("federation_directory_capsule: {e}"))
+            })
     }
 
     /// v2.7.0 (CIRISPersist#109) — cross-module accessor for the
@@ -17856,9 +17855,7 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
         };
-        let name = std::ffi::CString::new("ciris_persist::outbound_queue")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, dispatch, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, dispatch, c"ciris_persist::outbound_queue")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_capsule: {e}")))
     }
 
@@ -17881,9 +17878,7 @@ impl PyEngine {
             pqc_signer: self.local_signer.as_ref().and_then(|ls| ls.pqc_signer()),
             key_id: self.signer_key_id.clone(),
         };
-        let name = std::ffi::CString::new("ciris_persist::keyring_signer")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, handle, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, handle, c"ciris_persist::keyring_signer")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("keyring_signer_capsule: {e}")))
     }
 
@@ -17950,9 +17945,7 @@ impl PyEngine {
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
         let handle: tokio::runtime::Handle = self.runtime.handle().clone();
-        let name = std::ffi::CString::new("ciris_persist::runtime_handle")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, handle, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, handle, c"ciris_persist::runtime_handle")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("runtime_handle_capsule: {e}")))
     }
 
@@ -18077,9 +18070,7 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
         };
-        let name = std::ffi::CString::new("ciris_persist::blob_storage")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, dispatch, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, dispatch, c"ciris_persist::blob_storage")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("blob_storage_capsule: {e}")))
     }
 
@@ -18109,9 +18100,7 @@ impl PyEngine {
         let Some(local_signer) = self.local_signer.clone() else {
             return Err(PyValueError::new_err("local_signer_unavailable"));
         };
-        let name = std::ffi::CString::new("ciris_persist::local_signer")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, local_signer, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, local_signer, c"ciris_persist::local_signer")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("local_signer_capsule: {e}")))
     }
 
@@ -18145,9 +18134,7 @@ impl PyEngine {
         let scoring = gate
             .map(|g| g.scoring_arc())
             .ok_or_else(|| PyValueError::new_err("trust_scoring_unavailable"))?;
-        let name = std::ffi::CString::new("ciris_persist::trust_scoring")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, scoring, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, scoring, c"ciris_persist::trust_scoring")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("trust_scoring_capsule: {e}")))
     }
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -569,7 +569,7 @@ impl Backend for MemoryBackend {
             .events
             .values()
             .filter(|(eid, row)| {
-                *eid > after_event_id && agent_id_hash.map_or(true, |h| row.agent_id_hash == h)
+                *eid > after_event_id && agent_id_hash.is_none_or(|h| row.agent_id_hash == h)
             })
             .map(|(eid, row)| (*eid, row.clone()))
             .collect();
@@ -1317,7 +1317,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_organizations
             .values()
-            .filter(|o| since.map_or(true, |s| o.asserted_at > s))
+            .filter(|o| since.is_none_or(|s| o.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1338,7 +1338,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_org_memberships
             .values()
-            .filter(|m| since.map_or(true, |s| m.asserted_at > s))
+            .filter(|m| since.is_none_or(|s| m.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1359,7 +1359,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_partner_records
             .values()
-            .filter(|p| since.map_or(true, |s| p.asserted_at > s))
+            .filter(|p| since.is_none_or(|s| p.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1380,7 +1380,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_partner_records
             .values()
-            .filter(|p| since.map_or(true, |s| p.asserted_at > s))
+            .filter(|p| since.is_none_or(|s| p.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -2604,20 +2604,20 @@ impl crate::outbound::OutboundQueue for MemoryBackend {
             .outbound_queue
             .values()
             .filter(|r| {
-                filter.status.map_or(true, |s| r.status == s)
+                filter.status.is_none_or(|s| r.status == s)
                     && filter
                         .destination_key_id
                         .as_ref()
-                        .map_or(true, |d| r.destination_key_id == *d)
+                        .is_none_or(|d| r.destination_key_id == *d)
                     && filter
                         .sender_key_id
                         .as_ref()
-                        .map_or(true, |s| r.sender_key_id == *s)
+                        .is_none_or(|s| r.sender_key_id == *s)
                     && filter
                         .message_type
                         .as_ref()
-                        .map_or(true, |m| r.message_type == *m)
-                    && filter.enqueued_after.map_or(true, |t| r.enqueued_at >= t)
+                        .is_none_or(|m| r.message_type == *m)
+                    && filter.enqueued_after.is_none_or(|t| r.enqueued_at >= t)
             })
             .cloned()
             .collect();


### PR DESCRIPTION
Closes #201 (on the coordinated publish, not on merge — see **Hold** below).

## What
Persist is the head of the pyo3 0.29 lockstep chain (**persist → edge → lens-core**). Two pyo3 minors cannot coexist in one Python process (per-cdylib FFI tables / interpreter state are not ABI-compatible across minors), so the whole CIRIS wheel family moves together. This PR does the persist half.

### Code (mechanical, FFI surface only)
- **`src/ffi/pyo3.rs`** — 7 capsule exporters: `PyCapsule::new` (deprecated in 0.29) → `new_with_value`. The name arg type changed `Option<CString>` → `&'static CStr`, so each `let name = CString::new(..)` becomes a `c"ciris_persist::…"` literal (all names are compile-time constants).
- **`src/ffi/executor_capsule.rs`** — `new_with_destructor` → `new_with_value_and_destructor`, same `&'static CStr` name fix.

### MSRV
pyo3 0.29 sets `rust-version = "1.83"`; bump `Cargo.toml` + `clippy.toml` 1.75 → 1.83 to match. As `clippy.toml`'s pinned-MSRV comment predicts, raising the lint floor surfaced 12 `unnecessary_map_or` findings (`is_none_or` stabilized 1.82) — applied via `clippy --fix` in `store/memory.rs`, `federation/location.rs`, `federation/mod.rs`. All are `map_or(true, f)` → `is_none_or(f)`, semantically identical.

### cargo-deny
Drops the two v5.5.2 advisory ignores (`RUSTSEC-2026-0176` nth/nth_back OOB, `RUSTSEC-2026-0177` new_closure Sync) — both fixed in pyo3 0.29.0, gate is clean without them.

## Verified green locally
build (pyo3,server) · fmt · clippy ×3 (pyo3+server, sqlite-only, postgres+server+pyo3) `-D warnings` · backend-less `RUSTFLAGS=-D warnings test --no-run` · `cargo check --no-default-features` · `cargo deny` (advisories ok) · sqlite suite (786 passed) · live-PG suite (727 passed) · maturin wheel build + import + pytest FFI (9 passed) + capsule runtime smoke (6/8 exporters return a live `PyCapsule`; `local_signer`/`trust_scoring` hit their pre-capsule domain guards on a bare engine, as expected).

## 🛑 Hold — do not merge/tag/publish unilaterally
Publishing a 0.29 persist wheel while edge is still 0.28 breaks cohabitation: one process loading persist-0.29 + edge-0.28 = two pyo3 minors = crash. **Edge 2.1.1 pins `ciris-persist<6,>=5.2.0`, which *allows* a 0.29 persist** — so `pip install -U ciris-persist` in an edge-2.1.1 env would pull the break.

### Recommended publish boundary: cut the 0.29 persist as **6.0.0**
Edge 2.1.1's existing `<6` ceiling then becomes the firewall *for free*: a 6.0.0 persist is **excluded** by edge-2.1.1's pin, so `pip install -U` can't pull it into an old-edge env. Edge 2.2.0 opts in deliberately with `ciris-persist>=6,<7` + its own pyo3 0.29. The major bump is the correct semver signal for an ABI/cohabitation break and makes the coordination automatic rather than ordering-dependent.

(If instead cut as 5.6.0, edge-2.1.1's `<6` *allows* it → unsafe → requires edge 2.2.0 published first AND users upgrading edge before persist. Fragile. Prefer 6.0.0.)

**Handoff for edge (owned elsewhere):** edge 2.2.0 should move to pyo3 0.29 and floor-pin `ciris-persist>=6.0.0,<7`. Coordinated publish = persist 6.0.0 + edge 2.2.0 together; lens-core follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)