### PR TITLE
v9.4.2 — re-pin CIRISVerify v6.7.1 -> v6.8.0 (wheel concurrence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.4.2] — 2026-06-21
+
+### Changed — re-pin CIRISVerify v6.7.1 → v6.8.0 (wheel concurrence)
+
+- All six git-tag verify crates flipped in lockstep; `version = "6"` unchanged. v6.8.0 adds the **growable M-of-N accord family genesis** surface (`ciris_verify_core::accord_genesis` — membership-change supersedes + name-free labels, CIRISVerify#95/#96/#97) — a purely **additive** new module that does **not** touch persist's consumed APIs (`verify_hybrid` / `canonical` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode`). Family-floor / wheel-concurrence re-pin only; no persist code change. Wheel `Requires-Dist` floor stays `>=6.0.0,<7`.
+- **Forward pointer:** v6.8.0 is the crypto half of a coordinated rostered-group governance cut. CIRISServer made HUMANITY_ACCORD a first-class persist family (v0.5.22) and filed the symmetric **write + governance** ask on CIRISPersist#249 (uniform `cohort:{self|family|community}` dispatch, `supersede_group`/reconstitute, the deferred v3.13+ quorum-authorized membership gate, a canonical membership-change payload, atomic `swap_member`, rekey-on-revoke, group versioning/history, change-event hook). That substrate surface is scoped for a following cut, not this re-pin.
+
 ## [9.4.1] — 2026-06-20
 
 ### Changed — re-pin CIRISVerify v6.6.1 → v6.7.1 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.4.1"
+version = "9.4.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
## v9.4.2 — re-pin CIRISVerify v6.7.1 → v6.8.0 (wheel concurrence)

All six git-tag verify crates flipped in lockstep; `version = "6"` unchanged.

**v6.8.0 is purely additive** — it adds the **growable M-of-N accord family genesis** module (`ciris_verify_core::accord_genesis`: membership-change supersedes + name-free labels, CIRISVerify#95/#96/#97). This new surface does **not** touch any API persist consumes (`verify_hybrid` / `canonical` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode` / `threshold`) — confirmed by grep: persist holds no reference to `accord_genesis`. So this is a family-floor / wheel-concurrence re-pin only — **no persist code change**. Wheel `Requires-Dist` floor stays `>=6.0.0,<7`.

### Coordinated cut — forward pointer
v6.8.0 is the **crypto half** of a rostered-group governance cut. CIRISServer made HUMANITY_ACCORD a first-class persist family (v0.5.22) and filed the symmetric **write + governance** ask on #249 (uniform `cohort:{self|family|community}` dispatch, `supersede_group`/reconstitute, the deferred v3.13+ quorum-authorized membership gate, canonical membership-change payload, atomic `swap_member`, rekey-on-revoke, group versioning/history, change-event hook). That substrate surface lands in a following cut (v9.5.0), not this re-pin.

### Gate — all green
- `cargo nextest run --all-targets --no-fail-fast --test-threads=1` (full feature set, live postgres:16 + sqlite + memory): **1569/1569 passed**.
- `cargo clippy --all-targets -D warnings` (full features): clean.
- No-backend `RUSTFLAGS="-D warnings"` combos (`server`, `postgres,pyo3,server`, `sqlite`): clean.
- `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
