### PR TITLE
v9.0.3 — wheel Requires-Dist ciris-verify → >=6.0.0,<7 (metadata-only; closes #241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.0.3] — 2026-06-19
+
+### Fixed — wheel `Requires-Dist` ciris-verify range tracks the v6 Cargo pin (CIRISPersist#241)
+
+- The published v9.0.2 wheel declared `Requires-Dist: ciris-verify <6,>=5.0.0` while its Cargo deps pin `ciris-verify` v6.2.0 (since the v9.0.0 cut moved to the v6 family). The Rust side was consistent; the **Python wheel metadata was stale** — so sibling-repo cohabitation jobs (`pip install ciris-persist==9.0.2 ciris-verify==6.2.0`) hit a hard pip resolution conflict. Metadata-only fix: `pyproject.toml` `[project.dependencies]` floor bumped **`>=5.0.0,<6` → `>=6.0.0,<7`**, restoring the family-floor discipline (the Python wheel `Requires-Dist` tracks the Cargo verify pin). No Rust code change, no migration, no Cargo dep change. Same drift class as the v2.0.1 / v4.10.0 `Requires-Dist` corrections.
+
 ## [9.0.2] — 2026-06-18
 
 ### Changed — re-pin CIRISVerify v6.1.1 → v6.2.0 (additive minor)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.0.2"
+version = "9.0.3"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,19 @@ classifiers = [
 # Python binding, CIRISVerify#61) into its matrix alongside persist.
 # Floor is v5.0.0 to require the JCS-cutover line, coherent with the
 # Rust pin.
+#
+# v9.0.3 (CIRISPersist#241 metadata-only retag) — bumped floor to v6.0.0
+# (`<7`). The Rust-side Cargo.toml moved to ciris-verify-core/keyring/
+# crypto v6.x in the v9.0.0 cut (re-pinned 6.0.0→6.1.1→6.2.0 across
+# v9.0.0/.1/.2), but THIS Python wheel Requires-Dist stayed at `<6` —
+# the same drift class as the v2.0.1 / v4.10.0 entries above. The
+# mismatch made the published v9.0.2 wheel declare `ciris-verify<6`
+# while its Cargo deps pin v6.2.0, so sibling-repo cohabitation jobs
+# (`pip install ciris-persist==9.0.2 ciris-verify==6.2.0`) hit a hard
+# pip resolution conflict. Floor is v6.0.0 to track the v6 family floor,
+# coherent with the Rust pin.
 dependencies = [
-    "ciris-verify>=5.0.0,<6",
+    "ciris-verify>=6.0.0,<7",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## What
Metadata-only retag requested in #241. Bumps the Python wheel's `Requires-Dist` floor for the transitive `ciris-verify` PyPI package from `>=5.0.0,<6` → **`>=6.0.0,<7`** (pyproject `[project.dependencies]`), so the wheel metadata tracks the Cargo verify v6.x pin. Cargo version → 9.0.3.

## Why
v9.0.2's published wheel declared `Requires-Dist: ciris-verify <6,>=5.0.0` while its Cargo deps pin v6.2.0 (the v9.0.0 cut moved to the v6 family). The Rust side is consistent; the Python wheel metadata was stale → CIRISEdge cohab conformance jobs fail at `pip install ciris-persist==9.0.2 ciris-verify==6.2.0` (hard pip resolution conflict). Same drift class as the v2.0.1 / v4.10.0 `Requires-Dist` corrections.

## Verification
Locally-built wheel METADATA confirms: `Version: 9.0.3` / `Requires-Dist: ciris-verify>=6.0.0,<7`. No Rust code change, no migration, no Cargo dep change.

Closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)