### PR TITLE
v5.5.5 — CIRISVerify 5.1.3 (Win7-capable) + rust-postgres security floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [5.5.5] — 2026-06-12
+
+### Changed — CIRISVerify 5.1.0 → 5.1.3 (Win7-capable verify; TPM-1.2→software degradation)
+
+All three verify crate pins flip together (the coherence invariant — `ciris-verify-core` / `ciris-crypto` / `ciris-keyring`, plus the `tpm`/`ios`/`android` target-table keyring entries — must share one tag or `ciris_crypto` splits into two graph versions and the types break). Verify 5.1.3 ships its own Win7-loadable wheel and TPM-1.2→software keyring degradation (CIRISVerify#67); persist's own Win7 wheel lane (#205, v5.5.4) now builds against a Win7-capable verify, so the whole stack lines up. Graph stays coherent: single `ciris-crypto`, all three resolved to the 5.1.3 rev. No persist API changes.
+
+### Security — rust-postgres advisory floors (RUSTSEC-2026-0178 / -0179 / -0180)
+
+Three newly-published advisories against persist's `postgres` stack, all malicious-**server** DoS: a short `DataRow` panic (-0178, `tokio-postgres`), unbounded SCRAM iteration CPU-exhaustion (-0179, `postgres-protocol`), and a malformed-`hstore` decode panic (-0180, `postgres-protocol`). Fixed upstream, so persist floors the direct deps — **`tokio-postgres` ≥ 0.7.18**, **`postgres-types` ≥ 0.2.14** (which pull `postgres-protocol` ≥ 0.6.12) — rather than ignoring them. Low relevance to persist's posture (the Postgres server is trusted infrastructure, not an attacker surface), but the fix is free and there's no reason to ship the vulnerable decoder paths. cargo-deny clean without any new ignores.
+
+### Tests
+Verified against 5.1.3 + the floors: build (postgres+server+pyo3) · clippy `-D warnings` (pyo3+server, sqlite-only) · cargo-deny (advisories ok) · sqlite lib (787) · live-PG lib (728).
+
 ## [5.5.4] — 2026-06-12
 
 ### Fixed — trace seal no longer fails on lens-core deferral components (CIRISPersist#203)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "5.5.4"
+version = "5.5.5"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -555,10 +555,18 @@ uuid          = { version = "1", features = ["serde", "v4", "v5"] }
 jsonschema    = { version = "0.46", default-features = false }
 
 # Phase 1 — postgres feature
-tokio-postgres    = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"], optional = true }
+# v5.5.5 — security floors. Three newly-published rust-postgres
+# advisories (all malicious-SERVER DoS: RUSTSEC-2026-0178 short DataRow
+# panic, -0179 unbounded SCRAM iterations, -0180 malformed hstore panic)
+# are fixed in tokio-postgres 0.7.18 / postgres-types 0.2.14 (which pull
+# postgres-protocol >= 0.6.12). Pin the floors so the fix is enforced,
+# not merely "latest-resolved". Low relevance to persist (the DB is
+# trusted infra), but free to patch — no reason to ship the vulnerable
+# decoder paths.
+tokio-postgres    = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"], optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
 bytes             = { version = "1", optional = true }
-postgres-types    = { version = "0.2", optional = true }
+postgres-types    = { version = "0.2.14", optional = true }
 refinery          = { version = "0.9", features = ["tokio-postgres"], optional = true }
 
 # v0.1.3 — TLS for tokio-postgres connection pool (THREAT_MODEL.md AV-18).
@@ -728,10 +736,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -742,7 +750,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
## CIRISVerify 5.1.0 → 5.1.3
All six pins flip together (coherence invariant — `verify-core`/`crypto`/`keyring` + the `tpm`/`ios`/`android` target-table keyring entries; one tag or `ciris_crypto` splits into two graph versions and the types break). 5.1.3 ships a **Win7-capable verify** + TPM-1.2→software keyring degradation (CIRISVerify#67). persist's own Win7 wheel lane (#205, v5.5.4) now builds against a Win7-capable verify — the whole stack lines up. Graph stays coherent: single `ciris-crypto`, all three on the 5.1.3 rev. No persist API change.

## Security — rust-postgres advisory floors
Three newly-published advisories against the `postgres` stack, all malicious-**server** DoS (the verify bump's re-resolve surfaced them; they'd hit main regardless):
- **RUSTSEC-2026-0178** — short `DataRow` panic (`tokio-postgres`)
- **RUSTSEC-2026-0179** — unbounded SCRAM iteration CPU-exhaustion (`postgres-protocol`)
- **RUSTSEC-2026-0180** — malformed `hstore` decode panic (`postgres-protocol`)

Floored the direct deps **`tokio-postgres` ≥ 0.7.18** + **`postgres-types` ≥ 0.2.14** (pull `postgres-protocol` ≥ 0.6.12) rather than ignoring — fix is upstream and free. Low relevance to persist (the DB is trusted infra), but no reason to ship the vulnerable decoder paths. cargo-deny clean, **no new ignores**.

## Verified
build (postgres+server+pyo3) · clippy `-D warnings` (pyo3+server, sqlite-only) · cargo-deny (advisories ok) · sqlite lib (787) · live-PG lib (728, fresh container). The Windows build-std wheel job validates the win7 lane against verify 5.1.3 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)