### PR TITLE
Engine::with_hardware_signer — from-scratch TPM federation signer ctor (#220)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "6.5.0"
+version = "6.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3565,6 +3565,54 @@ mod tests {
         );
     }
 
+    /// v6.6.0 (CIRISPersist#220) — `with_hardware_signer` is the
+    /// from-scratch counterpart to `from_shared`: it RUNS migrations (via
+    /// `build_backend`, unlike `from_shared`) and stores the supplied
+    /// `Arc<dyn HardwareSigner>` directly with `local_signer: None`.
+    /// Successful construction proves migrations ran (`build_backend`
+    /// propagates migration errors); the post-construction directory read
+    /// proves the schema is live; and `sign_hybrid` being unavailable
+    /// proves the hardware-only signer shape (mirrors `from_shared`).
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn with_hardware_signer_migrates_and_is_hardware_only() {
+        // A host obtains an Arc<dyn HardwareSigner> from ciris-keyring; here
+        // we synthesize one the way `with_signer` does (adapter over a
+        // LocalSigner) and hand it to the from-scratch hardware ctor.
+        let seed = Engine::with_signer(test_signer(), "sqlite::memory:")
+            .await
+            .expect("seed engine");
+        let hw: Arc<dyn HardwareSigner> = seed.signer().clone();
+
+        let engine = Engine::with_hardware_signer(hw, "sqlite::memory:")
+            .await
+            .expect("with_hardware_signer constructs + migrates");
+
+        // Migrations ran: a directory read hits a live table (Ok(None)),
+        // not a "no such table" error — the differentiator from from_shared.
+        if let BackendDispatch::Sqlite(b) = engine.backend() {
+            let found = crate::federation::FederationDirectory::lookup_public_key(
+                b.as_ref(),
+                "nonexistent-key",
+            )
+            .await
+            .expect("schema is live");
+            assert!(found.is_none());
+        } else {
+            panic!("expected sqlite backend");
+        }
+
+        // Hardware-only shape: no LocalSigner → sign_hybrid unavailable.
+        let err = engine
+            .sign_hybrid(b"any message")
+            .await
+            .expect_err("hardware signer has no LocalSigner");
+        assert!(
+            matches!(err, SignError::LocalSignerUnavailable),
+            "got: {err:?}"
+        );
+    }
+
     // ── v2.13.0 (CIRISPersist#113) — detection-events facade + edge
     //    read + subscribe change-feed (LensCore #15 / #19 / #20 / #21 / #25)
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -320,6 +320,34 @@ impl Engine {
         Self::with_signer(signer, dsn).await
     }
 
+    /// v6.6.0 (CIRISPersist#220) — construct a fresh Engine (connect + run
+    /// migrations, exactly like [`Engine::with_signer`]) whose federation
+    /// signing identity is an externally-supplied [`HardwareSigner`] — a TPM /
+    /// Secure-Enclave / StrongBox key obtained via
+    /// [`ciris_keyring::get_platform_signer`] (which itself falls back to a
+    /// software signer when no hardware is present). Unlike `with_signer`, no
+    /// raw seed is read into the process when the signer is hardware-backed.
+    ///
+    /// `local_signer` is `None` (as in [`Engine::from_shared`]), so
+    /// [`Engine::sign_hybrid`] is unavailable on Engines built this way — a
+    /// hardware signer performs its own signing through the [`HardwareSigner`]
+    /// trait. This is the from-scratch counterpart to `from_shared` (which is
+    /// cohabitation-only and runs no migrations).
+    pub async fn with_hardware_signer(
+        signer: Arc<dyn HardwareSigner>,
+        dsn: &str,
+    ) -> Result<Self, EngineError> {
+        let backend = build_backend(dsn).await?;
+        Ok(Engine {
+            backend,
+            signer,
+            local_signer: None,
+            replication_config: None,
+            #[cfg(feature = "cirisnode")]
+            multimedia_config: Arc::new(std::sync::RwLock::new(None)),
+        })
+    }
+
     /// Borrow the public [`BackendDispatch`] enum the Engine
     /// composes. Consumers `match` on the variant and call the
     /// concrete backend's trait methods (`FederationDirectory`,


### PR DESCRIPTION
Closes #220.

Adds the from-scratch hardware-signer constructor the fabric node needs to take TPM custody of the **federation signing key**.

## Change
```rust
impl Engine {
    pub async fn with_hardware_signer(
        signer: Arc<dyn HardwareSigner>,
        dsn: &str,
    ) -> Result<Self, EngineError>;
}
```
Mirrors `with_signer` (`build_backend` → run migrations) but stores the supplied `Arc<dyn HardwareSigner>` **directly** (no `LocalSignerHardwareAdapter`; `local_signer: None`, as in `from_shared`). It is the from-scratch counterpart to `from_shared` (which is cohabitation-only and runs no migrations).

A host does:
```rust
let hw = ciris_keyring::get_platform_signer(key_id)?;   // TPM/SE/StrongBox, software fallback
let engine = Engine::with_hardware_signer(Arc::from(hw), &dsn).await?;
```
so the signing key need never be read into the process when hardware is present.

## Scope / safety
- **Additive.** `with_signer` (software seed) and `with_signer_arcs` are unchanged. `sign_hybrid` is unavailable on Engines built this way (`local_signer: None`) — a hardware signer signs through the `HardwareSigner` trait, same as the existing `from_shared` path.
- Reuses the existing `Engine.signer: Arc<dyn HardwareSigner>` field, the `from_shared` pattern, and the `secrets/hardware.rs` hardware posture already in persist.
- `version` 6.5.0 → **6.6.0** (minor; additive API).

## Verification
- `cargo build --features postgres,sqlite` — ✅ clean.

## Refs / consumer
- **CIRISServer** (the fabric node) consumes this to give its shared `Engine` a TPM-backed federation identity — the load-bearing half of hardware key custody (the transport-identity half already shipped via CIRISVerify#68 / CIRISEdge#99). Lands in CIRISServer once this tags **v6.6.0** and the family (edge / lens-core) co-bumps so the graph resolves to one persist version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
