### PR TITLE
#203 deferral_routed enum + #205 Win7 Windows wheel lane (v5.5.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,6 +676,18 @@ jobs:
           - { os: ubuntu-latest,    label: linux-x86_64,   tag: manylinux_2_34_x86_64 }
           - { os: ubuntu-24.04-arm, label: linux-aarch64,  tag: manylinux_2_34_aarch64 }
           - { os: macos-14,         label: darwin-aarch64, tag: macosx_11_0_arm64 }
+          # v5.5.4 (CIRISPersist#205) — windows-x86_64 wheel, Win7-capable
+          # FROM DAY ONE. persist shipped no Windows wheel before this; #205
+          # asks us to bake Win7 in rather than retrofit. Built with the
+          # Tier-3 `x86_64-win7-windows-msvc` target (nightly + `-Zbuild-std`)
+          # so std keeps the Win7 fallback paths (keyed events,
+          # GetSystemTimeAsFileTime, RtlGenRandom) instead of stable ≥1.78's
+          # hard-imported Win8/Win10 APIs (WaitOnAddress /
+          # GetSystemTimePreciseAsFileTime / ProcessPrng). The artifact runs
+          # unchanged on Win10/11. openssl-sys is satisfied by vcpkg static
+          # x64-windows-static (the `pyo3`→`postgres`→`dep:openssl` chain),
+          # mirroring the proven CIRISEdge#90 setup.
+          - { os: windows-latest,   label: windows-x86_64, tag: win_amd64 }
           # darwin-x86_64 (macos-13) intentionally omitted — GitHub
           # Actions Intel macOS runners have ongoing capacity issues
           # (jobs queue indefinitely). CIRISAgent's matrix dropped it
@@ -705,7 +717,41 @@ jobs:
       - name: install libtss2-dev + libsqlite3-dev (TPM + SQLite build deps)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      # v5.5.4 (CIRISPersist#205) — Windows openssl-sys link. The `pyo3`
+      # feature force-includes `postgres` → `dep:openssl` → openssl-sys;
+      # Linux/macOS have a system OpenSSL, Windows does not. vcpkg's
+      # static x64-windows-static triplet matches openssl-sys's expected
+      # `installed/x64-windows-static/{lib,include}` layout exactly and
+      # links statically, so the wheel has zero runtime OpenSSL dep. This
+      # is the proven CIRISEdge#90 approach (Strawberry-Perl/openssl-src
+      # and Chocolatey both failed there — perl @INC clash / wrong lib
+      # layout respectively).
+      - name: install OpenSSL via vcpkg (static, x64-windows-static)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$VCPKG_INSTALLATION_ROOT/vcpkg" install openssl:x64-windows-static --x-install-root="$VCPKG_INSTALLATION_ROOT/installed"
+          ROOT="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static"
+          win_root=$(cygpath -w "$ROOT")
+          {
+            echo "OPENSSL_DIR=${win_root}"
+            echo "OPENSSL_LIB_DIR=${win_root}\\lib"
+            echo "OPENSSL_INCLUDE_DIR=${win_root}\\include"
+            echo "OPENSSL_STATIC=1"
+            echo "OPENSSL_NO_VENDOR=1"
+          } >> "$GITHUB_ENV"
+          echo "::notice::OPENSSL_DIR=${win_root} (vcpkg static x64-windows-static)"
+          ls -la "${ROOT}/lib/libssl.lib" "${ROOT}/lib/libcrypto.lib"
+      # Non-Windows: stable. Windows: nightly + rust-src, because the
+      # Tier-3 `x86_64-win7-windows-msvc` target ships no precompiled std,
+      # so the wheel must `-Zbuild-std` it from source (CIRISPersist#205).
       - uses: dtolnay/rust-toolchain@stable
+        if: runner.os != 'Windows'
+      - uses: dtolnay/rust-toolchain@nightly
+        if: runner.os == 'Windows'
+        with:
+          components: rust-src
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -733,8 +779,30 @@ jobs:
       #
       # On macOS, `--auditwheel skip` is a no-op (auditwheel doesn't
       # run there).
-      - name: maturin build
+      - name: maturin build (Linux/macOS)
+        if: runner.os != 'Windows'
         run: maturin build --release --strip --auditwheel skip
+      # v5.5.4 (CIRISPersist#205) — Windows Win7-capable build. nightly +
+      # `-Zbuild-std` (via CARGO_UNSTABLE_BUILD_STD) compiles std from
+      # source for the Tier-3 `x86_64-win7-windows-msvc` target, retaining
+      # the Win7 fallback paths. RUSTUP_TOOLCHAIN=nightly makes the cargo
+      # maturin invokes use nightly; CARGO_BUILD_TARGET routes the build to
+      # the win7 triple (maturin tags it win_amd64 — x86_64 + windows). The
+      # `confirm wheel shape` gate below asserts the cp310-abi3 tag landed.
+      - name: maturin build (Windows — Tier-3 Win7 via build-std)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+          CARGO_BUILD_TARGET: x86_64-win7-windows-msvc
+          CARGO_UNSTABLE_BUILD_STD: std,panic_abort
+        run: |
+          set -euo pipefail
+          if ! rustc --print target-list | grep -qx 'x86_64-win7-windows-msvc'; then
+            echo "::error::x86_64-win7-windows-msvc not in nightly target-list — target may have been renamed; check rustc release notes"
+            exit 1
+          fi
+          maturin build --release --strip --auditwheel skip
       # v3.6.2 (CIRISPersist#136) — explicit auditwheel-repair with
       # libsqlite3 excluded from the bundling pass. This is the same
       # pattern `pyarrow` uses (excludes libssl/libcrypto/libz) and
@@ -896,6 +964,9 @@ jobs:
         # showed mixed-mode maturin can silently emit cp31N-cp31N
         # wheels which break consumer install on other minors. Catching
         # at build time, before the wheel reaches PyPI.
+        # shell: bash so the glob/test syntax runs on Windows too (the
+        # runner default is pwsh).
+        shell: bash
         run: |
           ls -la target/wheels/
           if ! ls target/wheels/*-cp310-abi3-*.whl >/dev/null 2>&1; then
@@ -1249,6 +1320,10 @@ jobs:
             ["ciris_persist-wheel-linux-x86_64"]="x86_64-unknown-linux-gnu"
             ["ciris_persist-wheel-linux-aarch64"]="aarch64-unknown-linux-gnu"
             ["ciris_persist-wheel-darwin-aarch64"]="aarch64-apple-darwin"
+            # v5.5.4 (CIRISPersist#205) — Win7-capable wheel signs under the
+            # consumer-facing windows triple (the win7 build triple is an
+            # implementation detail; consumers match x86_64-pc-windows-msvc).
+            ["ciris_persist-wheel-windows-x86_64"]="x86_64-pc-windows-msvc"
           )
           SIGNED_BINARY_TARGETS=()
           for ARTDIR in "${!WHEEL_TARGET[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,6 +802,24 @@ jobs:
             echo "::error::x86_64-win7-windows-msvc not in nightly target-list — target may have been renamed; check rustc release notes"
             exit 1
           fi
+          # LNK1181 workaround: under -Zbuild-std the linker doesn't
+          # auto-discover the per-version import library that a transitive
+          # `windows-targets` pulls (e.g. `windows.0.48.5.lib`, shipped
+          # inside the `windows_x86_64_msvc-0.48.5` crate). Pre-fetch so
+          # those crates are extracted, then put every
+          # `windows_x86_64_msvc-*/lib` dir on LIB (which link.exe
+          # searches) — covers whatever versions the graph resolves.
+          cargo fetch
+          extra=""
+          while IFS= read -r d; do
+            extra="${extra};$(cygpath -w "$d")"
+          done < <(find "$HOME/.cargo/registry/src" -type d -path '*windows_x86_64_msvc-*/lib' 2>/dev/null | sort -u)
+          if [ -n "$extra" ]; then
+            export LIB="${LIB:-}${extra}"
+            echo "::notice::LIB augmented with windows_x86_64_msvc import-lib dirs:${extra}"
+          else
+            echo "::warning::no windows_x86_64_msvc import-lib dirs found under cargo registry"
+          fi
           maturin build --release --strip --auditwheel skip
       # v3.6.2 (CIRISPersist#136) — explicit auditwheel-repair with
       # libsqlite3 excluded from the bundling pass. This is the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [5.5.4] — 2026-06-12
+
+### Fixed — trace seal no longer fails on lens-core deferral components (CIRISPersist#203)
+
+`engine.receive_and_persist` rejected any sealed trace carrying a Wisdom-Based Deferral component: agent 2.9.6 retired the bespoke WBD HTTP POST (CIRISAgent#857/#866), so deferrals now ride `LensClient.capture_event` as `DEFERRAL_ROUTED` and lens-core 1.0.1 stamps the component `deferral_routed` — a value absent from persist's `ComponentType` enum. The unknown variant failed serde deserialization → `schema_malformed_json` → the **entire** trace of every `$defer` was lost (not just the deferral component), deterministically, on both backends.
+
+- **`ComponentType::DeferralRouted`** added (serde `deferral_routed`).
+- **`ComponentType::Unknown` gains `#[serde(other)]`** — the root-cause fix. `ReasoningEventType::Unknown` got this after CIRISLens#13 (a 28-43% reject-rate incident from a closed enum rejecting an unknown variant); `ComponentType` never did, so it hard-failed the seal instead of degrading. Now the remaining 4 Commons Credits capture variants — and any future one — ingest as `Unknown` rather than 422'ing the whole trace. AV-15 safe (no payload echo; serializes back as `"unknown"`).
+- Regression tests (both backends via the lib suite): `deferral_routed` round-trips to `DeferralRouted`; out-of-set component values absorb to `Unknown` instead of failing.
+
+### Added — Windows wheel lane, Win7-capable from day one (CIRISPersist#205)
+
+persist published no Windows wheel before this. Rather than ship a stable-toolchain `win_amd64` wheel that silently fails to load on Windows 7 (stable Rust ≥1.78's prebuilt std hard-imports `WaitOnAddress` / `GetSystemTimePreciseAsFileTime` / `ProcessPrng`), the lane builds the Tier-3 **`x86_64-win7-windows-msvc`** target with nightly + `-Zbuild-std`, so std keeps the Win7 fallback paths (keyed events, `GetSystemTimeAsFileTime`, `RtlGenRandom`). The artifact runs unchanged on Win10/11; CIRISAgent's incoming Win7 SP1 tier pins to this floor.
+
+- New `pyo3-wheel` matrix entry `{ windows-latest, win_amd64 }`. openssl-sys (via the `pyo3`→`postgres`→`dep:openssl` chain) is satisfied by vcpkg static `x64-windows-static` — the proven CIRISEdge#90 approach, statically linked so the wheel has zero runtime OpenSSL dependency.
+- build-manifest signs the wheel under the consumer-facing `x86_64-pc-windows-msvc` triple; the `confirm wheel shape` gate (`shell: bash`) asserts the cp310-abi3 tag.
+- The Linux auditwheel / readelf and macOS Mach-O libsqlite3 gates remain OS-scoped and are skipped on Windows.
+
 ## [5.5.3] — 2026-06-12
 
 ### Changed — Postgres: bounded retry on connection acquisition (resilience)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "5.5.3"
+version = "5.5.4"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/schema/events.rs
+++ b/src/schema/events.rs
@@ -39,7 +39,31 @@ pub enum ComponentType {
     VerbSecondPass,
     /// Individual LLM call (sibling-table candidate).
     LlmCall,
+    /// v5.5.4 (CIRISPersist#203) — Wisdom-Based Deferral routed through
+    /// the LensCore capture fold. Agent 2.9.6 retired the bespoke WBD
+    /// HTTP POST (CIRISAgent#857/#866) — deferrals now ride
+    /// `LensClient.capture_event` as `DEFERRAL_ROUTED`, one of the 5
+    /// Commons Credits events in the closed capture taxonomy. lens-core
+    /// 1.0.1 stamps the component `deferral_routed`; before this variant
+    /// existed the whole trace seal failed `schema_malformed_json` on
+    /// every `$defer` (the deferring thought's entire trace was lost,
+    /// not just the deferral component).
+    DeferralRouted,
     /// Forward-compat fallback for unrecognized component types.
+    ///
+    /// v5.5.4 (CIRISPersist#203) — gains `#[serde(other)]`, mirroring
+    /// `ReasoningEventType::Unknown` (this file, line ~116), which got
+    /// the same treatment after CIRISLens#13. Without it, ANY component
+    /// value outside the closed set above fails the *entire* trace seal
+    /// rather than degrading — so the remaining Commons Credits capture
+    /// variants (and any future one) now ingest as `Unknown` instead of
+    /// 422'ing the whole trace. Promote a variant out of `Unknown` (like
+    /// `DeferralRouted` above) when persist needs its discriminant value.
+    ///
+    /// AV-15 safe: `#[serde(other)]` carries no payload (no
+    /// attacker-controlled bytes echoed); serializes back as
+    /// `"unknown"` regardless of the rejected input.
+    #[serde(other)]
     Unknown,
 }
 
@@ -416,6 +440,36 @@ mod tests {
             serde_json::to_string(&ComponentType::LlmCall).unwrap(),
             r#""llm_call""#
         );
+        // CIRISPersist#203 — the WBD-deferral component from the
+        // LensCore capture fold; must round-trip exactly.
+        assert_eq!(
+            serde_json::to_string(&ComponentType::DeferralRouted).unwrap(),
+            r#""deferral_routed""#
+        );
+        assert_eq!(
+            serde_json::from_str::<ComponentType>(r#""deferral_routed""#).unwrap(),
+            ComponentType::DeferralRouted
+        );
+        assert_eq!(
+            serde_json::to_string(&ComponentType::Unknown).unwrap(),
+            r#""unknown""#
+        );
+    }
+
+    /// CIRISPersist#203 — regression: a component value outside the
+    /// closed set must degrade to `Unknown` (via `#[serde(other)]`),
+    /// never fail the whole trace seal. Before this, lens-core 1.0.1's
+    /// `deferral_routed` (and any future Commons Credits variant)
+    /// 422'd the deferring thought's entire trace `schema_malformed_json`.
+    /// Mirrors `reasoning_event_type_unknown_variant_absorbs_drift`.
+    #[test]
+    fn component_type_unknown_variant_absorbs_drift() {
+        for wire in [r#""some_future_component""#, r#""hot_garbage""#, r#""""#] {
+            let parsed: ComponentType = serde_json::from_str(wire)
+                .unwrap_or_else(|e| panic!("#203 — should absorb {wire}, not fail the seal: {e}"));
+            assert_eq!(parsed, ComponentType::Unknown);
+        }
+        // Catchall serializes back as "unknown" (AV-15: no echo of input).
         assert_eq!(
             serde_json::to_string(&ComponentType::Unknown).unwrap(),
             r#""unknown""#


### PR DESCRIPTION
Two issues, both on the 5.X / pyo3 0.28 line.

## #203 — trace seal fails on lens-core deferral components (bug, data loss)
Agent 2.9.6 folded WBD deferrals into the LensCore capture path (CIRISAgent#857/#866); lens-core 1.0.1 stamps the component `deferral_routed`, which wasn't in persist's `ComponentType` enum — so serde decode failed `schema_malformed_json` and the **entire** trace of every `$defer` was lost (both backends, deterministic).

- `ComponentType::DeferralRouted` added (serde `deferral_routed`)
- **`#[serde(other)]` on `ComponentType::Unknown`** — the root-cause fix. `ReasoningEventType::Unknown` got this after the CIRISLens#13 reject-rate incident; `ComponentType` never did, so it hard-failed the seal instead of degrading. The other 4 Commons Credits capture variants (and any future one) now ingest as `Unknown` rather than 422'ing the whole trace. AV-15 safe.
- regression tests: `deferral_routed` round-trips; out-of-set values degrade to `Unknown`.

## #205 — Windows wheel lane, Win7-capable from day one
persist published no Windows wheel. Rather than ship a stable-toolchain wheel that silently won't load on Win7 (stable ≥1.78 std hard-imports `WaitOnAddress`/`GetSystemTimePreciseAsFileTime`/`ProcessPrng`), the lane builds the Tier-3 **`x86_64-win7-windows-msvc`** target with nightly + `-Zbuild-std`, retaining the Win7 fallback paths. Runs unchanged on Win10/11; CIRISAgent's incoming Win7 tier pins to this floor.

- new `pyo3-wheel` matrix entry `{ windows-latest, win_amd64 }`; openssl-sys via vcpkg static `x64-windows-static` (proven CIRISEdge#90 setup, statically linked → zero runtime OpenSSL dep)
- build-manifest signs under `x86_64-pc-windows-msvc`; `confirm wheel shape` gate switched to `shell: bash` so it runs on Windows
- Linux auditwheel/readelf + macOS Mach-O libsqlite3 gates stay OS-scoped (skipped on Windows)

## Verified
fmt · clippy (sqlite-only + pyo3,server) `-D warnings` · sqlite lib (787) · live-PG lib (728). The **Windows wheel build can only be validated in CI** (no local Windows) — watching the `windows-x86_64` job here; the Tier-3 + build-std path may need an iteration or two.

Closes #203. Advances #205 (closes once the wheel publishes green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)