### PR TITLE
v5.6.0 — SharedInstanceLease: cross-process leader election (#210, unblocks CIRISEdge#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [5.6.0] — 2026-06-12
+
+### Added — SharedInstanceLease: cross-process leader election (CIRISPersist#210; CIRISEdge#100)
+
+Multi-worker FastAPI/uvicorn deployments each call `init_edge_runtime` and race to bind the same Reticulum UDP socket — all but one fail `EADDRINUSE`. The clean fix is RNS shared-instance mode (one process owns the sockets, siblings attach); the missing piece was **leader election**. Persist already owns the family's cross-process atomic state, so it's the right home: liveness is a heartbeat-age query (a flock can't detect a crashed owner), the owner is operator-introspectable (`SELECT * FROM shared_instance_leases`), and every consumer already talks to persist.
+
+- **`federation::shared_instance`** (new module, re-exported): `SharedInstanceLease` (instance_name / owner_pid / owner_hostname / acquired_at / last_heartbeat_at / lease_version), `DEFAULT_STALE_AFTER` (30s), and the `staleness_threshold` helper.
+- **Four new `FederationDirectory` methods** (default-impl on the trait; real impls on the Postgres + SQLite backends): `try_acquire_shared_instance` / `heartbeat_shared_instance` / `lookup_shared_instance_lease` / `release_shared_instance_lease`. Additive — no breaking change; existing backends inherit the "not implemented" default until overridden (the in-memory backend, single-process by definition, does so).
+- **Atomic election** is a single-statement upsert — `INSERT … ON CONFLICT (instance_name) DO UPDATE … WHERE the incumbent heartbeat is stale` — so two siblings racing can never both win (the loser's `DO UPDATE WHERE` sees the just-written fresh heartbeat → 0 rows → `None`). A dead owner (heartbeat older than `stale_after`) is stolen with `lease_version + 1`; the demoted owner learns of the takeover when its next `heartbeat` returns `None` (version/pid no longer match). `release` is ownership-checked + idempotent — it never deletes a sibling's lease.
+- **V074** (both backends): `shared_instance_leases` + a `last_heartbeat_at` index. PG uses `TIMESTAMPTZ`; SQLite uses RFC-3339 TEXT with a fixed Micros+Z format on every write and the staleness threshold, so the comparison is a sound lexical `<`.
+
+Edge consumes the primitive through the existing `federation_directory_capsule` (it calls the trait on the concrete backend), so this ships with no new FFI surface.
+
+### Tests
+Full lifecycle on **both backends** (sqlite in-memory + live PG): acquire-wins, live-contention rejection, lookup, heartbeat-keeps-ownership, stale-steal (version bump), demotion detection on the stolen owner's heartbeat, and ownership-checked release (a stale release never evicts the current owner). Gate: fmt · clippy `-D warnings` (sqlite-only + postgres+server+pyo3) · backend-less `-D warnings` · `--no-default-features` check · cargo-deny · sqlite lib (788) · live-PG lib (729).
+
 ## [5.5.5] — 2026-06-12
 
 ### Changed — CIRISVerify 5.1.0 → 5.1.3 (Win7-capable verify; TPM-1.2→software degradation)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "5.5.5"
+version = "5.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V074__shared_instance_leases.sql
+++ b/migrations/postgres/lens/V074__shared_instance_leases.sql
@@ -1,0 +1,33 @@
+-- V074 — SharedInstanceLease: cross-process leader election for a named
+--        Reticulum (or other) singleton (CIRISPersist#210, CIRISEdge#100).
+--        Postgres dialect. SQLite parity: sqlite/lens/V074.
+--
+-- Multi-worker FastAPI/uvicorn deployments each call init_edge_runtime
+-- and race to bind the same Reticulum UDP socket → 5/7 EADDRINUSE. The
+-- clean fix is RNS shared-instance mode: one process owns the sockets,
+-- siblings attach. This table is the leader-election substrate — persist
+-- already owns cross-process atomic state (cf. the revocation-quorum
+-- pattern), so liveness (heartbeat age) is a DB query, not a brittle
+-- flock with no crash detection.
+--
+-- Atomicity lives in try_acquire_shared_instance, not the DDL: a single
+-- INSERT … ON CONFLICT (instance_name) DO UPDATE … WHERE the existing
+-- heartbeat is stale, so two siblings racing can never both win (the
+-- loser's DO UPDATE WHERE sees the just-written fresh heartbeat → 0 rows
+-- → None). TIMESTAMPTZ; the caller passes a client-computed staleness
+-- threshold so acquired_at / heartbeat / comparison share one clock.
+
+CREATE TABLE IF NOT EXISTS cirislens.shared_instance_leases (
+    instance_name        TEXT PRIMARY KEY,
+    owner_pid            INTEGER NOT NULL,
+    owner_hostname       TEXT NOT NULL,
+    acquired_at          TIMESTAMPTZ NOT NULL,
+    last_heartbeat_at    TIMESTAMPTZ NOT NULL,
+    -- increments on each acquire/steal — lets heartbeat detect a takeover
+    -- (our row's version moved on, so our lease was stolen).
+    lease_version        BIGINT NOT NULL DEFAULT 1
+);
+
+-- Operators / liveness sweeps query by heartbeat age.
+CREATE INDEX IF NOT EXISTS shared_instance_leases_heartbeat_idx
+    ON cirislens.shared_instance_leases (last_heartbeat_at);

--- a/migrations/sqlite/lens/V074__shared_instance_leases.sql
+++ b/migrations/sqlite/lens/V074__shared_instance_leases.sql
@@ -1,0 +1,30 @@
+-- V074 — SharedInstanceLease: cross-process leader election for a named
+--        Reticulum (or other) singleton (CIRISPersist#210, CIRISEdge#100).
+--        SQLite dialect. Postgres parity: postgres/lens/V074.
+--
+-- Multi-worker FastAPI/uvicorn deployments each call init_edge_runtime
+-- and race to bind the same Reticulum UDP socket → 5/7 EADDRINUSE. The
+-- clean fix is RNS shared-instance mode: one process owns the sockets,
+-- siblings attach. This table is the leader-election substrate — persist
+-- already owns cross-process atomic state (cf. the revocation-quorum
+-- pattern), so liveness (heartbeat age) is a DB query, not a brittle
+-- flock with no crash detection.
+--
+-- Atomicity lives in try_acquire_shared_instance, not the DDL: a single
+-- UPSERT (INSERT … ON CONFLICT DO UPDATE … WHERE heartbeat-is-stale) so
+-- two siblings racing can never both win. TIMESTAMPTZ → TEXT (RFC-3339,
+-- UTC — lexical order == chronological, so the staleness comparison is a
+-- plain string `<`). Refinery wraps this in its own transaction.
+
+CREATE TABLE shared_instance_leases (
+    instance_name        TEXT PRIMARY KEY,
+    owner_pid            INTEGER NOT NULL,
+    owner_hostname       TEXT NOT NULL,
+    acquired_at          TEXT NOT NULL,   -- RFC-3339 UTC
+    last_heartbeat_at    TEXT NOT NULL,   -- RFC-3339 UTC
+    lease_version        INTEGER NOT NULL DEFAULT 1
+);
+
+-- Operators / liveness sweeps query by heartbeat age.
+CREATE INDEX shared_instance_leases_heartbeat_idx
+    ON shared_instance_leases (last_heartbeat_at);

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -56,6 +56,10 @@ pub mod read;
 pub mod replication;
 pub mod rooting;
 pub mod schema_resolver;
+// CIRISPersist#210 — cross-process leader election (RNS shared-instance
+// owner; CIRISEdge#100). Backend-agnostic types + staleness helper; the
+// atomic acquire/heartbeat/release live in the backends.
+pub mod shared_instance;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_open;
 // v4.1 (CIRISPersist#142 Cut C2) — streaming-chunk AES-256-GCM + STREAM
@@ -138,6 +142,7 @@ pub use schema_resolver::BlobBackedSchemaResolver;
 pub use schema_resolver::{
     axis_from_dimension, AxisSchema, NoOpSchemaResolver, SchemaResolver, SchemaResolverError,
 };
+pub use shared_instance::{SharedInstanceLease, DEFAULT_STALE_AFTER};
 #[cfg(feature = "sqlite")]
 pub use sqlite_open::FederationDirectorySqlite;
 pub use stream_sth::{
@@ -1323,6 +1328,92 @@ pub trait FederationDirectory: Send + Sync {
         let _ = key_id;
         Err(Error::Backend(
             "peer_metadata_for not implemented for this backend".into(),
+        ))
+    }
+
+    // ── Shared-instance leases (CIRISPersist#210; CIRISEdge#100) ────
+    //
+    // Cross-process leader election for a named singleton (the RNS
+    // shared-instance owner). See [`shared_instance`] for the model.
+
+    /// Try to become the owner of `instance_name`. Atomic across racing
+    /// siblings — exactly one wins.
+    ///
+    /// - `Ok(Some(lease))` — won. The caller is now the server: hold the
+    ///   lease and call [`heartbeat_shared_instance`](Self::heartbeat_shared_instance)
+    ///   periodically. Won either because no row existed, or the prior
+    ///   owner's heartbeat aged past `stale_after` (a dead owner is
+    ///   stolen; `lease_version` increments so the demoted owner detects
+    ///   the takeover on its next heartbeat).
+    /// - `Ok(None)` — a *live* owner already holds it. The caller is a
+    ///   client; use [`lookup_shared_instance_lease`](Self::lookup_shared_instance_lease)
+    ///   to find who to dial.
+    /// - `Err(_)` — transport failure (DB unreachable etc.).
+    ///
+    /// `stale_after` defaults to
+    /// [`shared_instance::DEFAULT_STALE_AFTER`] (30s) when `None`. The
+    /// staleness threshold is computed client-side so the new row's
+    /// timestamps and the staleness comparison share one clock.
+    async fn try_acquire_shared_instance(
+        &self,
+        instance_name: &str,
+        owner_pid: i32,
+        owner_hostname: &str,
+        stale_after: Option<std::time::Duration>,
+    ) -> Result<Option<shared_instance::SharedInstanceLease>, Error> {
+        let _ = (instance_name, owner_pid, owner_hostname, stale_after);
+        Err(Error::Backend(
+            "try_acquire_shared_instance not implemented for this backend".into(),
+        ))
+    }
+
+    /// Refresh the lease's `last_heartbeat_at`. The owner calls this on a
+    /// timer (e.g. every 10s against a 30s `stale_after`).
+    ///
+    /// - `Ok(Some(lease))` — heartbeat landed; the caller is still owner
+    ///   (returned lease carries the refreshed `last_heartbeat_at`).
+    /// - `Ok(None)` — the lease was **stolen** (a stale window elapsed
+    ///   while the owner was paused and a sibling took over; the stored
+    ///   row's `lease_version`/owner no longer matches the held lease, or
+    ///   the row is gone). Treat as a demotion: stop owning, become a
+    ///   client, reconnect to the new owner.
+    /// - `Err(_)` — transport failure.
+    async fn heartbeat_shared_instance(
+        &self,
+        lease: &shared_instance::SharedInstanceLease,
+    ) -> Result<Option<shared_instance::SharedInstanceLease>, Error> {
+        let _ = lease;
+        Err(Error::Backend(
+            "heartbeat_shared_instance not implemented for this backend".into(),
+        ))
+    }
+
+    /// Look up the current owner of `instance_name` (live or stale).
+    /// `None` if no row exists. Clients use it to find who to dial;
+    /// operators use it to debug. Liveness is the caller's call from
+    /// `last_heartbeat_at` age.
+    async fn lookup_shared_instance_lease(
+        &self,
+        instance_name: &str,
+    ) -> Result<Option<shared_instance::SharedInstanceLease>, Error> {
+        let _ = instance_name;
+        Err(Error::Backend(
+            "lookup_shared_instance_lease not implemented for this backend".into(),
+        ))
+    }
+
+    /// Explicitly release the lease on graceful shutdown so a sibling can
+    /// take over immediately without waiting out `stale_after`. Idempotent
+    /// and ownership-checked: only deletes the row if the held lease is
+    /// still the current owner (matching `lease_version`); a no-op if the
+    /// lease was already stolen (never deletes another process's lease).
+    async fn release_shared_instance_lease(
+        &self,
+        lease: &shared_instance::SharedInstanceLease,
+    ) -> Result<(), Error> {
+        let _ = lease;
+        Err(Error::Backend(
+            "release_shared_instance_lease not implemented for this backend".into(),
         ))
     }
 }

--- a/src/federation/shared_instance.rs
+++ b/src/federation/shared_instance.rs
@@ -1,0 +1,75 @@
+//! SharedInstanceLease — cross-process leader election for a named
+//! singleton (CIRISPersist#210, CIRISEdge#100).
+//!
+//! Multi-worker FastAPI/uvicorn deployments each call `init_edge_runtime`
+//! and race to bind the same Reticulum UDP socket; all but one fail with
+//! `EADDRINUSE`. The architecturally clean fix is RNS shared-instance
+//! mode — one process owns the link-layer sockets, siblings attach over
+//! an AF_UNIX socket and get full RNS semantics without binding. The only
+//! missing piece is **leader election**: deciding which process is the
+//! server. Persist already owns the canonical cross-process coordination
+//! layer for the CIRIS family (cf. the revocation-quorum state), so this
+//! is its right home: liveness is a heartbeat-age query (a flock can't
+//! detect a crashed owner), the owner is operator-introspectable
+//! (`SELECT * FROM shared_instance_leases`), and every consumer already
+//! talks to persist (no new IPC channel).
+//!
+//! The election is a TTL lease: a process [`try_acquire`]s a named
+//! instance; the winner becomes the server and
+//! [`heartbeat`]s on a timer; if the owner pauses/crashes past the
+//! staleness window, a sibling steals the lease (and the original owner
+//! learns it was demoted when its next heartbeat returns `None`). The
+//! atomicity that makes "exactly one winner" hold lives in the backends'
+//! single-statement upsert — see [`FederationDirectory::try_acquire_shared_instance`].
+//!
+//! [`try_acquire`]: crate::federation::FederationDirectory::try_acquire_shared_instance
+//! [`heartbeat`]: crate::federation::FederationDirectory::heartbeat_shared_instance
+//! [`FederationDirectory::try_acquire_shared_instance`]: crate::federation::FederationDirectory::try_acquire_shared_instance
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Default staleness window: a lease whose `last_heartbeat_at` is older
+/// than this is considered dead and stealable. Pairs with a ~10s
+/// heartbeat cadence (3 missed beats before takeover).
+pub const DEFAULT_STALE_AFTER: Duration = Duration::from_secs(30);
+
+/// A lease over a named singleton instance (e.g. the Reticulum
+/// shared-instance owner). Held for the lifetime of the owning process;
+/// auto-released when the row's `last_heartbeat_at` ages past the
+/// staleness window a sibling acquires with.
+///
+/// Serde-serializable so it round-trips the FFI boundary as JSON; the
+/// owning process holds the returned value and passes it back to
+/// [`heartbeat`](crate::federation::FederationDirectory::heartbeat_shared_instance)
+/// / [`release`](crate::federation::FederationDirectory::release_shared_instance_lease).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SharedInstanceLease {
+    /// The named singleton this lease is for (e.g. `"reticulum:default"`).
+    pub instance_name: String,
+    /// OS pid of the owning process. Diagnostic + lets an operator map a
+    /// lease to a running process.
+    pub owner_pid: i32,
+    /// Hostname of the owning process. With `owner_pid`, uniquely
+    /// identifies the owner for cross-host debugging.
+    pub owner_hostname: String,
+    /// When this owner most recently *acquired* (or stole) the lease.
+    pub acquired_at: DateTime<Utc>,
+    /// When the owner last proved liveness. Drives the staleness check.
+    pub last_heartbeat_at: DateTime<Utc>,
+    /// Increments on every acquire/steal. The heartbeat compares the
+    /// stored version against the held one to detect a takeover: if the
+    /// row's version has moved past ours, our lease was stolen while we
+    /// were paused and we must demote to client.
+    pub lease_version: i64,
+}
+
+/// The instant before which a `last_heartbeat_at` counts as stale. The
+/// caller computes this client-side (= `now - stale_after`) and passes it
+/// to the backend so the new row's timestamps and the staleness
+/// comparison share one clock — no server/client clock-skew in the race.
+#[must_use]
+pub fn staleness_threshold(now: DateTime<Utc>, stale_after: Duration) -> DateTime<Utc> {
+    now - chrono::Duration::from_std(stale_after).unwrap_or_else(|_| chrono::Duration::seconds(30))
+}

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2581,6 +2581,134 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         rows.into_iter().map(pg_row_to_location_proof).collect()
     }
 
+    // ── Shared-instance leases (CIRISPersist#210) ──────────────────
+
+    async fn try_acquire_shared_instance(
+        &self,
+        instance_name: &str,
+        owner_pid: i32,
+        owner_hostname: &str,
+        stale_after: Option<std::time::Duration>,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let now = chrono::Utc::now();
+        let stale = stale_after.unwrap_or(crate::federation::shared_instance::DEFAULT_STALE_AFTER);
+        let threshold = crate::federation::shared_instance::staleness_threshold(now, stale);
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Single-statement atomic election: insert fresh, or steal iff the
+        // incumbent's heartbeat is stale. A live incumbent fails the DO
+        // UPDATE WHERE → 0 rows → RETURNING empty → we lost. Two racers:
+        // the first writes a fresh heartbeat, the second's WHERE then sees
+        // it as live → exactly one winner.
+        let row = client
+            .query_opt(
+                "INSERT INTO cirislens.shared_instance_leases \
+                    (instance_name, owner_pid, owner_hostname, acquired_at, \
+                     last_heartbeat_at, lease_version) \
+                 VALUES ($1, $2, $3, $4, $4, 1) \
+                 ON CONFLICT (instance_name) DO UPDATE SET \
+                    owner_pid = EXCLUDED.owner_pid, \
+                    owner_hostname = EXCLUDED.owner_hostname, \
+                    acquired_at = EXCLUDED.acquired_at, \
+                    last_heartbeat_at = EXCLUDED.last_heartbeat_at, \
+                    lease_version = shared_instance_leases.lease_version + 1 \
+                 WHERE shared_instance_leases.last_heartbeat_at < $5 \
+                 RETURNING instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version",
+                &[
+                    &instance_name,
+                    &owner_pid,
+                    &owner_hostname,
+                    &now,
+                    &threshold,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("try_acquire_shared_instance: {e}"))
+            })?;
+        row.map(pg_row_to_shared_instance_lease).transpose()
+    }
+
+    async fn heartbeat_shared_instance(
+        &self,
+        lease: &crate::federation::SharedInstanceLease,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let now = chrono::Utc::now();
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Refresh only if WE are still the current owner — match on
+        // (instance, lease_version, pid). If the lease was stolen the
+        // version/pid moved on → 0 rows → None (demotion signal).
+        let row = client
+            .query_opt(
+                "UPDATE cirislens.shared_instance_leases SET last_heartbeat_at = $1 \
+                 WHERE instance_name = $2 AND lease_version = $3 AND owner_pid = $4 \
+                 RETURNING instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version",
+                &[
+                    &now,
+                    &lease.instance_name,
+                    &lease.lease_version,
+                    &lease.owner_pid,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("heartbeat_shared_instance: {e}"))
+            })?;
+        row.map(pg_row_to_shared_instance_lease).transpose()
+    }
+
+    async fn lookup_shared_instance_lease(
+        &self,
+        instance_name: &str,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let row = client
+            .query_opt(
+                "SELECT instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version \
+                 FROM cirislens.shared_instance_leases WHERE instance_name = $1",
+                &[&instance_name],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("lookup_shared_instance_lease: {e}"))
+            })?;
+        row.map(pg_row_to_shared_instance_lease).transpose()
+    }
+
+    async fn release_shared_instance_lease(
+        &self,
+        lease: &crate::federation::SharedInstanceLease,
+    ) -> Result<(), crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // Ownership-checked + idempotent: only delete our own current
+        // lease. A no-op if it was already stolen (never delete a sibling's).
+        client
+            .execute(
+                "DELETE FROM cirislens.shared_instance_leases \
+                 WHERE instance_name = $1 AND lease_version = $2 AND owner_pid = $3",
+                &[&lease.instance_name, &lease.lease_version, &lease.owner_pid],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("release_shared_instance_lease: {e}"))
+            })?;
+        Ok(())
+    }
+
     async fn communities_containing(
         &self,
         cell_id: &str,
@@ -7459,6 +7587,20 @@ fn pg_row_to_location_proof(
         attestation_evidence: row.safe_get_with("attestation_evidence", mk_err)?,
         withdrawn_at: row.safe_get_with("withdrawn_at", mk_err)?,
         persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+fn pg_row_to_shared_instance_lease(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::SharedInstanceLease, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    Ok(crate::federation::SharedInstanceLease {
+        instance_name: row.safe_get_with("instance_name", mk_err)?,
+        owner_pid: row.safe_get_with("owner_pid", mk_err)?,
+        owner_hostname: row.safe_get_with("owner_hostname", mk_err)?,
+        acquired_at: row.safe_get_with("acquired_at", mk_err)?,
+        last_heartbeat_at: row.safe_get_with("last_heartbeat_at", mk_err)?,
+        lease_version: row.safe_get_with("lease_version", mk_err)?,
     })
 }
 
@@ -22150,6 +22292,110 @@ mod tests {
     }
 
     /// v4.10.0 (CIRISPersist#154) — live-PG location_proof round-trip:
+    /// CIRISPersist#210 — SharedInstanceLease lifecycle on live PG: the
+    /// `INSERT … ON CONFLICT … WHERE stale` atomic election, live-owner
+    /// rejection, heartbeat, stale-steal (version bump + RETURNING),
+    /// demotion detection, ownership-checked release.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_shared_instance_lease_election_lifecycle() {
+        use crate::federation::FederationDirectory;
+        use std::time::Duration;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        // Unique instance name so serial reuse of the shared test DB
+        // doesn't collide with a prior run's row.
+        let name = format!("reticulum:{}", uuid_like());
+
+        // 1. Acquire on an empty slot → win, version 1.
+        let lease = backend
+            .try_acquire_shared_instance(&name, 1001, "hostA", None)
+            .await
+            .unwrap()
+            .expect("first acquire wins");
+        assert_eq!((lease.owner_pid, lease.lease_version), (1001, 1));
+
+        // 2. Live contender → loses.
+        assert!(
+            backend
+                .try_acquire_shared_instance(&name, 2002, "hostB", None)
+                .await
+                .unwrap()
+                .is_none(),
+            "a live owner blocks a second acquirer"
+        );
+
+        // 3. lookup reports the owner.
+        let found = backend
+            .lookup_shared_instance_lease(&name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!((found.owner_pid, found.lease_version), (1001, 1));
+
+        // 4. Owner heartbeats → still owner.
+        let beat = backend
+            .heartbeat_shared_instance(&lease)
+            .await
+            .unwrap()
+            .expect("owner still holds");
+        assert_eq!((beat.owner_pid, beat.lease_version), (1001, 1));
+
+        // 5. Age the heartbeat, then steal with a small stale window.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        let stolen = backend
+            .try_acquire_shared_instance(&name, 2002, "hostB", Some(Duration::from_millis(10)))
+            .await
+            .unwrap()
+            .expect("a stale owner is stealable");
+        assert_eq!((stolen.owner_pid, stolen.lease_version), (2002, 2));
+
+        // 6. Demoted original owner's heartbeat → None.
+        assert!(
+            backend
+                .heartbeat_shared_instance(&beat)
+                .await
+                .unwrap()
+                .is_none(),
+            "original owner learns its lease was stolen"
+        );
+
+        // 7. Release by the current owner → gone; next acquire fresh v1.
+        backend
+            .release_shared_instance_lease(&stolen)
+            .await
+            .unwrap();
+        assert!(backend
+            .lookup_shared_instance_lease(&name)
+            .await
+            .unwrap()
+            .is_none());
+        let fresh = backend
+            .try_acquire_shared_instance(&name, 3003, "hostC", None)
+            .await
+            .unwrap()
+            .expect("acquire after release wins");
+        assert_eq!(fresh.lease_version, 1, "released slot → fresh lease at v1");
+
+        // 8. Stale release must not evict the live owner.
+        backend
+            .release_shared_instance_lease(&stolen)
+            .await
+            .unwrap();
+        assert!(
+            backend
+                .lookup_shared_instance_lease(&name)
+                .await
+                .unwrap()
+                .is_some(),
+            "stale release never deletes the current lease"
+        );
+    }
+
     /// SMALLINT `cell_resolution` + BYTEA `attestation_evidence` binding,
     /// valid res-7 admits, over-precise res-9 refused (§0.8.1).
     #[tokio::test]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2239,6 +2239,148 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         .map_err(|e| crate::federation::Error::Backend(format!("list_location_proofs_for: {e}")))
     }
 
+    // ── Shared-instance leases (CIRISPersist#210) ──────────────────
+
+    async fn try_acquire_shared_instance(
+        &self,
+        instance_name: &str,
+        owner_pid: i32,
+        owner_hostname: &str,
+        stale_after: Option<std::time::Duration>,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let now = chrono::Utc::now();
+        let stale = stale_after.unwrap_or(crate::federation::shared_instance::DEFAULT_STALE_AFTER);
+        // Fixed Micros+Z format on every write AND the threshold so the
+        // staleness check is a plain TEXT `<` (lexical == chronological
+        // only with one consistent format; every row here is written by
+        // these methods, so the invariant holds).
+        let now_s = now.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let threshold_s = crate::federation::shared_instance::staleness_threshold(now, stale)
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let conn = self.conn.clone();
+        let name = instance_name.to_owned();
+        let host = owner_hostname.to_owned();
+        (move || -> Result<Option<crate::federation::SharedInstanceLease>, rusqlite::Error> {
+            let conn = conn.lock();
+            // Insert fresh, or steal iff the incumbent's heartbeat is
+            // stale. SQLite serializes writers, so the race is naturally
+            // single-winner; the WHERE makes a live incumbent a 0-row
+            // no-op. `execute` returns rows-affected: >0 = we own it.
+            let affected = conn.execute(
+                "INSERT INTO shared_instance_leases \
+                    (instance_name, owner_pid, owner_hostname, acquired_at, \
+                     last_heartbeat_at, lease_version) \
+                 VALUES (?1, ?2, ?3, ?4, ?4, 1) \
+                 ON CONFLICT(instance_name) DO UPDATE SET \
+                    owner_pid = excluded.owner_pid, \
+                    owner_hostname = excluded.owner_hostname, \
+                    acquired_at = excluded.acquired_at, \
+                    last_heartbeat_at = excluded.last_heartbeat_at, \
+                    lease_version = shared_instance_leases.lease_version + 1 \
+                 WHERE shared_instance_leases.last_heartbeat_at < ?5",
+                rusqlite::params![name, i64::from(owner_pid), host, now_s, threshold_s],
+            )?;
+            if affected == 0 {
+                return Ok(None); // a live owner holds it
+            }
+            let lease = conn.query_row(
+                "SELECT instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version \
+                 FROM shared_instance_leases WHERE instance_name = ?1",
+                [&name],
+                sqlite_row_to_shared_instance_lease,
+            )?;
+            Ok(Some(lease))
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("try_acquire_shared_instance: {e}")))
+    }
+
+    async fn heartbeat_shared_instance(
+        &self,
+        lease: &crate::federation::SharedInstanceLease,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let now_s = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let conn = self.conn.clone();
+        let lease = lease.clone();
+        (move || -> Result<Option<crate::federation::SharedInstanceLease>, rusqlite::Error> {
+            let conn = conn.lock();
+            // Refresh only if we're still the current owner (match on
+            // version + pid). 0 rows = our lease was stolen or is gone.
+            let affected = conn.execute(
+                "UPDATE shared_instance_leases SET last_heartbeat_at = ?1 \
+                 WHERE instance_name = ?2 AND lease_version = ?3 AND owner_pid = ?4",
+                rusqlite::params![
+                    now_s,
+                    lease.instance_name,
+                    lease.lease_version,
+                    i64::from(lease.owner_pid),
+                ],
+            )?;
+            if affected == 0 {
+                return Ok(None); // demoted — sibling took over
+            }
+            let updated = conn.query_row(
+                "SELECT instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version \
+                 FROM shared_instance_leases WHERE instance_name = ?1",
+                [&lease.instance_name],
+                sqlite_row_to_shared_instance_lease,
+            )?;
+            Ok(Some(updated))
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("heartbeat_shared_instance: {e}")))
+    }
+
+    async fn lookup_shared_instance_lease(
+        &self,
+        instance_name: &str,
+    ) -> Result<Option<crate::federation::SharedInstanceLease>, crate::federation::Error> {
+        let conn = self.conn.clone();
+        let name = instance_name.to_owned();
+        (move || -> Result<Option<crate::federation::SharedInstanceLease>, rusqlite::Error> {
+            let conn = conn.lock();
+            match conn.query_row(
+                "SELECT instance_name, owner_pid, owner_hostname, acquired_at, \
+                    last_heartbeat_at, lease_version \
+                 FROM shared_instance_leases WHERE instance_name = ?1",
+                [&name],
+                sqlite_row_to_shared_instance_lease,
+            ) {
+                Ok(l) => Ok(Some(l)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!("lookup_shared_instance_lease: {e}"))
+        })
+    }
+
+    async fn release_shared_instance_lease(
+        &self,
+        lease: &crate::federation::SharedInstanceLease,
+    ) -> Result<(), crate::federation::Error> {
+        let conn = self.conn.clone();
+        let lease = lease.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            // Ownership-checked + idempotent: only our own current lease.
+            conn.execute(
+                "DELETE FROM shared_instance_leases \
+                 WHERE instance_name = ?1 AND lease_version = ?2 AND owner_pid = ?3",
+                rusqlite::params![
+                    lease.instance_name,
+                    lease.lease_version,
+                    i64::from(lease.owner_pid),
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!("release_shared_instance_lease: {e}"))
+        })
+    }
+
     async fn communities_containing(
         &self,
         cell_id: &str,
@@ -7399,6 +7541,21 @@ fn sqlite_row_to_location_proof(
         attestation_evidence: row.get("attestation_evidence")?,
         withdrawn_at: withdrawn_at.as_deref().map(parse_rfc3339),
         persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+fn sqlite_row_to_shared_instance_lease(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::SharedInstanceLease> {
+    let acquired_at: String = row.get("acquired_at")?;
+    let last_heartbeat_at: String = row.get("last_heartbeat_at")?;
+    Ok(crate::federation::SharedInstanceLease {
+        instance_name: row.get("instance_name")?,
+        owner_pid: row.get("owner_pid")?,
+        owner_hostname: row.get("owner_hostname")?,
+        acquired_at: parse_rfc3339(&acquired_at),
+        last_heartbeat_at: parse_rfc3339(&last_heartbeat_at),
+        lease_version: row.get("lease_version")?,
     })
 }
 
@@ -12765,6 +12922,105 @@ mod tests {
                 .unwrap()
                 .len(),
             1
+        );
+    }
+
+    /// CIRISPersist#210 — full SharedInstanceLease lifecycle: acquire,
+    /// live-contention rejection, lookup, heartbeat, stale-steal (version
+    /// bump), demotion detection, ownership-checked release.
+    #[tokio::test]
+    async fn shared_instance_lease_election_lifecycle() {
+        use std::time::Duration;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let name = "reticulum:default";
+
+        // 1. Acquire on an empty slot → win, version 1.
+        let lease = backend
+            .try_acquire_shared_instance(name, 1001, "hostA", None)
+            .await
+            .unwrap()
+            .expect("first acquire wins");
+        assert_eq!(lease.owner_pid, 1001);
+        assert_eq!(lease.lease_version, 1);
+        assert_eq!(lease.instance_name, name);
+
+        // 2. A second, live contender → loses (None).
+        assert!(
+            backend
+                .try_acquire_shared_instance(name, 2002, "hostB", None)
+                .await
+                .unwrap()
+                .is_none(),
+            "a live owner blocks a second acquirer"
+        );
+
+        // 3. lookup reports the owner.
+        let found = backend
+            .lookup_shared_instance_lease(name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!((found.owner_pid, found.lease_version), (1001, 1));
+
+        // 4. Owner heartbeats → still owner, same version, fresher beat.
+        let beat = backend
+            .heartbeat_shared_instance(&lease)
+            .await
+            .unwrap()
+            .expect("owner still holds");
+        assert_eq!((beat.owner_pid, beat.lease_version), (1001, 1));
+        assert!(beat.last_heartbeat_at >= lease.last_heartbeat_at);
+
+        // 5. Let the heartbeat age, then steal with a small stale window.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        let stolen = backend
+            .try_acquire_shared_instance(name, 2002, "hostB", Some(Duration::from_millis(10)))
+            .await
+            .unwrap()
+            .expect("a stale owner is stealable");
+        assert_eq!(stolen.owner_pid, 2002);
+        assert_eq!(stolen.lease_version, 2, "steal increments the version");
+
+        // 6. The demoted original owner's heartbeat → None (takeover seen).
+        assert!(
+            backend
+                .heartbeat_shared_instance(&beat)
+                .await
+                .unwrap()
+                .is_none(),
+            "original owner learns its lease was stolen"
+        );
+
+        // 7. Owner releases → row gone; next acquire is fresh at v1.
+        backend
+            .release_shared_instance_lease(&stolen)
+            .await
+            .unwrap();
+        assert!(backend
+            .lookup_shared_instance_lease(name)
+            .await
+            .unwrap()
+            .is_none());
+        let fresh = backend
+            .try_acquire_shared_instance(name, 3003, "hostC", None)
+            .await
+            .unwrap()
+            .expect("acquire after release wins");
+        assert_eq!(fresh.lease_version, 1, "released slot → fresh lease at v1");
+
+        // 8. A stale (non-current) release must NOT evict the live owner.
+        backend
+            .release_shared_instance_lease(&stolen)
+            .await
+            .unwrap();
+        assert!(
+            backend
+                .lookup_shared_instance_lease(name)
+                .await
+                .unwrap()
+                .is_some(),
+            "stale release never deletes another process's current lease"
         );
     }
 


### PR DESCRIPTION
Closes #210. **Unblocks edge** — this is the substrate primitive CIRISEdge#100 / edge v2.3.0's auto leader-election needs.

## Why
Multi-worker FastAPI/uvicorn deployments each call `init_edge_runtime` and race to bind the same Reticulum UDP socket — 5/7 workers `EADDRINUSE`. RNS shared-instance mode (one process owns the sockets, siblings attach) is the clean fix; the missing piece was **leader election**. Persist already owns the family's cross-process atomic state, so it's the right home: liveness is a heartbeat-age query (a flock can't detect a crash), the owner is operator-introspectable, and every consumer already talks to persist.

## What
- **`federation::shared_instance`** (new module): `SharedInstanceLease`, `DEFAULT_STALE_AFTER` (30s), `staleness_threshold`.
- **4 `FederationDirectory` methods** — `try_acquire` / `heartbeat` / `lookup` / `release` — default-impl on the trait (additive, non-breaking), real impls on Postgres + SQLite.
- **Atomic election**: single-statement `INSERT … ON CONFLICT DO UPDATE … WHERE incumbent-heartbeat-is-stale` → two racers can never both win (the loser's `DO UPDATE WHERE` sees the just-written fresh heartbeat → 0 rows → `None`). Stale owner stolen with `lease_version + 1`; the demoted owner learns of takeover when its next `heartbeat` returns `None`; `release` is ownership-checked + idempotent (never deletes a sibling's lease).
- **V074** both backends: `shared_instance_leases` + heartbeat index. PG `TIMESTAMPTZ`; SQLite RFC-3339 TEXT with a fixed Micros+Z format on every write + the threshold, so the staleness compare is a sound lexical `<`.
- **No new FFI** — edge consumes via the existing `federation_directory_capsule` (calls the trait on the concrete backend).

## Tests — both backends, full lifecycle
acquire-wins · live-contention rejection · lookup · heartbeat-keeps-ownership · stale-steal (version bump) · demotion detection · ownership-checked release (a stale release never evicts the current owner). Gate: fmt · clippy `-D warnings` ×2 · backend-less `-D warnings` · `--no-default-features` · cargo-deny · sqlite lib (788) · live-PG lib (729).

## Edge sequencing
Per #210: persist ships this (v5.6.0) → edge consumes (`init_edge_runtime` auto mode calls `try_acquire_shared_instance`, heartbeats from the server) → lens-API drops `WORKERS=1`. Floor for the auto layer: **`ciris-persist>=5.6.0,<6`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)