### PR TITLE
ci: cache wheel builds + parallelize iOS — cut cycle wall time ~2×

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,20 @@ jobs:
   # BeeWare's Python-Apple-support for the target libpython + _sysconfigdata
   # (PyO3 PR #5605 requires libpython linking on iOS).
   ios-build:
-    name: ios PyO3 abi3 (device + simulator)
+    name: ios PyO3 abi3 (${{ matrix.dir }})
     runs-on: macos-14
+    # ci-perf — split the two iOS targets into a 2-entry matrix so they
+    # build in PARALLEL (was one ~20m job building device then simulator
+    # sequentially — cargo's target-dir lock prevents in-job parallelism,
+    # so a matrix is the way). `ios-package` below recombines them into
+    # the single `ciris-persist-ios` tar that mobile-release consumes.
+    # Mirrors the android build-matrix → android-package shape.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: aarch64-apple-ios,     dir: ios-device,    lib_dir_out: device_lib_dir }
+          - { target: aarch64-apple-ios-sim, dir: ios-simulator, lib_dir_out: sim_lib_dir }
     env:
       PYTHON_IOS_VER: "3.10"
       PYTHON_IOS_BUILD: "b13"
@@ -236,9 +248,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
+          key: ios-${{ matrix.dir }}
           cache-bin: false
         continue-on-error: true
       - uses: actions/setup-python@v5
@@ -279,65 +292,72 @@ jobs:
 
           echo "✓ Python-Apple-support ${PYTHON_IOS_VER}-${PYTHON_IOS_BUILD} staged"
           ls -la "$DEVICE_DIR/" "$SIM_DIR/"
-      - name: cargo build (ios device — aarch64-apple-ios)
+      - name: cargo build (ios — ${{ matrix.target }})
         env:
           PYO3_CROSS: "1"
           PYO3_CROSS_PYTHON_VERSION: "3.10"
-          PYO3_CROSS_LIB_DIR: ${{ steps.python-ios.outputs.device_lib_dir }}
+          PYO3_CROSS_LIB_DIR: ${{ steps.python-ios.outputs[matrix.lib_dir_out] }}
         run: >-
           cargo build --release
-          --target aarch64-apple-ios
+          --target ${{ matrix.target }}
           --features "$IOS_PYO3_FEATURES"
-      - name: cargo build (ios simulator — aarch64-apple-ios-sim)
-        env:
-          PYO3_CROSS: "1"
-          PYO3_CROSS_PYTHON_VERSION: "3.10"
-          PYO3_CROSS_LIB_DIR: ${{ steps.python-ios.outputs.sim_lib_dir }}
-        run: >-
-          cargo build --release
-          --target aarch64-apple-ios-sim
-          --features "$IOS_PYO3_FEATURES"
-      - name: strip + package ios artifacts
+      - name: strip + stage ios cdylib (${{ matrix.dir }})
+        run: |
+          mkdir -p "dist/${{ matrix.dir }}"
+          # cdylib output is libciris_persist.dylib → ciris_persist.abi3.so
+          # (Python ext naming). Fix install name: cargo embeds the runner's
+          # absolute path; BeeWare Briefcase needs the @rpath-relative
+          # framework name.
+          SRC="target/${{ matrix.target }}/release/libciris_persist.dylib"
+          DST="dist/${{ matrix.dir }}/ciris_persist.abi3.so"
+          if [ ! -f "$SRC" ]; then
+            echo "::error::${SRC} not found"
+            ls -la "target/${{ matrix.target }}/release/" | grep ciris || true
+            exit 1
+          fi
+          strip -x "$SRC"
+          install_name_tool -id \
+            "@rpath/ciris_persist.ciris_persist.framework/ciris_persist.ciris_persist" \
+            "$SRC"
+          cp "$SRC" "$DST"
+          echo "✓ ${{ matrix.dir }}: $(ls -la "$DST" | awk '{print $5}') bytes"
+          otool -D "$DST"
+          file "$DST"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ciris-persist-ios-${{ matrix.dir }}
+          path: dist/${{ matrix.dir }}/ciris_persist.abi3.so
+
+  # ci-perf — recombine the two parallel iOS target builds into the single
+  # `ciris-persist-ios` tar that mobile-release uploads. Mirrors
+  # android-package. Runs on every PR (NOT tag-gated), so the recombine is
+  # validated before any release — only the mobile-release UPLOAD itself
+  # is tag-gated.
+  ios-package:
+    name: package ios artifacts
+    runs-on: ubuntu-latest
+    needs: [ios-build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: download both iOS target artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ciris-persist-ios-*
+          path: artifacts/
+      - name: package ios tarball
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           mkdir -p dist/ios-device dist/ios-simulator
-
-          # The cdylib output is libciris_persist.dylib; rename to
-          # ciris_persist.abi3.so (Python extension naming convention).
-          # Fix install name: cargo embeds the CI runner's absolute path;
-          # BeeWare Briefcase needs @rpath-relative framework name.
-          for pair in \
-            "aarch64-apple-ios:ios-device" \
-            "aarch64-apple-ios-sim:ios-simulator"; do
-            target="${pair%%:*}"
-            dir="${pair##*:}"
-            SRC="target/${target}/release/libciris_persist.dylib"
-            DST="dist/${dir}/ciris_persist.abi3.so"
-            if [ -f "$SRC" ]; then
-              strip -x "$SRC"
-              install_name_tool -id \
-                "@rpath/ciris_persist.ciris_persist.framework/ciris_persist.ciris_persist" \
-                "$SRC"
-              cp "$SRC" "$DST"
-              echo "✓ ${dir}: $(ls -la "$DST" | awk '{print $5}') bytes"
-              otool -D "$DST"
-            else
-              echo "::error::${SRC} not found"
-              ls -la "target/${target}/release/" | grep ciris
-              exit 1
-            fi
-          done
-
-          echo "=== ios-device ==="
-          ls -la dist/ios-device/
-          file dist/ios-device/ciris_persist.abi3.so
-          echo "=== ios-simulator ==="
-          ls -la dist/ios-simulator/
-          file dist/ios-simulator/ciris_persist.abi3.so
-
-          tar -czf "dist/ciris-persist-v${VERSION}-ios.tar.gz" \
-            -C dist ios-device ios-simulator
-
+          cp artifacts/ciris-persist-ios-ios-device/ciris_persist.abi3.so    dist/ios-device/
+          cp artifacts/ciris-persist-ios-ios-simulator/ciris_persist.abi3.so dist/ios-simulator/
+          echo "=== ios-device ===";    ls -la dist/ios-device/;    file dist/ios-device/ciris_persist.abi3.so
+          echo "=== ios-simulator ==="; ls -la dist/ios-simulator/; file dist/ios-simulator/ciris_persist.abi3.so
+          tar -czf "dist/ciris-persist-v${VERSION}-ios.tar.gz" -C dist ios-device ios-simulator
           echo "✓ packaged ciris-persist-v${VERSION}-ios.tar.gz"
           ls -la dist/ciris-persist-v${VERSION}-ios.tar.gz
       - uses: actions/upload-artifact@v4
@@ -748,10 +768,34 @@ jobs:
       # so the wheel must `-Zbuild-std` it from source (CIRISPersist#205).
       - uses: dtolnay/rust-toolchain@stable
         if: runner.os != 'Windows'
-      - uses: dtolnay/rust-toolchain@nightly
+      # ci-perf — PIN the Windows nightly (don't track `@nightly`). Two
+      # reasons: (1) the rust-cache key below includes the rustc version,
+      # so a daily-rotating nightly would bust the build-std cache every
+      # day — pinning keeps it warm across days; (2) reproducible Win7
+      # wheels (no surprise nightly std/codegen regressions). Bump this
+      # date deliberately when a std/build-std fix is needed; the date
+      # below is the known-good nightly the v5.5.4 Win7 wheel shipped on.
+      - uses: dtolnay/rust-toolchain@master
         if: runner.os == 'Windows'
         with:
+          toolchain: nightly-2026-06-12
           components: rust-src
+      # ci-perf — cache the wheel builds. This matrix was the ONLY build
+      # job without rust-cache, and it holds the two longest jobs: the
+      # Windows job recompiles std-from-source (build-std) + the full
+      # graph every run (~24m cold), and the linux/darwin wheels recompile
+      # the verify+pyo3+postgres graph. Warm cache skips all of it. Keyed
+      # per (os,label) so matrix entries don't share/thrash a cache
+      # (target/ differs per triple — esp. the win7 build-std artifacts).
+      # cache-bin: false mirrors the macOS/iOS sites (rustup-init shadow).
+      # Zero quality impact: cargo fingerprints on Cargo.lock+rustc and
+      # always recompiles persist's own (changed) crate; the published
+      # wheel is identical to a clean build.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: wheel-${{ matrix.label }}
+          cache-bin: false
+        continue-on-error: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -1029,7 +1073,7 @@ jobs:
     # The lint job (clippy + fmt + audit), license-audit, and the
     # full-features integration test (linux-x86_64-test) all need to pass
     # before the wheel reaches PyPI — those are quality gates that
-    # presence-of-wheel doesn't otherwise enforce. ios-build + darwin-test
+    # presence-of-wheel doesn't otherwise enforce. ios-package + darwin-test
     # are platform-specific build sanity, included for the same reason.
     # v3.6.6 — `build-manifest` re-added as a HARD gate. v2.5.0 made it
     # soft because the hybrid-signing secrets weren't configured; with
@@ -1046,7 +1090,7 @@ jobs:
       - license-audit
       - linux-x86_64-test
       - darwin-aarch64-test
-      - ios-build
+      - ios-package
       - android-package
     if: startsWith(github.ref, 'refs/tags/v')
     environment:
@@ -1595,7 +1639,7 @@ jobs:
     name: Upload mobile artifacts to GitHub Release (tag-gated)
     runs-on: ubuntu-latest
     needs:
-      - ios-build
+      - ios-package
       - android-package
       - lint
       - license-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,6 +720,14 @@ jobs:
           # bearing for the lens cutover. Add back via manual upload
           # if a real consumer materializes.
     runs-on: ${{ matrix.os }}
+    # ci-perf — single source of truth for the pinned Windows nightly. It
+    # is used in TWO places that MUST agree: the rust-src install below and
+    # RUSTUP_TOOLCHAIN in the build step. If they diverge, `-Zbuild-std`
+    # looks for std source in a toolchain that has no rust-src and fails
+    # ("…/library/Cargo.lock does not exist"). Bump deliberately; the date
+    # is the known-good nightly the v5.5.4 Win7 wheel shipped on.
+    env:
+      NIGHTLY_PIN: nightly-2026-06-12
     steps:
       - uses: actions/checkout@v4
       # v1.10.0 (CIRISPersist#87) — libtss2 for the `tpm` keyring
@@ -778,7 +786,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         if: runner.os == 'Windows'
         with:
-          toolchain: nightly-2026-06-12
+          toolchain: ${{ env.NIGHTLY_PIN }}
           components: rust-src
       # ci-perf — cache the wheel builds. This matrix was the ONLY build
       # job without rust-cache, and it holds the two longest jobs: the
@@ -829,15 +837,17 @@ jobs:
       # v5.5.4 (CIRISPersist#205) — Windows Win7-capable build. nightly +
       # `-Zbuild-std` (via CARGO_UNSTABLE_BUILD_STD) compiles std from
       # source for the Tier-3 `x86_64-win7-windows-msvc` target, retaining
-      # the Win7 fallback paths. RUSTUP_TOOLCHAIN=nightly makes the cargo
-      # maturin invokes use nightly; CARGO_BUILD_TARGET routes the build to
-      # the win7 triple (maturin tags it win_amd64 — x86_64 + windows). The
-      # `confirm wheel shape` gate below asserts the cp310-abi3 tag landed.
+      # the Win7 fallback paths. RUSTUP_TOOLCHAIN pins to the SAME dated
+      # nightly we installed rust-src on above (NIGHTLY_PIN) — using bare
+      # `nightly` here would resolve to a different, auto-installed toolchain
+      # with no rust-src and break build-std. CARGO_BUILD_TARGET routes the
+      # build to the win7 triple (maturin tags it win_amd64 — x86_64 +
+      # windows). The `confirm wheel shape` gate below asserts cp310-abi3.
       - name: maturin build (Windows — Tier-3 Win7 via build-std)
         if: runner.os == 'Windows'
         shell: bash
         env:
-          RUSTUP_TOOLCHAIN: nightly
+          RUSTUP_TOOLCHAIN: ${{ env.NIGHTLY_PIN }}
           CARGO_BUILD_TARGET: x86_64-win7-windows-msvc
           CARGO_UNSTABLE_BUILD_STD: std,panic_abort
         run: |


### PR DESCRIPTION
Workflow-only (no Rust, no deps — **identical artifacts**). Grounded in the v5.5.4 tag run's per-job times: two jobs define the whole cycle — Windows wheel (24m) and iOS (20m) — and the Windows one was *uncached* while rebuilding std from source.

### 1. `rust-cache` on the `pyo3-wheel` matrix
It was the **only** build job without caching, yet holds the long poles. Warm cache skips the std-from-source rebuild (Windows `-Zbuild-std`) and the verify+pyo3+postgres graph (all wheels). Keyed per `(os,label)`. Also **pin the Windows nightly** (was `@nightly`) so nightly's daily rotation doesn't bust the build-std cache every day — and for reproducible Win7 wheels.
- Zero quality impact: cargo fingerprints on `Cargo.lock`+rustc and always rebuilds persist's own crate → published wheel identical to a clean build. (Edge already publishes from cached wheel builds.)

### 2. Split the iOS job into a 2-target matrix + `ios-package`
It built `aarch64-apple-ios` then `-sim` **sequentially** in one 20m job (cargo's target-dir lock blocks in-job parallelism, so a matrix is the only way). Now two parallel builds + a recombine job that produces the **same** `ciris-persist-ios` tar — mirroring the existing `android-package` pattern. `mobile-release` + `publish-pypi` re-pointed to `ios-package`. The recombine runs on every PR (not tag-gated), so it's validated before any release.

### Expected
| | cold | now (warm) |
|---|---|---|
| Windows wheel | ~24m | ~10m |
| iOS | ~20m | ~11m |
| **PR cycle** | **~24m** | **~11m** |
| **publish critical path** | **~27m** | **~14m** |

No tests, coverage, or platforms dropped. This PR's own CI is the validation — watch the `pyo3-wheel (windows-x86_64)` and the two `ios-build` matrix jobs + `ios-package`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)