### PR TITLE
v6.0.1 — pyo3 0.28→0.29 re-land (#201/#216); edge unblocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [6.0.1] — 2026-06-13
+
+### Changed (BREAKING — dependency ABI) — pyo3 0.28 → 0.29 re-land; the 0.29 line resumes (CIRISPersist#201, #216)
+
+The pyo3 0.29 lockstep, deferred since the 6.0.0 cut was reverted (edge was blocked on its own 0.29 migration), now lands as **6.0.1** — edge cleared its block (cold-migration probe ship-ready, CIRISEdge#99/v2.5.0). This re-applies the 0.29 migration **on top of the current 5.x line**, so 6.0.1 = everything through **5.9.0** (shared-instance leases, hard_case emission + consent observability, consent-SLA watcher, retention, **verify 5.2.0**) **plus** pyo3 0.29 — a single coherent cut, not a forward-port of substrate onto the stale 6.0.0 branch.
+
+- **pyo3 0.28 → 0.29**: the 7 `PyCapsule::new` → `new_with_value` exporters + the `new_with_destructor` → `new_with_value_and_destructor` executor capsule (the name arg is `&'static CStr` in 0.29 → `c"…"` literals). MSRV 1.75 → **1.83** (pyo3 0.29's floor; `clippy.toml` moves in lockstep), which surfaced the `clippy::unnecessary_map_or` → `is_none_or` autofixes.
+- **RUSTSEC-2026-0176 + 0177 genuinely cleared** — both are pyo3 `< 0.29`; the v5.5.2 `deny.toml` ignores are **removed**, not merely unneeded. cargo-deny passes with no pyo3 ignores.
+
+**6.0.0 is the tombstone** (cut + published + yanked the same day during the first attempt; PyPI burns the filename). **6.0.1 is the live 0.29 cut.** Cohabitation firewall holds: edge ≤2.x pins `ciris-persist<6`, so a 6.x wheel is excluded from any 0.28-edge env; edge 2.5.0 opts in with `>=6.0.1,<7` + its own pyo3 0.29; lens-core follows. The **5.x line stays published (5.9.0)** for any 0.28 consumer still mid-transition.
+
+### Tests
+Full gate under pyo3 0.29: build (pyo3,server) · fmt · clippy `-D warnings` ×2 · backend-less `-D warnings` · `--no-default-features` · cargo-deny (advisories ok, **no pyo3 ignores**) · sqlite lib (792) · live-PG lib (732). The win7 build-std wheel lane already targets 0.29; the capsule runtime smoke covered the exporters on the original 6.0.0 cut.
+
 ## [5.9.0] — 2026-06-13
 
 ### Added — pressure-gated retention primitive (CIRISPersist#209; CIRISLens#21)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ciris-persist"
-version = "5.9.0"
+version = "6.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
 repository = "https://github.com/CIRISAI/CIRISPersist"
 authors = ["CIRIS AI <hello@ciris.ai>"]
-rust-version = "1.75"
+rust-version = "1.83"
 publish = false
 
 # Status: Phase 1 in flight (TDD + MDD; see MISSION.md).
@@ -600,7 +600,7 @@ url     = { version = "2.5", optional = true }
 # it is a separate top-level crate feature (`extension-module`) that
 # maturin turns on for the wheel build. See the `[features]` section.
 # This keeps `cargo test --features pyo3` linking libpython normally.
-pyo3 = { version = "0.28", features = ["abi3-py310"], optional = true }
+pyo3 = { version = "0.29", features = ["abi3-py310"], optional = true }
 
 # v0.6.0 (CIRISPersist#19) — post-ingest filter pipeline deps.
 # Light deps (regex) gate `scrub` + `extract`; heavy ML deps below

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,7 +10,7 @@
 # Pinning to our declared MSRV (`Cargo.toml`'s `rust-version`)
 # means clippy applies the lint set as it was at that toolchain,
 # even when the runner is newer.
-msrv = "1.75"
+msrv = "1.83"
 
 # We don't override `cognitive-complexity-threshold` etc. — clippy
 # defaults are reasonable for this crate's size. If a future

--- a/deny.toml
+++ b/deny.toml
@@ -77,17 +77,8 @@ ignore = [
     # unmaintained ignores above. Re-evaluate when candle/ort upgrade.
     "RUSTSEC-2025-0119",  # number_prefix unmaintained — transitive via indicatif → hf-hub
     "RUSTSEC-2024-0436",  # paste unmaintained — transitive via candle / ort macros
-
-    # v5.5.2 — two pyo3 0.28.x advisories, both fixed in pyo3 0.29.0, both
-    # newly published (began failing the cargo-deny gate). Both vulnerable
-    # paths are UNREACHABLE in persist (verified by grep): persist's FFI
-    # never uses `new_closure`/`PyCFunction::new`, and it only *builds*
-    # PyLists (`PyList::empty` + append) — it never `.nth()`/`.nth_back()`/
-    # `.skip()`-iterates an incoming Python list/tuple. Lifting these
-    # requires the pyo3 0.28→0.29 breaking-API migration, tracked
-    # separately; ignored here because neither is exploitable in persist.
-    "RUSTSEC-2026-0176",  # pyo3 nth/nth_back OOB read on PyList/PyTuple — adapter unused by persist
-    "RUSTSEC-2026-0177",  # pyo3 new_closure Sync bound — API unused by persist
+    # v6.0.1 — RUSTSEC-2026-0176 + 0177 (pyo3 < 0.29) genuinely CLEARED by
+    # the 0.29 re-land; the v5.5.2 ignores are removed, not just unneeded.
 ]
 
 [sources]

--- a/src/federation/location.rs
+++ b/src/federation/location.rs
@@ -135,7 +135,7 @@ pub fn member_in_geographic_constraint(
 ) -> bool {
     member_proofs.iter().any(|p| {
         p.withdrawn_at.is_none()
-            && p.valid_until.map_or(true, |vu| vu > now)
+            && p.valid_until.is_none_or(|vu| vu > now)
             && h3_cell_contained(&p.cell_id, constraint_cell)
     })
 }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -458,7 +458,7 @@ pub trait FederationDirectory: Send + Sync {
         Ok(self
             .lookup_identity_for_occurrence(occurrence_key_id)
             .await?
-            .filter(|o| o.valid_until.map_or(true, |vu| vu > now))
+            .filter(|o| o.valid_until.is_none_or(|vu| vu > now))
             .and_then(|o| o.encryption_pubkeys))
     }
 
@@ -1477,7 +1477,7 @@ pub trait FederationDirectory: Send + Sync {
             .into_iter()
             .filter(|a| a.attesting_key_id == subject_key_id)
             .filter(|a| envelope_dimension(a).is_some_and(|d| d.starts_with("consent:state:")))
-            .filter(|a| a.expires_at.map_or(true, |exp| exp > now))
+            .filter(|a| a.expires_at.is_none_or(|exp| exp > now))
             .max_by_key(|a| a.asserted_at);
         Ok(match latest.as_ref().and_then(envelope_dimension) {
             Some(d) if d.starts_with("consent:state:granted") => hard_case::ConsentState::Granted,

--- a/src/ffi/executor_capsule.rs
+++ b/src/ffi/executor_capsule.rs
@@ -305,27 +305,30 @@ pub fn build_capsule_with_destructor<'py>(
     let executor = build_persist_executor(runtime);
     let boxed_executor: Box<AsyncExecutor> = Box::new(executor);
     let raw: *mut AsyncExecutor = Box::into_raw(boxed_executor);
-    let name = std::ffi::CString::new("ciris_persist::executor_capsule_v1")
-        .expect("static name has no NUL bytes");
     // SAFETY: `raw` was just produced by `Box::into_raw`; we hand it
     // to PyCapsule, which calls the destructor exactly once at GC.
     // The destructor reconstructs the Box (recovering ownership)
     // before invoking vtable.drop on the inner data pointer.
     unsafe {
-        PyCapsule::new_with_destructor(py, raw as usize, Some(name), |raw_usize, _ctx| {
-            let raw_ptr = raw_usize as *mut AsyncExecutor;
-            if raw_ptr.is_null() {
-                return;
-            }
-            // SAFETY: raw_ptr is the pointer we Box::into_raw'd. It
-            // has not been observed by anyone else (the only path
-            // into this destructor is PyCapsule's single-fire GC).
-            let executor: Box<AsyncExecutor> = Box::from_raw(raw_ptr);
-            // Dispatch through the vtable's drop function (lives
-            // inside persist's .so; decrements the Arc<Runtime>).
-            (executor.vtable.drop)(executor.data);
-            // Box deallocates the AsyncExecutor envelope here.
-        })
+        PyCapsule::new_with_value_and_destructor(
+            py,
+            raw as usize,
+            c"ciris_persist::executor_capsule_v1",
+            |raw_usize, _ctx| {
+                let raw_ptr = raw_usize as *mut AsyncExecutor;
+                if raw_ptr.is_null() {
+                    return;
+                }
+                // SAFETY: raw_ptr is the pointer we Box::into_raw'd. It
+                // has not been observed by anyone else (the only path
+                // into this destructor is PyCapsule's single-fire GC).
+                let executor: Box<AsyncExecutor> = Box::from_raw(raw_ptr);
+                // Dispatch through the vtable's drop function (lives
+                // inside persist's .so; decrements the Arc<Runtime>).
+                (executor.vtable.drop)(executor.data);
+                // Box deallocates the AsyncExecutor envelope here.
+            },
+        )
     }
 }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -17826,11 +17826,10 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => b.clone(),
         };
-        let name = std::ffi::CString::new("ciris_persist::federation_directory")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, arc, Some(name)).map_err(|e| {
-            PyErr::new::<LensQueryError, _>(format!("federation_directory_capsule: {e}"))
-        })
+        pyo3::types::PyCapsule::new_with_value(py, arc, c"ciris_persist::federation_directory")
+            .map_err(|e| {
+                PyErr::new::<LensQueryError, _>(format!("federation_directory_capsule: {e}"))
+            })
     }
 
     /// v2.7.0 (CIRISPersist#109) — cross-module accessor for the
@@ -17856,9 +17855,7 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
         };
-        let name = std::ffi::CString::new("ciris_persist::outbound_queue")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, dispatch, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, dispatch, c"ciris_persist::outbound_queue")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_capsule: {e}")))
     }
 
@@ -17881,9 +17878,7 @@ impl PyEngine {
             pqc_signer: self.local_signer.as_ref().and_then(|ls| ls.pqc_signer()),
             key_id: self.signer_key_id.clone(),
         };
-        let name = std::ffi::CString::new("ciris_persist::keyring_signer")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, handle, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, handle, c"ciris_persist::keyring_signer")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("keyring_signer_capsule: {e}")))
     }
 
@@ -17950,9 +17945,7 @@ impl PyEngine {
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
         let handle: tokio::runtime::Handle = self.runtime.handle().clone();
-        let name = std::ffi::CString::new("ciris_persist::runtime_handle")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, handle, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, handle, c"ciris_persist::runtime_handle")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("runtime_handle_capsule: {e}")))
     }
 
@@ -18077,9 +18070,7 @@ impl PyEngine {
             #[cfg(feature = "sqlite")]
             BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
         };
-        let name = std::ffi::CString::new("ciris_persist::blob_storage")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, dispatch, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, dispatch, c"ciris_persist::blob_storage")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("blob_storage_capsule: {e}")))
     }
 
@@ -18109,9 +18100,7 @@ impl PyEngine {
         let Some(local_signer) = self.local_signer.clone() else {
             return Err(PyValueError::new_err("local_signer_unavailable"));
         };
-        let name = std::ffi::CString::new("ciris_persist::local_signer")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, local_signer, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, local_signer, c"ciris_persist::local_signer")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("local_signer_capsule: {e}")))
     }
 
@@ -18145,9 +18134,7 @@ impl PyEngine {
         let scoring = gate
             .map(|g| g.scoring_arc())
             .ok_or_else(|| PyValueError::new_err("trust_scoring_unavailable"))?;
-        let name = std::ffi::CString::new("ciris_persist::trust_scoring")
-            .expect("static name has no NUL bytes");
-        pyo3::types::PyCapsule::new(py, scoring, Some(name))
+        pyo3::types::PyCapsule::new_with_value(py, scoring, c"ciris_persist::trust_scoring")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("trust_scoring_capsule: {e}")))
     }
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -569,7 +569,7 @@ impl Backend for MemoryBackend {
             .events
             .values()
             .filter(|(eid, row)| {
-                *eid > after_event_id && agent_id_hash.map_or(true, |h| row.agent_id_hash == h)
+                *eid > after_event_id && agent_id_hash.is_none_or(|h| row.agent_id_hash == h)
             })
             .map(|(eid, row)| (*eid, row.clone()))
             .collect();
@@ -1317,7 +1317,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_organizations
             .values()
-            .filter(|o| since.map_or(true, |s| o.asserted_at > s))
+            .filter(|o| since.is_none_or(|s| o.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1338,7 +1338,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_org_memberships
             .values()
-            .filter(|m| since.map_or(true, |s| m.asserted_at > s))
+            .filter(|m| since.is_none_or(|s| m.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1359,7 +1359,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_partner_records
             .values()
-            .filter(|p| since.map_or(true, |s| p.asserted_at > s))
+            .filter(|p| since.is_none_or(|s| p.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -1380,7 +1380,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         let mut rows: Vec<_> = state
             .federation_partner_records
             .values()
-            .filter(|p| since.map_or(true, |s| p.asserted_at > s))
+            .filter(|p| since.is_none_or(|s| p.asserted_at > s))
             .cloned()
             .collect();
         rows.sort_by(|a, b| {
@@ -2604,20 +2604,20 @@ impl crate::outbound::OutboundQueue for MemoryBackend {
             .outbound_queue
             .values()
             .filter(|r| {
-                filter.status.map_or(true, |s| r.status == s)
+                filter.status.is_none_or(|s| r.status == s)
                     && filter
                         .destination_key_id
                         .as_ref()
-                        .map_or(true, |d| r.destination_key_id == *d)
+                        .is_none_or(|d| r.destination_key_id == *d)
                     && filter
                         .sender_key_id
                         .as_ref()
-                        .map_or(true, |s| r.sender_key_id == *s)
+                        .is_none_or(|s| r.sender_key_id == *s)
                     && filter
                         .message_type
                         .as_ref()
-                        .map_or(true, |m| r.message_type == *m)
-                    && filter.enqueued_after.map_or(true, |t| r.enqueued_at >= t)
+                        .is_none_or(|m| r.message_type == *m)
+                    && filter.enqueued_after.is_none_or(|t| r.enqueued_at >= t)
             })
             .cloned()
             .collect();


### PR DESCRIPTION
The pyo3 0.29 lockstep resumes — **edge cleared its block** (CIRISEdge#99 / v2.5.0 cold-migration probe ship-ready). Closes #201, resolves #216.

## Approach (note: #216's scope is superseded)
#216 was filed to "forward-port v5.6.0→v5.8.0 substrate onto v6.0.0 + bump verify to v5.1.3." But main is now **5.9.0 with verify 5.2.0** — already past all of that. So this is the **reverse, cleaner** direction: re-apply the small **pyo3 0.29 migration onto current main**, giving 6.0.1 = everything through 5.9.0 (shared-instance, hard_case + consent observability, consent-SLA watcher, retention, **verify 5.2.0**) **+ pyo3 0.29**, in one coherent cut.

## What
- **pyo3 0.28 → 0.29**: 7 `PyCapsule::new` → `new_with_value` + the executor `new_with_destructor` → `new_with_value_and_destructor` (`&'static CStr` names → `c"…"`). MSRV 1.75 → **1.83** (Cargo.toml + clippy.toml); `is_none_or` autofixes from the raised floor.
- **RUSTSEC-2026-0176/0177 genuinely cleared** (pyo3 `<0.29`) — the v5.5.2 deny ignores removed, not just unneeded.

## Versioning / firewall
6.0.0 = tombstone (yanked); **6.0.1 = live 0.29 cut**. Edge ≤2.x's `<6` pin excludes 6.x from 0.28 envs (firewall holds); edge 2.5.0 opts in with `>=6.0.1,<7` + its own pyo3 0.29; lens-core follows; the family-wide RUSTSEC-2026-0176 ignore lifts. **5.9.0 stays published** as the last 0.28 line for consumers mid-transition.

## Tests
Full gate under pyo3 0.29: build · fmt · clippy `-D warnings` ×2 · backend-less `-D warnings` · `--no-default-features` · cargo-deny (advisories ok, **no pyo3 ignores**) · sqlite (792) · live-PG (732). The win7 build-std lane already targets 0.29.

I'll post the shipped contract on #216 + notify CIRISEdge#99 once 6.0.1 publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)