### PR TITLE
v9.2.1 — re-pin CIRISVerify v6.3.0 → v6.5.0 (wheel concurrence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.2.1] — 2026-06-19
+
+### Changed — re-pin CIRISVerify v6.3.0 → v6.5.0 (wheel concurrence)
+
+- All six git-tag verify crates flipped in lockstep per the coherence rule; `version = "6"` unchanged (6.5.0 satisfies it). v6.4.x/6.5.0 are accord/server-facing (genesis producer, invocation concurrence) and do **not** touch persist's consumed surface — persist pins verify only for the scope-privacy XChaCha20-Poly1305 AEAD (`put_scope_blob`), live since v6.3.0. This re-pin is **family-floor / wheel concurrence** only: it keeps `pip install ciris-persist ciris-verify` resolving to one coherent verify across the cdylib family. No persist code change, no migration. Wheel `Requires-Dist` floor stays `ciris-verify>=6.0.0,<7` (6.5.0 in range; no #241-class metadata change).
+
 ## [9.2.0] — 2026-06-19
 
 ### Added — `EncryptedKVStore` app-layer XChaCha20-Poly1305 store (CIRISPersist#243 part 3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.2.0"
+version = "9.2.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
## What
Re-pins all six git-tag CIRISVerify crates **v6.3.0 → v6.5.0** in lockstep (coherence rule); `version = "6"` unchanged. Cargo version → **9.2.1**.

## Why
Family-floor / **wheel concurrence** only. v6.4.0/6.4.1/6.5.0 are accord/server-facing (genesis producer + invocation concurrence) and do **not** touch persist's consumed surface — persist pins verify solely for the scope-privacy XChaCha20-Poly1305 AEAD (`put_scope_blob`), live since 6.3.0. Re-pinning keeps `pip install ciris-persist ciris-verify` resolving to one coherent verify across the cdylib family. No persist code change, no migration.

## Gate (local, pg16 + sqlite)
- clippy `-D warnings` (full + encrypted-kv) / fmt — clean
- `nextest --all-targets --test-threads=1` (full incl encrypted-kv) — **1535 passed, 0 failed**
- no-backend `-D warnings` combos (server-only / postgres,pyo3,server / sqlite-only) — all compile

Wheel `Requires-Dist` floor stays `ciris-verify>=6.0.0,<7` (6.5.0 in range; no #241-class metadata change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)