### PR TITLE
v9.2.2 — re-pin CIRISVerify v6.5.0 → v6.6.0 (wheel concurrence) + sth stack fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.2.2] — 2026-06-20
+
+### Changed — re-pin CIRISVerify v6.5.0 → v6.6.0 (wheel concurrence)
+
+- All six git-tag verify crates flipped in lockstep per the coherence rule; `version = "6"` unchanged (6.6.0 satisfies it). v6.6.0 is accord/keyring-facing (portable signature-wrapped ML-DSA-65 USB key mode, CIRISVerify#88) and does **not** touch persist's consumed surface (`verify_hybrid` / `canonical` / `transparency` / `xchacha` / `hkdf` / `hmac`). Family-floor / wheel-concurrence re-pin only — keeps `pip install ciris-persist ciris-verify` resolving to one coherent verify. No persist production-code change. Wheel `Requires-Dist` floor stays `>=6.0.0,<7`.
+
+### Fixed — `sth_*` test stack overflow under v6.6.0's larger ML-DSA-65
+
+- v6.6.0's ML-DSA-65 layout/`zeroize` change (#88) enlarged the signer's stack footprint just enough that the transparency-log test helper `register_hybrid_producer` (sqlite test module) overflowed the 2 MiB tokio test-thread stack — it held a multi-KiB Ed25519+ML-DSA-65 `HybridSigner` in its async future state **across** the `put_public_key().await`. Fixed test-side: the helper now returns a **boxed** signer built **before** the await, so only an 8-byte pointer crosses it (production's 8 MiB main-thread stack was never affected). Pure test-fixture change.
+
 ## [9.2.1] — 2026-06-19
 
 ### Changed — re-pin CIRISVerify v6.3.0 → v6.5.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.2.1"
+version = "9.2.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.5.0", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -25946,7 +25946,8 @@ mod tests {
     async fn register_hybrid_producer(
         backend: &SqliteBackend,
         key_id: &str,
-    ) -> ciris_crypto::HybridSigner<ciris_crypto::Ed25519Signer, ciris_crypto::MlDsa65Signer> {
+    ) -> Box<ciris_crypto::HybridSigner<ciris_crypto::Ed25519Signer, ciris_crypto::MlDsa65Signer>>
+    {
         use base64::engine::general_purpose::STANDARD as B64;
         use base64::Engine as _;
         let ed = ciris_crypto::Ed25519Signer::from_seed(&[0x31; 32]).unwrap();
@@ -25959,11 +25960,15 @@ mod tests {
             use ciris_crypto::PqcSigner as _;
             B64.encode(mldsa.public_key().unwrap())
         };
-        // v9.0.0 — build the KeyRecord inline (NOT via `fed_key`): both
-        // pubkeys are overwritten with this producer's real hybrid keys
-        // anyway, and `fed_key` now derives ML-DSA pubkeys (a multi-KiB
-        // keygen) which, stacked on this frame's own ML-DSA signer +
-        // HybridSigner, overflowed the tokio worker stack.
+        // v9.2.2 — return a BOXED HybridSigner, built BEFORE the
+        // `put_public_key().await`. The multi-KiB Ed25519+ML-DSA-65 signer
+        // would otherwise live in this async fn's future state ACROSS the
+        // await (and inline into the caller's future), and CIRISVerify
+        // v6.6.0's larger ML-DSA-65 tipped the 2 MiB tokio test-thread stack
+        // over (#88 zeroize/layout). Only the 8-byte Box crosses the await.
+        // (KeyRecord is also built inline rather than via `fed_key`, which
+        // would derive its own multi-KiB ML-DSA pubkeys on this frame.)
+        let signer = Box::new(ciris_crypto::HybridSigner::new(ed, mldsa).unwrap());
         let record = crate::federation::KeyRecord {
             key_id: key_id.into(),
             pubkey_ed25519_base64: ed_pub_b64,
@@ -25988,7 +25993,7 @@ mod tests {
             .put_public_key(SignedKeyRecord { record })
             .await
             .unwrap();
-        ciris_crypto::HybridSigner::new(ed, mldsa).unwrap()
+        signer
     }
 
     /// Produce a producer-signed STH over a stream's recomputed root for


### PR DESCRIPTION
## What
Re-pins all six git-tag CIRISVerify crates **v6.5.0 → v6.6.0** (coherence rule; `version = "6"` unchanged). Cargo version → **9.2.2**. Family-floor / wheel-concurrence only.

## Why safe
v6.6.0 is accord/keyring-facing (portable signature-wrapped ML-DSA-65 USB key mode, CIRISVerify#88) — **none of persist's consumed surface** (`verify_hybrid`/`canonical`/`transparency`/`xchacha`/`hkdf`/`hmac`) is touched.

## sth test stack fix (the one wrinkle)
v6.6.0's larger ML-DSA-65 (the `zeroize`/layout change) tipped the 2 MiB tokio **test-thread** stack: the transparency-log helper `register_hybrid_producer` held a multi-KiB `HybridSigner` in its async future state **across** `put_public_key().await`. Fixed test-side by **boxing** the signer built **before** the await (8-byte pointer crosses the await). Production's 8 MiB main-thread stack was never affected; pure test-fixture change.

## Gate (local, pg16 + sqlite)
- clippy `-D warnings` / fmt — clean
- `nextest --all-targets --test-threads=1` (full incl encrypted-kv) — **1535 passed, 0 failed** (sth tests pass on the default 2 MiB stack)
- no-backend `-D warnings` combos — all compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)