### PR TITLE
v5.9.0 — pressure-gated retention primitive (#209) + verify 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [5.9.0] — 2026-06-13
+
+### Added — pressure-gated retention primitive (CIRISPersist#209; CIRISLens#21)
+
+`trace_events` / `trace_llm_calls` grew unbounded post-cutover (the old `accord_traces` 90d retention didn't carry to the new write targets); the lens shipped a stopgap sweeper, but reaching into persist-owned tables from the lens is the wrong layer. This puts retention in the substrate, on `MaintenanceService` (which already owns `archive_expired`'s DELETEs).
+
+- **`set_retention` / `get_retention` / `list_retention` / `run_retention`** (both backends) + **V076 `retention_policies`** (durable across restarts). `RetentionPolicy` = `min_keep_secs` (the **sacred floor** — rows younger are never deleted), `time_column`, optional `pressure_trigger_bytes` / `pressure_target_bytes`, `interval_secs`.
+- **Pressure-gated sweep** (`run_retention`): below the trigger → **total no-op** (no churn); at/above → DELETE rows older than `min_keep`, reporting `exhausted` if still over target after sweeping all eligible. No pressure config → flat drop-after-`min_keep`. Size via `pg_database_size` (PG) / `page_count × page_size` (SQLite).
+- **Injection-safe**: `table_name` / `time_column` flow into `DELETE` SQL un-bindable, so both are gated through `validate_sql_identifier` (strict snake_case `table` / `schema.table`) before any write — and re-validated in the sweep. A non-identifier name is rejected at `set_retention`.
+
+**Scoped to v1 per #209** — the pressure-gated DELETE shape. Deferred: TimescaleDB `drop_chunks` / partition-drop (precise until-target reclaim — a row DELETE doesn't reclaim PG heap until VACUUM, so `exhausted` is best-effort under v1), fidelity-tiered `set_compaction` / `set_landmark_keep` (gated on #196 + the `keep_full_fidelity` CEG envelope), and the engine/PyO3 surface (`Engine.set_retention`) lens calls — a thin follow-up. Anchors the disk-pressure cluster (#148/#149).
+
+### Changed — CIRISVerify 5.1.3 → 5.2.0
+
+All three verify crate pins flip together (coherence: single `ciris-crypto` in the graph). 5.2.0 ships `TransportIdentityKeystore` (keyring-backed RNS transport identity + the import/migration primitives; CIRISVerify#68, unblocks CIRISEdge#99). Additive on persist's side — no API change; builds clean, full gate green.
+
+### Tests
+Both backends: retention CRUD + flat sweep (rows past the floor deleted, recent kept) + pressure-gated no-op below trigger + injection guard (sqlite); live-PG exercises `pg_database_size` + the validated-identifier DELETE on a temp table. Gate: fmt · clippy `-D warnings` ×2 · backend-less `-D warnings` · `--no-default-features` · cargo-deny · sqlite lib (792) · live-PG lib (732).
+
 ## [5.8.0] — 2026-06-13
 
 ### Added — consent-SLA watcher (CIRISPersist#146 Ask 3 complete; CEG §8.1.11.3 / §10.1.3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "5.8.0"
+version = "5.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -736,10 +736,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -750,7 +750,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/migrations/postgres/lens/V076__retention_policies.sql
+++ b/migrations/postgres/lens/V076__retention_policies.sql
@@ -1,0 +1,28 @@
+-- V076 — retention_policies: durable per-table retention config for the
+--        pressure-gated sweeper (CIRISPersist#209; CIRISLens#21).
+--        Postgres dialect. SQLite parity: sqlite/lens/V076.
+--
+-- trace_events / trace_llm_calls grew unbounded post-cutover (the old
+-- accord_traces 90d retention didn't carry to the new write targets).
+-- Lens shipped a stopgap DELETE sweeper, but reaching into persist-owned
+-- tables from the lens is the wrong layer — schema lifecycle belongs to
+-- the substrate. This table stores the operator's per-table policy so the
+-- sweeper (MaintenanceService::run_retention) is durable across restarts.
+--
+-- min_keep is the SACRED FLOOR — rows younger than it are never deleted,
+-- regardless of pressure. pressure_trigger/target (nullable) gate the
+-- sweep on pg_database_size: below trigger = no-op (no churn); at/above =
+-- sweep oldest rows past min_keep. NULL pressure cols = flat
+-- drop-after-min_keep. time_column is the ordering axis (the hypertable
+-- time column, default `ts`); it + table_name are validated as strict
+-- identifiers before reaching any SQL (identifiers can't be bound).
+
+CREATE TABLE IF NOT EXISTS cirislens.retention_policies (
+    table_name             TEXT PRIMARY KEY,
+    time_column            TEXT NOT NULL DEFAULT 'ts',
+    min_keep_secs          BIGINT NOT NULL,
+    pressure_trigger_bytes BIGINT,
+    pressure_target_bytes  BIGINT,
+    interval_secs          BIGINT NOT NULL,
+    updated_at             TIMESTAMPTZ NOT NULL
+);

--- a/migrations/sqlite/lens/V076__retention_policies.sql
+++ b/migrations/sqlite/lens/V076__retention_policies.sql
@@ -1,0 +1,28 @@
+-- V076 — retention_policies: durable per-table retention config for the
+--        pressure-gated sweeper (CIRISPersist#209; CIRISLens#21).
+--        SQLite dialect. Postgres parity: postgres/lens/V076.
+--
+-- trace_events / trace_llm_calls grew unbounded post-cutover (the old
+-- accord_traces 90d retention didn't carry to the new write targets).
+-- Lens shipped a stopgap DELETE sweeper, but reaching into persist-owned
+-- tables from the lens is the wrong layer — schema lifecycle belongs to
+-- the substrate. This table stores the operator's per-table policy so the
+-- sweeper (MaintenanceService::run_retention) is durable across restarts.
+--
+-- min_keep is the SACRED FLOOR — rows younger than it are never deleted,
+-- regardless of pressure. pressure_trigger/target (nullable) gate the
+-- sweep on db size: below trigger = no-op (no churn); at/above = sweep
+-- oldest rows past min_keep. NULL pressure cols = flat drop-after-min_keep.
+-- time_column is the ordering axis (the hypertable time column, default
+-- `ts`); it + table_name are validated as strict identifiers before they
+-- reach any SQL (no parameter binding for identifiers).
+
+CREATE TABLE retention_policies (
+    table_name             TEXT PRIMARY KEY,   -- validated identifier (schema.table)
+    time_column            TEXT NOT NULL DEFAULT 'ts',
+    min_keep_secs          INTEGER NOT NULL,   -- sacred floor
+    pressure_trigger_bytes INTEGER,            -- NULL = flat (no pressure gate)
+    pressure_target_bytes  INTEGER,            -- NULL = flat
+    interval_secs          INTEGER NOT NULL,   -- sweeper cadence (advisory; scheduler honours)
+    updated_at             TEXT NOT NULL       -- RFC-3339 UTC
+);

--- a/src/maintenance/mod.rs
+++ b/src/maintenance/mod.rs
@@ -41,7 +41,10 @@ pub mod sqlite;
 pub mod types;
 
 pub use service::MaintenanceService;
-pub use types::{ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, VacuumReport};
+pub use types::{
+    validate_sql_identifier, ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport,
+    RetentionPolicy, RetentionPolicyRow, RetentionReport, VacuumReport,
+};
 
 /// Maintenance-layer errors. Surface kinds map onto the PyO3 typed
 /// exception hierarchy via

--- a/src/maintenance/postgres.rs
+++ b/src/maintenance/postgres.rs
@@ -28,7 +28,10 @@ use std::time::Instant;
 use chrono::{DateTime, Utc};
 
 use super::service::MaintenanceService;
-use super::types::{ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, VacuumReport};
+use super::types::{
+    ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, RetentionPolicy,
+    RetentionPolicyRow, RetentionReport, VacuumReport,
+};
 use super::Error;
 use crate::store::postgres::PostgresBackend;
 
@@ -225,6 +228,171 @@ impl MaintenanceService for PostgresMaintenanceBackend {
             elapsed_ms,
         })
     }
+
+    // ── Retention (CIRISPersist#209) ───────────────────────────────
+
+    async fn set_retention(
+        &self,
+        table_name: String,
+        policy: RetentionPolicy,
+    ) -> Result<(), Error> {
+        crate::maintenance::validate_sql_identifier(&table_name)?;
+        crate::maintenance::validate_sql_identifier(&policy.time_column)?;
+        let client = self
+            .backend
+            .pool()
+            .get()
+            .await
+            .map_err(|e| Error::Backend(format!("retention pool: {e}")))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.retention_policies \
+                    (table_name, time_column, min_keep_secs, pressure_trigger_bytes, \
+                     pressure_target_bytes, interval_secs, updated_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6, now()) \
+                 ON CONFLICT (table_name) DO UPDATE SET \
+                    time_column = EXCLUDED.time_column, \
+                    min_keep_secs = EXCLUDED.min_keep_secs, \
+                    pressure_trigger_bytes = EXCLUDED.pressure_trigger_bytes, \
+                    pressure_target_bytes = EXCLUDED.pressure_target_bytes, \
+                    interval_secs = EXCLUDED.interval_secs, \
+                    updated_at = now()",
+                &[
+                    &table_name,
+                    &policy.time_column,
+                    &(policy.min_keep_secs as i64),
+                    &policy.pressure_trigger_bytes.map(|v| v as i64),
+                    &policy.pressure_target_bytes.map(|v| v as i64),
+                    &(policy.interval_secs as i64),
+                ],
+            )
+            .await
+            .map_err(|e| map_pg_error(e, "set_retention"))?;
+        Ok(())
+    }
+
+    async fn get_retention(&self, table_name: &str) -> Result<Option<RetentionPolicy>, Error> {
+        let client = self
+            .backend
+            .pool()
+            .get()
+            .await
+            .map_err(|e| Error::Backend(format!("retention pool: {e}")))?;
+        let row = client
+            .query_opt(
+                "SELECT time_column, min_keep_secs, pressure_trigger_bytes, \
+                    pressure_target_bytes, interval_secs \
+                 FROM cirislens.retention_policies WHERE table_name = $1",
+                &[&table_name],
+            )
+            .await
+            .map_err(|e| map_pg_error(e, "get_retention"))?;
+        Ok(row.map(|r| pg_row_to_retention_policy(&r)))
+    }
+
+    async fn list_retention(&self) -> Result<Vec<RetentionPolicyRow>, Error> {
+        let client = self
+            .backend
+            .pool()
+            .get()
+            .await
+            .map_err(|e| Error::Backend(format!("retention pool: {e}")))?;
+        let rows = client
+            .query(
+                "SELECT table_name, time_column, min_keep_secs, pressure_trigger_bytes, \
+                    pressure_target_bytes, interval_secs \
+                 FROM cirislens.retention_policies ORDER BY table_name",
+                &[],
+            )
+            .await
+            .map_err(|e| map_pg_error(e, "list_retention"))?;
+        Ok(rows
+            .iter()
+            .map(|r| RetentionPolicyRow {
+                table_name: r.get("table_name"),
+                policy: pg_row_to_retention_policy(r),
+            })
+            .collect())
+    }
+
+    async fn run_retention(&self, now: DateTime<Utc>) -> Result<Vec<RetentionReport>, Error> {
+        let policies = self.list_retention().await?;
+        let client = self
+            .backend
+            .pool()
+            .get()
+            .await
+            .map_err(|e| Error::Backend(format!("retention pool: {e}")))?;
+        let mut reports = Vec::with_capacity(policies.len());
+        for row in policies {
+            // Defense in depth — stored rows should already be valid, but
+            // these reach DELETE SQL un-bindable, so re-validate.
+            crate::maintenance::validate_sql_identifier(&row.table_name)?;
+            crate::maintenance::validate_sql_identifier(&row.policy.time_column)?;
+            let db_size: i64 = client
+                .query_one("SELECT pg_database_size(current_database())", &[])
+                .await
+                .map_err(|e| map_pg_error(e, "pg_database_size"))?
+                .get(0);
+            let db_size = db_size.max(0) as u64;
+            let cutoff = now - chrono::Duration::seconds(row.policy.min_keep_secs as i64);
+            let pressure_gated = row.policy.pressure_trigger_bytes.is_some()
+                && row.policy.pressure_target_bytes.is_some();
+            let do_sweep = match row.policy.pressure_trigger_bytes {
+                Some(trigger) if pressure_gated => db_size >= trigger,
+                _ => true, // flat schedule
+            };
+            let mut swept = false;
+            let mut rows_deleted = 0usize;
+            let mut exhausted = false;
+            if do_sweep {
+                // table_name + time_column are validated identifiers; cutoff is bound.
+                let sql = format!(
+                    "DELETE FROM {} WHERE {} < $1",
+                    row.table_name, row.policy.time_column
+                );
+                let n = client
+                    .execute(sql.as_str(), &[&cutoff])
+                    .await
+                    .map_err(|e| map_pg_error(e, "run_retention DELETE"))?;
+                rows_deleted = n as usize;
+                swept = true;
+                if let (true, Some(target)) = (pressure_gated, row.policy.pressure_target_bytes) {
+                    // Best-effort: a row DELETE doesn't reclaim heap until
+                    // VACUUM, so this measures the not-yet-reclaimed size —
+                    // precise targeting awaits the drop_chunks path (#209).
+                    let after: i64 = client
+                        .query_one("SELECT pg_database_size(current_database())", &[])
+                        .await
+                        .map_err(|e| map_pg_error(e, "pg_database_size"))?
+                        .get(0);
+                    exhausted = after.max(0) as u64 >= target;
+                }
+            }
+            reports.push(RetentionReport {
+                table_name: row.table_name,
+                swept,
+                rows_deleted,
+                db_size_bytes: db_size,
+                exhausted,
+            });
+        }
+        Ok(reports)
+    }
+}
+
+fn pg_row_to_retention_policy(r: &tokio_postgres::Row) -> RetentionPolicy {
+    RetentionPolicy {
+        min_keep_secs: r.get::<_, i64>("min_keep_secs").max(0) as u64,
+        time_column: r.get("time_column"),
+        pressure_trigger_bytes: r
+            .get::<_, Option<i64>>("pressure_trigger_bytes")
+            .map(|v| v.max(0) as u64),
+        pressure_target_bytes: r
+            .get::<_, Option<i64>>("pressure_target_bytes")
+            .map(|v| v.max(0) as u64),
+        interval_secs: r.get::<_, i64>("interval_secs").max(0) as u64,
+    }
 }
 
 #[cfg(test)]
@@ -244,6 +412,86 @@ mod tests {
         let arc = Arc::new(backend);
         let svc = PostgresMaintenanceBackend::new(arc.clone());
         Some((arc, svc))
+    }
+
+    /// CIRISPersist#209 — retention CRUD + flat sweep on live PG:
+    /// `pg_database_size` measured, the validated-identifier DELETE drops
+    /// rows past `min_keep`, recent rows kept. Uses a unique temp table
+    /// (cleaned up) to stay isolated on the shared serial DB.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_retention_crud_and_flat_sweep() {
+        let Some((arc, svc)) = fresh_backend().await else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let tbl = format!("ret_test_{}", Uuid::new_v4().simple());
+        let now = Utc::now();
+        {
+            let client = arc.pool().get().await.unwrap();
+            client
+                .execute(
+                    &format!("CREATE TABLE {tbl} (ts TIMESTAMPTZ NOT NULL, v INT)"),
+                    &[],
+                )
+                .await
+                .unwrap();
+            client
+                .execute(
+                    &format!("INSERT INTO {tbl} (ts, v) VALUES ($1, 1), ($2, 2)"),
+                    &[
+                        &(now - chrono::Duration::days(40)),
+                        &(now - chrono::Duration::hours(1)),
+                    ],
+                )
+                .await
+                .unwrap();
+        }
+        let pol = RetentionPolicy {
+            min_keep_secs: 30 * 86_400,
+            time_column: "ts".into(),
+            pressure_trigger_bytes: None,
+            pressure_target_bytes: None,
+            interval_secs: 3_600,
+        };
+        svc.set_retention(tbl.clone(), pol).await.unwrap();
+        assert_eq!(
+            svc.get_retention(&tbl)
+                .await
+                .unwrap()
+                .unwrap()
+                .min_keep_secs,
+            30 * 86_400
+        );
+        assert!(svc
+            .list_retention()
+            .await
+            .unwrap()
+            .iter()
+            .any(|r| r.table_name == tbl));
+
+        let reports = svc.run_retention(now).await.unwrap();
+        let r = reports.iter().find(|r| r.table_name == tbl).unwrap();
+        assert!(r.swept);
+        assert_eq!(
+            r.rows_deleted, 1,
+            "40d row past the 30d floor deleted; recent kept"
+        );
+        assert!(r.db_size_bytes > 0, "pg_database_size measured");
+
+        // cleanup — drop the temp table + its policy row.
+        let client = arc.pool().get().await.unwrap();
+        client
+            .execute(&format!("DROP TABLE {tbl}"), &[])
+            .await
+            .unwrap();
+        client
+            .execute(
+                "DELETE FROM cirislens.retention_policies WHERE table_name = $1",
+                &[&tbl],
+            )
+            .await
+            .unwrap();
     }
 
     /// v1.2.0 (CIRISPersist#48) PG Test 1 — VACUUM ANALYZE runs

--- a/src/maintenance/service.rs
+++ b/src/maintenance/service.rs
@@ -9,7 +9,10 @@ use std::future::Future;
 
 use chrono::{DateTime, Utc};
 
-use super::types::{ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, VacuumReport};
+use super::types::{
+    ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, RetentionPolicy,
+    RetentionPolicyRow, RetentionReport, VacuumReport,
+};
 use super::Error;
 
 /// v1.2.0 (CIRISPersist#48) — operation surface for substrate
@@ -73,4 +76,41 @@ pub trait MaintenanceService: Send + Sync {
     /// state is preserved (each step commits independently before
     /// the next runs).
     fn maintain(&self) -> impl Future<Output = Result<MaintenanceReport, Error>> + Send;
+
+    // ── Retention (CIRISPersist#209) ───────────────────────────────
+
+    /// Set (or update) the retention policy for `table_name`. Idempotent —
+    /// re-applying the same policy is a no-op upsert. `table_name` and
+    /// `policy.time_column` are validated as strict SQL identifiers (they
+    /// reach `DELETE` SQL un-bindable); an invalid one is rejected before
+    /// any write. v1 stores the policy; the pressure-gated DELETE sweep is
+    /// [`run_retention`](Self::run_retention). (The TimescaleDB
+    /// `drop_chunks` / partition-drop strategies and fidelity-tiered
+    /// compaction are deferred per #209.)
+    fn set_retention(
+        &self,
+        table_name: String,
+        policy: RetentionPolicy,
+    ) -> impl Future<Output = Result<(), Error>> + Send;
+
+    /// The stored policy for `table_name`, or `None`.
+    fn get_retention(
+        &self,
+        table_name: &str,
+    ) -> impl Future<Output = Result<Option<RetentionPolicy>, Error>> + Send;
+
+    /// All stored retention policies.
+    fn list_retention(&self)
+        -> impl Future<Output = Result<Vec<RetentionPolicyRow>, Error>> + Send;
+
+    /// Run one retention pass over every stored policy (§ pressure-gated
+    /// sweep). Per policy: measure db size; if pressure-gated and below the
+    /// trigger, no-op; otherwise DELETE rows older than `min_keep` (the
+    /// sacred floor) and report whether the pressure target was still
+    /// unmet (`exhausted`). Returns a [`RetentionReport`] per table. The
+    /// caller's scheduler decides cadence (honouring `interval_secs`).
+    fn run_retention(
+        &self,
+        now: DateTime<Utc>,
+    ) -> impl Future<Output = Result<Vec<RetentionReport>, Error>> + Send;
 }

--- a/src/maintenance/sqlite.rs
+++ b/src/maintenance/sqlite.rs
@@ -33,7 +33,10 @@ use parking_lot::Mutex;
 use rusqlite::Connection;
 
 use super::service::MaintenanceService;
-use super::types::{ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, VacuumReport};
+use super::types::{
+    ArchiveReport, ArchiveWindow, MaintenanceReport, PruneReport, RetentionPolicy,
+    RetentionPolicyRow, RetentionReport, VacuumReport,
+};
 use super::Error;
 
 /// v1.2.0 (CIRISPersist#48) — SQLite-backed
@@ -206,6 +209,156 @@ impl MaintenanceService for SqliteMaintenanceBackend {
             elapsed_ms,
         })
     }
+
+    // ── Retention (CIRISPersist#209) ───────────────────────────────
+
+    async fn set_retention(
+        &self,
+        table_name: String,
+        policy: RetentionPolicy,
+    ) -> Result<(), Error> {
+        crate::maintenance::validate_sql_identifier(&table_name)?;
+        crate::maintenance::validate_sql_identifier(&policy.time_column)?;
+        let conn = self.conn.clone();
+        let updated = Utc::now().to_rfc3339();
+        (move || -> Result<(), rusqlite::Error> {
+            let g = conn.lock();
+            g.execute(
+                "INSERT INTO retention_policies \
+                    (table_name, time_column, min_keep_secs, pressure_trigger_bytes, \
+                     pressure_target_bytes, interval_secs, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+                 ON CONFLICT(table_name) DO UPDATE SET \
+                    time_column = excluded.time_column, \
+                    min_keep_secs = excluded.min_keep_secs, \
+                    pressure_trigger_bytes = excluded.pressure_trigger_bytes, \
+                    pressure_target_bytes = excluded.pressure_target_bytes, \
+                    interval_secs = excluded.interval_secs, \
+                    updated_at = excluded.updated_at",
+                rusqlite::params![
+                    table_name,
+                    policy.time_column,
+                    policy.min_keep_secs as i64,
+                    policy.pressure_trigger_bytes.map(|v| v as i64),
+                    policy.pressure_target_bytes.map(|v| v as i64),
+                    policy.interval_secs as i64,
+                    updated,
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| map_sqlite_error(e, "set_retention"))
+    }
+
+    async fn get_retention(&self, table_name: &str) -> Result<Option<RetentionPolicy>, Error> {
+        let conn = self.conn.clone();
+        let name = table_name.to_owned();
+        (move || -> Result<Option<RetentionPolicy>, rusqlite::Error> {
+            let g = conn.lock();
+            match g.query_row(
+                "SELECT time_column, min_keep_secs, pressure_trigger_bytes, \
+                    pressure_target_bytes, interval_secs \
+                 FROM retention_policies WHERE table_name = ?1",
+                [&name],
+                sqlite_row_to_retention_policy,
+            ) {
+                Ok(p) => Ok(Some(p)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })()
+        .map_err(|e| map_sqlite_error(e, "get_retention"))
+    }
+
+    async fn list_retention(&self) -> Result<Vec<RetentionPolicyRow>, Error> {
+        let conn = self.conn.clone();
+        (move || -> Result<Vec<RetentionPolicyRow>, rusqlite::Error> {
+            let g = conn.lock();
+            let mut stmt = g.prepare(
+                "SELECT table_name, time_column, min_keep_secs, pressure_trigger_bytes, \
+                    pressure_target_bytes, interval_secs \
+                 FROM retention_policies ORDER BY table_name",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok(RetentionPolicyRow {
+                    table_name: row.get("table_name")?,
+                    policy: sqlite_row_to_retention_policy(row)?,
+                })
+            })?;
+            rows.collect()
+        })()
+        .map_err(|e| map_sqlite_error(e, "list_retention"))
+    }
+
+    async fn run_retention(&self, now: DateTime<Utc>) -> Result<Vec<RetentionReport>, Error> {
+        let policies = self.list_retention().await?;
+        let conn = self.conn.clone();
+        (move || -> Result<Vec<RetentionReport>, rusqlite::Error> {
+            let g = conn.lock();
+            let mut reports = Vec::with_capacity(policies.len());
+            for row in policies {
+                // Defense in depth — these reach DELETE SQL un-bindable.
+                if crate::maintenance::validate_sql_identifier(&row.table_name).is_err()
+                    || crate::maintenance::validate_sql_identifier(&row.policy.time_column).is_err()
+                {
+                    continue; // skip a malformed stored row rather than inject
+                }
+                // SQLite db size = page_count × page_size.
+                let page_count: i64 = g.query_row("PRAGMA page_count", [], |r| r.get(0))?;
+                let page_size: i64 = g.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+                let db_size = (page_count.max(0) as u64) * (page_size.max(0) as u64);
+                let cutoff =
+                    (now - chrono::Duration::seconds(row.policy.min_keep_secs as i64)).to_rfc3339();
+                let pressure_gated = row.policy.pressure_trigger_bytes.is_some()
+                    && row.policy.pressure_target_bytes.is_some();
+                let do_sweep = match row.policy.pressure_trigger_bytes {
+                    Some(trigger) if pressure_gated => db_size >= trigger,
+                    _ => true,
+                };
+                let mut swept = false;
+                let mut rows_deleted = 0usize;
+                let mut exhausted = false;
+                if do_sweep {
+                    // Validated identifiers; cutoff is bound.
+                    let sql = format!(
+                        "DELETE FROM {} WHERE {} < ?1",
+                        row.table_name, row.policy.time_column
+                    );
+                    rows_deleted = g.execute(&sql, rusqlite::params![cutoff])?;
+                    swept = true;
+                    if let (true, Some(target)) = (pressure_gated, row.policy.pressure_target_bytes)
+                    {
+                        let pc: i64 = g.query_row("PRAGMA page_count", [], |r| r.get(0))?;
+                        let ps: i64 = g.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+                        exhausted = (pc.max(0) as u64) * (ps.max(0) as u64) >= target;
+                    }
+                }
+                reports.push(RetentionReport {
+                    table_name: row.table_name,
+                    swept,
+                    rows_deleted,
+                    db_size_bytes: db_size,
+                    exhausted,
+                });
+            }
+            Ok(reports)
+        })()
+        .map_err(|e| map_sqlite_error(e, "run_retention"))
+    }
+}
+
+fn sqlite_row_to_retention_policy(row: &rusqlite::Row<'_>) -> rusqlite::Result<RetentionPolicy> {
+    Ok(RetentionPolicy {
+        min_keep_secs: row.get::<_, i64>("min_keep_secs")?.max(0) as u64,
+        time_column: row.get("time_column")?,
+        pressure_trigger_bytes: row
+            .get::<_, Option<i64>>("pressure_trigger_bytes")?
+            .map(|v| v.max(0) as u64),
+        pressure_target_bytes: row
+            .get::<_, Option<i64>>("pressure_target_bytes")?
+            .map(|v| v.max(0) as u64),
+        interval_secs: row.get::<_, i64>("interval_secs")?.max(0) as u64,
+    })
 }
 
 #[cfg(test)]
@@ -239,6 +392,101 @@ mod tests {
         // modern hardware; assert it ran (non-panic) rather than a
         // strict time floor. CI runners can clock 0ms.
         let _ = report.elapsed_ms;
+    }
+
+    /// CIRISPersist#209 — retention CRUD + the pressure-gated sweep: flat
+    /// drop deletes rows past `min_keep`; pressure-gated below the trigger
+    /// is a total no-op; an injection-shaped table name is rejected.
+    #[tokio::test]
+    async fn retention_crud_sweep_and_injection_guard() {
+        let (backend, svc) = fresh_backend().await;
+        let conn = backend.conn_handle();
+        {
+            let g = conn.lock();
+            g.execute_batch("CREATE TABLE ret_test (ts TEXT NOT NULL, v INTEGER);")
+                .unwrap();
+        }
+        let now = Utc::now();
+        let insert = |ts: DateTime<Utc>, v: i64| {
+            let g = conn.lock();
+            g.execute(
+                "INSERT INTO ret_test (ts, v) VALUES (?1, ?2)",
+                params![fmt(ts), v],
+            )
+            .unwrap();
+        };
+        insert(now - Duration::days(40), 1); // past the 30d floor
+        insert(now - Duration::days(20), 2); // within the floor
+        insert(now - Duration::hours(1), 3); // recent
+
+        let flat = RetentionPolicy {
+            min_keep_secs: 30 * 86_400,
+            time_column: "ts".into(),
+            pressure_trigger_bytes: None,
+            pressure_target_bytes: None,
+            interval_secs: 4 * 3_600,
+        };
+        svc.set_retention("ret_test".into(), flat).await.unwrap();
+        assert_eq!(
+            svc.get_retention("ret_test")
+                .await
+                .unwrap()
+                .unwrap()
+                .min_keep_secs,
+            30 * 86_400
+        );
+        assert_eq!(svc.list_retention().await.unwrap().len(), 1);
+
+        // Flat sweep: only the 40d row is past the 30d floor.
+        let reports = svc.run_retention(now).await.unwrap();
+        let r = reports.iter().find(|r| r.table_name == "ret_test").unwrap();
+        assert!(r.swept);
+        assert_eq!(r.rows_deleted, 1);
+        let remaining: i64 = {
+            let g = conn.lock();
+            g.query_row("SELECT COUNT(*) FROM ret_test", [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(remaining, 2, "20d + recent rows kept (sacred floor)");
+
+        // Pressure-gated below an unreachable trigger → no-op, even with
+        // min_keep 0 (the floor would otherwise drop everything).
+        let ten_tib: u64 = 10 * 1024 * 1024 * 1024 * 1024;
+        let gated = RetentionPolicy {
+            min_keep_secs: 0,
+            time_column: "ts".into(),
+            pressure_trigger_bytes: Some(ten_tib),
+            pressure_target_bytes: Some(ten_tib / 2),
+            interval_secs: 3_600,
+        };
+        svc.set_retention("ret_test".into(), gated).await.unwrap();
+        let reports2 = svc.run_retention(now).await.unwrap();
+        let r2 = reports2
+            .iter()
+            .find(|r| r.table_name == "ret_test")
+            .unwrap();
+        assert!(!r2.swept, "below pressure trigger → no churn");
+        let still: i64 = {
+            let g = conn.lock();
+            g.query_row("SELECT COUNT(*) FROM ret_test", [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(still, 2, "no deletions while below the trigger");
+
+        // Injection guard: a non-identifier table name is rejected.
+        assert!(svc
+            .set_retention(
+                "ret_test; DROP TABLE ret_test".into(),
+                RetentionPolicy {
+                    min_keep_secs: 0,
+                    time_column: "ts".into(),
+                    pressure_trigger_bytes: None,
+                    pressure_target_bytes: None,
+                    interval_secs: 1,
+                },
+            )
+            .await
+            .is_err());
     }
 
     /// v1.2.0 (CIRISPersist#48) Test 2 — archive_expired removes

--- a/src/maintenance/types.rs
+++ b/src/maintenance/types.rs
@@ -89,3 +89,92 @@ pub struct MaintenanceReport {
     /// per-call orchestration overhead.
     pub elapsed_ms: u32,
 }
+
+// ── Retention (CIRISPersist#209) ───────────────────────────────────
+
+/// v5.9.0 (CIRISPersist#209) — a per-table retention policy for the
+/// pressure-gated sweeper. `min_keep_secs` is the **sacred floor**: rows
+/// younger than it are never deleted, regardless of pressure. The pair
+/// `pressure_trigger_bytes` / `pressure_target_bytes` (both `Some` =
+/// pressure-gated; both `None` = flat drop-after-`min_keep`) gate the
+/// sweep on `pg_database_size` (SQLite: page_count × page_size): below
+/// trigger is a total no-op (no churn); at/above, the sweeper deletes
+/// rows older than `min_keep` aiming to get back under target. `interval_secs`
+/// is advisory cadence for the caller's scheduler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionPolicy {
+    /// Sacred floor — rows younger than this are never deleted.
+    pub min_keep_secs: u64,
+    /// The time column to order/cut on (the hypertable time column).
+    /// Default `"ts"`. Validated as a strict SQL identifier.
+    #[serde(default = "default_time_column")]
+    pub time_column: String,
+    /// High-water mark (bytes): sweep only when db size ≥ this. `None`
+    /// (with `pressure_target_bytes` `None`) = flat schedule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pressure_trigger_bytes: Option<u64>,
+    /// Low-water mark (bytes): sweep aims to get db size below this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pressure_target_bytes: Option<u64>,
+    /// Advisory sweeper cadence (seconds). The substrate doesn't schedule
+    /// itself; the caller honours this.
+    pub interval_secs: u64,
+}
+
+fn default_time_column() -> String {
+    "ts".to_string()
+}
+
+/// A stored retention policy together with the table it governs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionPolicyRow {
+    /// The (validated-identifier) table the policy applies to.
+    pub table_name: String,
+    /// The policy.
+    pub policy: RetentionPolicy,
+}
+
+/// v5.9.0 (CIRISPersist#209) — per-table outcome of one
+/// [`run_retention`](super::MaintenanceService::run_retention) pass.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionReport {
+    /// The table swept.
+    pub table_name: String,
+    /// Did a DELETE run this pass? `false` = no-op (pressure-gated and
+    /// below the trigger).
+    pub swept: bool,
+    /// Rows deleted this pass.
+    pub rows_deleted: usize,
+    /// DB size (bytes) observed at the start of this table's pass.
+    pub db_size_bytes: u64,
+    /// Pressure-gated but still ≥ target after sweeping everything older
+    /// than `min_keep` — the operator must lower `min_keep` or raise the
+    /// cap (CEG §8.1.11.3-style observability; the "RetentionExhausted"
+    /// condition). Note: a row-`DELETE` doesn't reclaim Postgres heap
+    /// until VACUUM, so this is best-effort under the v1 DELETE strategy;
+    /// precise until-target reclaim awaits the `drop_chunks`/partition
+    /// path (deferred per #209).
+    pub exhausted: bool,
+}
+
+/// Reject anything that isn't a strict `snake_case` SQL identifier
+/// (optionally `schema.table`). **Security-critical**: `table_name` /
+/// `time_column` are interpolated into `DELETE` SQL (identifiers can't be
+/// bound), so this is the injection gate — no quotes, whitespace,
+/// semicolons, or comment markers can pass.
+pub fn validate_sql_identifier(ident: &str) -> Result<(), super::Error> {
+    fn part_ok(p: &str) -> bool {
+        let mut chars = p.chars();
+        matches!(chars.next(), Some(c) if c.is_ascii_lowercase() || c == '_')
+            && p.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    }
+    let parts: Vec<&str> = ident.split('.').collect();
+    if (1..=2).contains(&parts.len()) && parts.iter().all(|p| part_ok(p)) {
+        Ok(())
+    } else {
+        Err(super::Error::Backend(format!(
+            "invalid SQL identifier {ident:?} (expected snake_case `table` or `schema.table`)"
+        )))
+    }
+}


### PR DESCRIPTION
## #209 — substrate-owned retention
`trace_events` / `trace_llm_calls` grew unbounded post-cutover; the lens shipped a stopgap, but table lifecycle belongs to the substrate. This lands retention on `MaintenanceService` (which already owns `archive_expired`'s DELETEs).

- **`set_retention` / `get_retention` / `list_retention` / `run_retention`** (both backends) + **V076 `retention_policies`** (durable). `RetentionPolicy`: `min_keep_secs` (the **sacred floor**), `time_column`, optional `pressure_trigger_bytes`/`pressure_target_bytes`, `interval_secs`.
- **Pressure-gated sweep**: below trigger → **no-op** (no churn); at/above → DELETE rows past `min_keep`, `exhausted` if still over target. No pressure config → flat drop. Size via `pg_database_size` / `page_count×page_size`.
- **Injection-safe**: `table_name`/`time_column` reach `DELETE` un-bindable, so both pass `validate_sql_identifier` (strict `table`/`schema.table`) before any write + re-validated in the sweep. Non-identifier names rejected at `set_retention`.

**Scoped to v1 per the issue** (pressure-gated DELETE). Deferred: TimescaleDB `drop_chunks`/partition precise reclaim (a row DELETE doesn't reclaim PG heap until VACUUM, so `exhausted` is best-effort under v1 — flagged in the code + report doc), fidelity-tiered `set_compaction`/`set_landmark_keep` (gated on #196 + the `keep_full_fidelity` CEG envelope), and the `Engine.set_retention` PyO3 surface lens calls (thin follow-up). Anchors the disk-pressure cluster (#148/#149).

## Verify 5.1.3 → 5.2.0
All three pins flipped together (coherence: single `ciris-crypto`). 5.2.0 ships `TransportIdentityKeystore` (CIRISVerify#68, unblocks CIRISEdge#99). Additive on persist's side — no API change. Folded into this cut per "next pin."

## Tests
Both backends: retention CRUD + flat sweep + pressure-gated no-op + injection guard (sqlite, clean DB); live-PG exercises `pg_database_size` + the validated DELETE on a temp table. fmt · clippy `-D warnings` ×2 · backend-less `-D warnings` · `--no-default-features` · cargo-deny · sqlite (792) · live-PG (732). Graph coherent (single `ciris-crypto` @ 5.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)