### PR TITLE
v9.0.1 — re-pin CIRISVerify v6.0.0 → v6.1.1 (additive minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.0.1] — 2026-06-18
+
+### Changed — re-pin CIRISVerify v6.0.0 → v6.1.1 (additive minor)
+
+- All six git-tag verify crates (`ciris-keyring` / `ciris-verify-core` / `ciris-crypto`, incl. the tpm/ios/android target pins) flipped in lockstep per the coherence rule; `version = "6"` unchanged (6.1.1 satisfies it). v6.1.x is additive for persist — CIRISVerify adds a producer-side `delegate` CLI, build-manifest-as-CEG-Contribution, and a YubiKey (pkcs11) granter path; persist consumes none of those (it uses `verify_hybrid` / `canonical` / `transparency` / `ciris-crypto` / `ciris-keyring`, unchanged). No persist code change; no migration; no version-string flip.
+
 ## [9.0.0] — 2026-06-18
 
 **Constitution-alignment major cut** — aligned to the CIRIS Constitution 0.1.5 (`CIRISAI/CIRISRegistry@FSD/CIRIS_Constitution`). Bundles the CIRISVerify v6.0.0 re-pin with the substrate-binding clauses surfaced by a full constitution→persist alignment pass. The MAJOR bump is earned by the breaking changes below (PQC-mandatory federation-tier ingest + the node-agency admission rejection).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.0.0"
+version = "9.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -475,14 +475,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -736,10 +736,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -750,7 +750,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.0.0", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.1.1", version = "6", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
## What
Re-pins all six git-tag CIRISVerify crates (`ciris-keyring` / `ciris-verify-core` / `ciris-crypto`, incl. the tpm/ios/android target pins) from **v6.0.0 → v6.1.1**, in lockstep per the crate-coherence rule. `version = "6"` is unchanged (6.1.1 satisfies the caret). Cargo version → **9.0.1**.

## Why it's safe (additive minor)
v6.1.x is producer-side-only for CIRISVerify: a `delegate` CLI, build-manifest-as-CEG-Contribution, and a YubiKey (pkcs11) granter path. **persist consumes none of those** — it uses `verify_hybrid` / `canonical` / `transparency` / `ciris-crypto` / `ciris-keyring`, all unchanged across 6.0→6.1. **No persist code change, no migration, no version-string flip.**

## Gate (local, pg16 + sqlite)
- `cargo build` / `clippy --all-targets -D warnings` / `fmt --check` — clean
- `cargo nextest run --all-targets --test-threads=1` (full features incl. cirisnode) — **1504 passed, 0 failed**
- **No-backend `-D warnings` combos** (the class that broke v9.0.0's darwin job) re-verified clean: `server`-only, `postgres,pyo3,server`, `sqlite`-only.

Follows the v9.0.0 constitution-alignment release; this is a clean dependency-coherence bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)