### PR TITLE
ci(auto-retry): catch crates.io registry-fetch flakes

### DIFF
--- a/.github/workflows/auto-retry.yml
+++ b/.github/workflows/auto-retry.yml
@@ -76,7 +76,17 @@ jobs:
           # ── Signal 2: transient signatures in the failed-step logs (mid-run
           # network/registry blips that DO produce logs). ──
           logs=$(gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null || true)
-          transient='Docker pull failed|Initialize containers|toomanyrequests|429 Too Many Requests|TLS handshake timeout|i/o timeout|[Cc]onnection reset|503 Service|502 Bad Gateway|504 Gateway|[Ss]ervice [Uu]navailable|unexpected EOF|net/http: (request canceled|TLS handshake)|failed to (pull|fetch|resolve)|temporary failure in name resolution'
+          # The registry-fetch cluster (HTTP2 framing / download failed /
+          # unable to update registry / curl failed / spurious network
+          # error) covers crates.io sparse-index blips that fail a fresh
+          # `cargo metadata` mid-job — hit 3× during the v6.0.0 cut on
+          # three different jobs (cirisgraph, the aarch64 wheel, the
+          # CanonicalBuild signer). All are unambiguous network signatures;
+          # none appears on a genuine compile/test failure. (The rarer
+          # "no matching package named … found" incomplete-index variant
+          # is deliberately NOT matched — it is indistinguishable from a
+          # genuine typo'd dependency, so it stays red for a human.)
+          transient='Docker pull failed|Initialize containers|toomanyrequests|429 Too Many Requests|TLS handshake timeout|i/o timeout|[Cc]onnection reset|503 Service|502 Bad Gateway|504 Gateway|[Ss]ervice [Uu]navailable|unexpected EOF|net/http: (request canceled|TLS handshake)|failed to (pull|fetch|resolve)|temporary failure in name resolution|HTTP2 framing layer|download of .* failed|unable to update registry|curl failed|spurious network error'
           # Genuine failures we must NEVER auto-rerun (would mask a real red).
           genuine='error\[E[0-9]|error: could not compile|test result: FAILED|panicked at|assertion .*failed|thread .* panicked|cargo (test|clippy|fmt).*error'
 


### PR DESCRIPTION
The v6.0.0 release run hit the same transient crates.io sparse-index fetch failure **3×** on three different jobs (cirisgraph `cargo metadata`, the linux-aarch64 wheel, the CanonicalBuild signer). Each surfaced as `curl failed` / `[16] Error in the HTTP2 framing layer` / `download of <crate> failed` during a fresh `cargo metadata`, and **none** matched the existing `transient` regex — so auto-retry fell through to "leave for a human" and I re-ran each by hand.

Adds five unambiguous network signatures to the transient match:
- `HTTP2 framing layer`
- `download of .* failed`
- `unable to update registry`
- `curl failed`
- `spurious network error`

None of these appears on a genuine compile/test failure, so the design contract ("NEVER auto-rerun a real red") and the `run_attempt == 1` one-shot cap are both preserved.

**Deliberately not matched:** `no matching package named … found` (the incomplete-index variant — what the *first* cirisgraph flake emitted). It's indistinguishable from a genuine typo'd dependency, so it stays red for a human. (Decision made with @mooreericnyc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)