### PR TITLE
v9.5.0 — #249 Cut G1: uniform cohort rostered-group surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.5.0] — 2026-06-21
+
+### Added — #249 Cut G1: the uniform cohort **rostered-group** surface (CIRISServer #249 §1/§2/§6)
+
+The persist half of the CIRISServer #249 write+governance ask, first cut. `self` (identity_occurrences), `family`, and `community` are the three **rostered groups** — the same machine (`members[]` + an append-only revocation table + the `roster − effective revocations` fold) at three points on the visibility gradient. Persist exposed that machine **three times** as mirrored `*_family_*` / `*_community_*` / occurrence-* method sets; this cut is the single **cohort-parameterized** surface over them, so consumers (CIRISServer's `family.rs`, the KMP UI) write rostered-group ops **once** instead of branching family-vs-community-vs-self by hand. (verify v6.8.0's `accord_genesis` is the crypto half of the same coordinated cut.)
+
+- **New `federation::cohort` module:** `Cohort` (`#[non_exhaustive]`; wire tokens `self` / `family` / `community`), `RosterMember`, `GroupRef`, `RevokeSpec`.
+- **Seven default `FederationDirectory` methods**, each composing the existing per-backend mirrored methods — so **backend parity (pg / sqlite / memory) is inherited with zero backend overrides**:
+  - `active_members(cohort, group)` (§1) — the uniform active roster.
+  - `active_member_keys(cohort, group)` (§2) — the active roster resolved to pinned hybrid pubkeys (`Vec<KeyRecord>`), the bridge to threshold verification. **Fail-secure:** a roster member with no `federation_keys` row is `InvalidArgument`, never a silent quorum undercount.
+  - `lookup_group` / `groups_of` (§1) — uniform group lookup + active reverse-membership.
+  - `add_member` / `revoke_member` / `swap_member` (§1/§6) — uniform roster mutation (`self` admits occurrences via the richer `put_identity_occurrence`; `swap_member` composes revoke+add — eventually-consistent, never a double-counted roster; a single-transaction backend swap is a later hardening).
+- **FFI:** `cohort_active_members_json` / `cohort_active_member_keys_json` / `cohort_lookup_group_json` / `cohort_groups_of_json` / `cohort_add_member` / `cohort_revoke_member` / `cohort_swap_member` (RosterMember / RevokeSpec as JSON).
+- **Cohort coverage (CIRISServer #249 Q1):** `affiliations` / `species` / `biosphere` / `federation` are audience scopes with no roster table, so they are not cohorts; `Cohort` is `#[non_exhaustive]` so a future CEG decision to make `affiliations` rostered extends it without a break.
+- **Tested:** round-trips across all three cohorts on sqlite + live Postgres (`cohort_surface_roundtrip_*`).
+
 ## [9.4.2] — 2026-06-21
 
 ### Changed — re-pin CIRISVerify v6.7.1 → v6.8.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.4.2"
+version = "9.5.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7918,6 +7918,286 @@ mod tests {
         );
     }
 
+    /// #249 Cut G1 — the uniform cohort surface round-trips across all three
+    /// rostered cohorts (`family` / `community` / `self`) over the SAME API:
+    /// `active_members` / `active_member_keys` / `lookup_group` / `groups_of` /
+    /// `add_member` / `revoke_member` / `swap_member`. Backend-generic body run
+    /// on sqlite + live Postgres (backend parity, CIRISServer #249 §1/§2/§6).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn cohort_surface_roundtrip_body<D>(d: &D, s: &str)
+    where
+        D: crate::federation::FederationDirectory + ?Sized,
+    {
+        use crate::federation::cohort::{Cohort, RevokeSpec, RosterMember};
+        use crate::federation::types;
+
+        let founder = format!("g1-founder-{s}");
+        let mem_b = format!("g1-memb-{s}");
+        let mem_c = format!("g1-memc-{s}");
+        let fam = format!("g1-fam-{s}");
+        let comm = format!("g1-comm-{s}");
+        let ident = format!("g1-ident-{s}");
+        let occ1 = format!("g1-occ1-{s}");
+        let occ2 = format!("g1-occ2-{s}");
+
+        // Members / groups / occurrences all FK to federation_keys.
+        for k in [&founder, &mem_b, &mem_c, &fam, &comm, &ident, &occ1, &occ2] {
+            d.put_public_key(sweeper_test_key(k))
+                .await
+                .expect("seed key");
+        }
+        let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+
+        d.put_family(crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "g1-fam".into(),
+                members: vec![types::FamilyMember {
+                    key_id: founder.clone(),
+                    joined_at: joined,
+                    role: Some("founder".into()),
+                }],
+                founded_at: joined,
+                consensus_protocol: types::consensus_protocol::FOUNDER_ONLY.into(),
+                consensus_protocol_entrenched: false,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("put_family");
+        d.put_community(crate::federation::SignedCommunity {
+            community: types::Community {
+                community_key_id: comm.clone(),
+                community_name: "g1-comm".into(),
+                members: vec![types::CommunityMember {
+                    key_id: founder.clone(),
+                    joined_at: joined,
+                    role: Some("founder".into()),
+                }],
+                founded_at: joined,
+                consensus_protocol: types::consensus_protocol::FOUNDER_ONLY.into(),
+                policy_blob: None,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("put_community");
+
+        // family + community: identical uniform ops, no per-cohort branching.
+        for (cohort, group) in [(Cohort::Family, &fam), (Cohort::Community, &comm)] {
+            let tag = cohort.as_str();
+            let m = d
+                .active_members(cohort, group)
+                .await
+                .expect("active_members");
+            assert_eq!(m.len(), 1, "{tag} starts with founder");
+            assert_eq!(m[0].key_id, founder);
+
+            let g = d
+                .lookup_group(cohort, group)
+                .await
+                .expect("lookup_group")
+                .expect("group exists");
+            assert_eq!(g.cohort, cohort);
+            assert_eq!(
+                g.consensus_protocol.as_deref(),
+                Some(types::consensus_protocol::FOUNDER_ONLY),
+                "{tag} lookup_group carries consensus_protocol"
+            );
+            assert!(g.name.is_some(), "{tag} lookup_group carries name");
+
+            let gs = d.groups_of(cohort, &founder).await.expect("groups_of");
+            assert!(
+                gs.iter().any(|x| &x.group_key_id == group),
+                "{tag} groups_of(founder) contains the group"
+            );
+
+            assert!(
+                d.add_member(
+                    cohort,
+                    group,
+                    RosterMember {
+                        key_id: mem_b.clone(),
+                        joined_at: joined,
+                        role: None
+                    },
+                )
+                .await
+                .expect("add_member"),
+                "{tag} add_member(mem_b) is a genuine add"
+            );
+            assert_eq!(d.active_members(cohort, group).await.unwrap().len(), 2);
+            assert!(
+                !d.add_member(
+                    cohort,
+                    group,
+                    RosterMember {
+                        key_id: mem_b.clone(),
+                        joined_at: joined,
+                        role: None
+                    },
+                )
+                .await
+                .expect("add_member idempotent"),
+                "{tag} re-add(mem_b) is a no-op"
+            );
+
+            let keys = d
+                .active_member_keys(cohort, group)
+                .await
+                .expect("active_member_keys");
+            assert_eq!(keys.len(), 2, "{tag} active_member_keys resolves both pins");
+
+            d.revoke_member(
+                cohort,
+                group,
+                &mem_b,
+                RevokeSpec {
+                    effective_at: chrono::Utc::now(),
+                    reason: Some("test".into()),
+                    witness_set: vec![],
+                },
+            )
+            .await
+            .expect("revoke_member");
+            assert_eq!(
+                d.active_members(cohort, group).await.unwrap().len(),
+                1,
+                "{tag} revoke drops mem_b"
+            );
+
+            assert!(
+                d.swap_member(
+                    cohort,
+                    group,
+                    &founder,
+                    RosterMember {
+                        key_id: mem_c.clone(),
+                        joined_at: joined,
+                        role: None
+                    },
+                    RevokeSpec {
+                        effective_at: chrono::Utc::now(),
+                        reason: None,
+                        witness_set: vec![],
+                    },
+                )
+                .await
+                .expect("swap_member"),
+                "{tag} swap adds mem_c"
+            );
+            let after: Vec<String> = d
+                .active_members(cohort, group)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|m| m.key_id)
+                .collect();
+            assert_eq!(after, vec![mem_c.clone()], "{tag} after swap = {{mem_c}}");
+        }
+
+        // self cohort: identity_occurrences through the SAME read API.
+        for occ in [&occ1, &occ2] {
+            d.put_identity_occurrence(crate::federation::SignedIdentityOccurrence {
+                identity_occurrence: types::IdentityOccurrence {
+                    identity_key_id: ident.clone(),
+                    occurrence_key_id: occ.clone(),
+                    device_class: types::device_class::SERVER.into(),
+                    hardware_attestation: None,
+                    asserted_at: joined,
+                    valid_until: None,
+                    encryption_pubkeys: None,
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .expect("put_identity_occurrence");
+        }
+        let occ_members = d
+            .active_members(Cohort::SelfId, &ident)
+            .await
+            .expect("self active_members");
+        assert_eq!(occ_members.len(), 2, "self has 2 active occurrences");
+        assert!(
+            occ_members
+                .iter()
+                .all(|m| m.role.as_deref() == Some("server")),
+            "self RosterMember.role projects device_class"
+        );
+        let ig = d
+            .groups_of(Cohort::SelfId, &occ1)
+            .await
+            .expect("groups_of self");
+        assert_eq!(ig.len(), 1);
+        assert_eq!(ig[0].group_key_id, ident, "occ1 resolves to its identity");
+        assert!(
+            d.lookup_group(Cohort::SelfId, &ident)
+                .await
+                .unwrap()
+                .is_some(),
+            "self lookup_group on a known identity key"
+        );
+        d.revoke_member(
+            Cohort::SelfId,
+            &ident,
+            &occ1,
+            RevokeSpec {
+                effective_at: chrono::Utc::now(),
+                reason: None,
+                witness_set: vec![],
+            },
+        )
+        .await
+        .expect("revoke self occurrence");
+        assert_eq!(
+            d.active_members(Cohort::SelfId, &ident)
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "self revoke drops occ1"
+        );
+        // self admits occurrences via the typed put, NOT the uniform add_member.
+        let err = d
+            .add_member(
+                Cohort::SelfId,
+                &ident,
+                RosterMember {
+                    key_id: "nope".into(),
+                    joined_at: joined,
+                    role: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument");
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn cohort_surface_roundtrip_sqlite() {
+        let signer = crate::federation::tier_ingest::test_support::local_signer("g1");
+        let engine = Engine::with_signer(signer, "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        cohort_surface_roundtrip_body(&*sq, "sq").await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn cohort_surface_roundtrip_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let label = format!("g1-{}", uuid::Uuid::new_v4().simple());
+        let signer = crate::federation::tier_ingest::test_support::local_signer(&label);
+        let engine = Engine::with_signer(signer, &dsn).await.expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend").clone();
+        cohort_surface_roundtrip_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
+    }
+
     /// #249 — `file_moderation` stores a `moderation:{allegation}` scores
     /// row when the signer is a named moderator (community founder, as-self
     /// duty-holder). Proves the §11.10 EMIT path is feature-free (no

--- a/src/federation/cohort.rs
+++ b/src/federation/cohort.rs
@@ -1,0 +1,220 @@
+//! #249 Cut G1 — the uniform **rostered-group** surface (CIRISServer #249
+//! write+governance ask, §1/§2/§6/§Q1-self).
+//!
+//! Framing (CIRISServer #249): `self` (identity_occurrences), `family`, and
+//! `community` are the three **rostered groups** — the same machine
+//! (`members[]` + an append-only revocation table + the
+//! `roster − effective revocations` fold) at three points on the visibility
+//! gradient. Today persist exposes that machine **three times** as mirrored
+//! `*_family_*` / `*_community_*` / occurrence-* method sets, so every
+//! consumer branches family-vs-community-vs-self by hand and persist
+//! maintains the mirror 3×. This module is the single **cohort-parameterized**
+//! surface over those three sets, so consumers write rostered-group ops once.
+//!
+//! The uniform methods live as **default methods on
+//! [`FederationDirectory`](crate::federation::FederationDirectory)** — they
+//! compose the existing per-backend mirrored methods, so backend parity
+//! (pg / sqlite / memory) is inherited for free and no backend override is
+//! needed.
+//!
+//! ## Cohort coverage (CIRISServer #249 Q1/Q4)
+//! `affiliations` / `species` / `biosphere` / `federation` are audience scopes
+//! with **no roster table** today, so they are NOT cohorts here. Whether
+//! `affiliations` should become a first-class rostered group (a managed set of
+//! org affiliations mirroring family/community) is an open CEG/constitution
+//! shape question (CIRISServer #249 Q1). [`Cohort`] is therefore
+//! `#[non_exhaustive]`: a future decision to add `affiliations` extends the
+//! enum without a breaking change, and this whole surface covers it the moment
+//! the roster table exists.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::types;
+
+/// One of the three rostered-group kinds. Serializes to the wire scope token
+/// (`"self"` / `"family"` / `"community"`) so the cohort dispatch is portable
+/// over FFI / JSON.
+///
+/// `#[non_exhaustive]` — see the module docs (CIRISServer #249 Q1: `affiliations`
+/// may join later without breaking callers).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Cohort {
+    /// The `self` collective — an identity_key and its device/incarnation
+    /// occurrences (`federation_identity_occurrences`). No quorum.
+    #[serde(rename = "self")]
+    SelfId,
+    /// A `family` (`federation_families`) — the entrenched-able M-of-N group
+    /// the accord rides on.
+    #[serde(rename = "family")]
+    Family,
+    /// A `community` (`federation_communities`).
+    #[serde(rename = "community")]
+    Community,
+}
+
+impl Cohort {
+    /// The wire scope token (`"self"` / `"family"` / `"community"`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Cohort::SelfId => "self",
+            Cohort::Family => "family",
+            Cohort::Community => "community",
+        }
+    }
+
+    /// Parse the wire scope token. `Err` (the offending token) for anything
+    /// that is not a rostered cohort (e.g. `"affiliations"` today — Q1).
+    pub fn from_token(s: &str) -> Result<Cohort, String> {
+        match s {
+            "self" => Ok(Cohort::SelfId),
+            "family" => Ok(Cohort::Family),
+            "community" => Ok(Cohort::Community),
+            other => Err(other.to_string()),
+        }
+    }
+}
+
+/// A roster entry, uniform across the three cohorts (the read shape §1/§2).
+///
+/// For `family`/`community` this is the `members[]` entry verbatim; for `self`
+/// it projects an `IdentityOccurrence` (`key_id` = the occurrence key,
+/// `joined_at` = `asserted_at`, `role` = the `device_class`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RosterMember {
+    /// The member's `federation_keys.key_id` (an occurrence key for `self`).
+    pub key_id: String,
+    /// When the member joined the roster (`asserted_at` for a `self`
+    /// occurrence).
+    pub joined_at: DateTime<Utc>,
+    /// Optional role tag (the `device_class` for a `self` occurrence).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+impl From<types::FamilyMember> for RosterMember {
+    fn from(m: types::FamilyMember) -> Self {
+        RosterMember {
+            key_id: m.key_id,
+            joined_at: m.joined_at,
+            role: m.role,
+        }
+    }
+}
+
+impl From<types::CommunityMember> for RosterMember {
+    fn from(m: types::CommunityMember) -> Self {
+        RosterMember {
+            key_id: m.key_id,
+            joined_at: m.joined_at,
+            role: m.role,
+        }
+    }
+}
+
+impl From<types::IdentityOccurrence> for RosterMember {
+    fn from(o: types::IdentityOccurrence) -> Self {
+        RosterMember {
+            key_id: o.occurrence_key_id,
+            joined_at: o.asserted_at,
+            role: Some(o.device_class),
+        }
+    }
+}
+
+/// The knobs of a roster removal / swap-out (#249 Cut G1 §1/§6), uniform
+/// across the three cohorts. `effective_at` may be future-dated (the member
+/// stays active until it arrives); `witness_set` is the vouch set — the
+/// member cosignatures the Cut G3 quorum gate will count land here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RevokeSpec {
+    /// When the removal takes effect (`effective_at <= now` ⇒ active-drop).
+    pub effective_at: DateTime<Utc>,
+    /// Optional operator/ceremony annotation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Vouch set (`federation_keys.key_id`s) — Cut G3's quorum cosignatures.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub witness_set: Vec<String>,
+}
+
+/// A group identity, uniform across the three cohorts (the `lookup_group` /
+/// `groups_of` shape §1). `name` / `consensus_protocol` / `founded_at` are
+/// `None` for the `self` cohort (the identity_key IS the group; it carries no
+/// roster-row metadata).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupRef {
+    /// Which rostered-group kind this is.
+    pub cohort: Cohort,
+    /// The group's `federation_keys.key_id` (the identity_key for `self`).
+    pub group_key_id: String,
+    /// Display name (family/community only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// The group's `consensus_protocol` (family/community only) — the M-of-N /
+    /// majority / founder_only rule a membership change must satisfy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consensus_protocol: Option<String>,
+    /// When the group was founded (family/community only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub founded_at: Option<DateTime<Utc>>,
+}
+
+impl From<types::Family> for GroupRef {
+    fn from(f: types::Family) -> Self {
+        GroupRef {
+            cohort: Cohort::Family,
+            group_key_id: f.family_key_id,
+            name: Some(f.family_name),
+            consensus_protocol: Some(f.consensus_protocol),
+            founded_at: Some(f.founded_at),
+        }
+    }
+}
+
+impl From<types::Community> for GroupRef {
+    fn from(c: types::Community) -> Self {
+        GroupRef {
+            cohort: Cohort::Community,
+            group_key_id: c.community_key_id,
+            name: Some(c.community_name),
+            consensus_protocol: Some(c.consensus_protocol),
+            founded_at: Some(c.founded_at),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cohort_token_roundtrips_and_rejects_non_rostered() {
+        for c in [Cohort::SelfId, Cohort::Family, Cohort::Community] {
+            assert_eq!(Cohort::from_token(c.as_str()), Ok(c));
+        }
+        // `self` serializes to the wire token, not the Rust ident.
+        assert_eq!(Cohort::SelfId.as_str(), "self");
+        // audience scopes with no roster are not cohorts (Q1).
+        assert_eq!(
+            Cohort::from_token("affiliations"),
+            Err("affiliations".to_string())
+        );
+        assert_eq!(
+            Cohort::from_token("federation"),
+            Err("federation".to_string())
+        );
+    }
+
+    #[test]
+    fn cohort_serde_is_the_wire_token() {
+        assert_eq!(serde_json::to_string(&Cohort::SelfId).unwrap(), "\"self\"");
+        assert_eq!(
+            serde_json::to_string(&Cohort::Community).unwrap(),
+            "\"community\""
+        );
+        let c: Cohort = serde_json::from_str("\"family\"").unwrap();
+        assert_eq!(c, Cohort::Family);
+    }
+}

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -38,6 +38,7 @@ pub mod at_rest_cascade;
 pub mod backfill;
 pub mod blackhole;
 pub mod blobs;
+pub mod cohort;
 pub mod community_dek;
 #[cfg(feature = "cirisaudit")]
 pub mod emit;
@@ -134,6 +135,7 @@ pub use blobs::{
     PutBlobAttestation, ScopeBlobSymbol, CHUNK_MANIFEST_VERSION, DEFAULT_INLINE_BYTES_CAP,
     HOLDS_BYTES_ATTESTATION_TYPE_PREFIX, HOLDS_BYTES_PREFIX_HEX_LEN,
 };
+pub use cohort::{Cohort, GroupRef, RevokeSpec, RosterMember};
 pub use goal::{
     canonicalize_goal_text, DeliberationRef, Goal, GoalScope, GoalsFilter, M1Dimension,
     MetaGoalAlignment,
@@ -1049,6 +1051,301 @@ pub trait FederationDirectory: Send + Sync {
         community_key_id: &str,
         member: types::CommunityMember,
     ) -> Result<bool, Error>;
+
+    // ── #249 Cut G1 ── the uniform rostered-group surface ──────────────
+    //
+    // CIRISServer #249 write+governance ask §1/§2/§6/§Q1-self. `self` /
+    // `family` / `community` are the same machine (roster + append-only
+    // revocations + the `roster − effective revocations` fold) at three
+    // points on the visibility gradient; these methods are the single
+    // `cohort`-parameterized surface over the three mirrored method sets,
+    // so consumers write rostered-group ops ONCE. All are DEFAULT methods
+    // composing the existing per-backend methods — backend parity (pg /
+    // sqlite / memory) is inherited, no override needed. See
+    // [`cohort`](crate::federation::cohort).
+
+    /// #249 Cut G1 (§1) — the **active roster** of `group_key_id` in `cohort`,
+    /// uniform across `self` / `family` / `community` (`roster − effective
+    /// revocations`, `effective_at <= now`). Dispatches to
+    /// [`Self::active_family_members`] / [`Self::active_community_members`] /
+    /// [`Self::list_identity_occurrences_active`] and projects each to the
+    /// uniform [`RosterMember`]. [`Error::InvalidArgument`] if a
+    /// family/community `group_key_id` is unknown.
+    async fn active_members(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<cohort::RosterMember>, Error> {
+        Ok(match cohort {
+            cohort::Cohort::Family => self
+                .active_family_members(group_key_id)
+                .await?
+                .into_iter()
+                .map(cohort::RosterMember::from)
+                .collect(),
+            cohort::Cohort::Community => self
+                .active_community_members(group_key_id)
+                .await?
+                .into_iter()
+                .map(cohort::RosterMember::from)
+                .collect(),
+            cohort::Cohort::SelfId => self
+                .list_identity_occurrences_active(group_key_id)
+                .await?
+                .into_iter()
+                .map(cohort::RosterMember::from)
+                .collect(),
+        })
+    }
+
+    /// #249 Cut G1 (§2) — the active roster resolved to its **pinned hybrid
+    /// public keys** ([`KeyRecord`]s), one call. The bridge from membership to
+    /// threshold verification (the input to every quorum check): composes
+    /// [`Self::active_members`] with [`Self::lookup_public_key`] per member.
+    ///
+    /// **Fail-secure:** an active roster member whose key is absent from
+    /// `federation_keys` is a graph inconsistency that would silently undercount
+    /// a quorum, so this returns [`Error::InvalidArgument`] rather than skip it.
+    async fn active_member_keys(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<types::KeyRecord>, Error> {
+        let members = self.active_members(cohort, group_key_id).await?;
+        let mut out = Vec::with_capacity(members.len());
+        for m in members {
+            let rec = self.lookup_public_key(&m.key_id).await?.ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "active_member_keys: roster member {:?} of {} {:?} has no federation_keys \
+                     row (broken roster — refusing to undercount a quorum)",
+                    m.key_id,
+                    cohort.as_str(),
+                    group_key_id
+                ))
+            })?;
+            out.push(rec);
+        }
+        Ok(out)
+    }
+
+    /// #249 Cut G1 (§1) — look up a group's identity uniformly. Dispatches to
+    /// [`Self::lookup_family`] / [`Self::lookup_community`]; for `self` the
+    /// identity_key IS the group, so it returns a metadata-free [`GroupRef`]
+    /// when `group_key_id` is a known key ([`Self::lookup_public_key`] is
+    /// `Some`). `Ok(None)` if the group/key is unknown.
+    async fn lookup_group(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Option<cohort::GroupRef>, Error> {
+        Ok(match cohort {
+            cohort::Cohort::Family => self
+                .lookup_family(group_key_id)
+                .await?
+                .map(cohort::GroupRef::from),
+            cohort::Cohort::Community => self
+                .lookup_community(group_key_id)
+                .await?
+                .map(cohort::GroupRef::from),
+            cohort::Cohort::SelfId => {
+                self.lookup_public_key(group_key_id)
+                    .await?
+                    .map(|_| cohort::GroupRef {
+                        cohort: cohort::Cohort::SelfId,
+                        group_key_id: group_key_id.to_string(),
+                        name: None,
+                        consensus_protocol: None,
+                        founded_at: None,
+                    })
+            }
+        })
+    }
+
+    /// #249 Cut G1 (§1) — every group in `cohort` that `member_key_id` is
+    /// **currently** a member of (the active reverse lookup). Dispatches to
+    /// [`Self::list_families_for_member_active`] /
+    /// [`Self::list_communities_for_member_active`]; for `self` it resolves the
+    /// occurrence → its identity via [`Self::lookup_identity_for_occurrence`].
+    async fn groups_of(
+        &self,
+        cohort: cohort::Cohort,
+        member_key_id: &str,
+    ) -> Result<Vec<cohort::GroupRef>, Error> {
+        Ok(match cohort {
+            cohort::Cohort::Family => self
+                .list_families_for_member_active(member_key_id)
+                .await?
+                .into_iter()
+                .map(cohort::GroupRef::from)
+                .collect(),
+            cohort::Cohort::Community => self
+                .list_communities_for_member_active(member_key_id)
+                .await?
+                .into_iter()
+                .map(cohort::GroupRef::from)
+                .collect(),
+            cohort::Cohort::SelfId => self
+                .lookup_identity_for_occurrence(member_key_id)
+                .await?
+                .into_iter()
+                .map(|o| cohort::GroupRef {
+                    cohort: cohort::Cohort::SelfId,
+                    group_key_id: o.identity_key_id,
+                    name: None,
+                    consensus_protocol: None,
+                    founded_at: None,
+                })
+                .collect(),
+        })
+    }
+
+    /// #249 Cut G1 (§1) — admit one [`RosterMember`] into a `family` /
+    /// `community` roster uniformly (dispatches to [`Self::add_family_member`]
+    /// / [`Self::add_community_member`]). Idempotent on `member.key_id`
+    /// (`Ok(false)` = already present, `Ok(true)` = genuine add).
+    ///
+    /// The `self` cohort is **not** admissible here: an occurrence carries
+    /// `device_class` / `hardware_attestation` / `encryption_pubkeys` that a
+    /// [`RosterMember`] cannot, so `self` members are added via
+    /// [`Self::put_identity_occurrence`]. Returns [`Error::InvalidArgument`]
+    /// for `Cohort::SelfId`.
+    async fn add_member(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        member: cohort::RosterMember,
+    ) -> Result<bool, Error> {
+        match cohort {
+            cohort::Cohort::Family => {
+                self.add_family_member(
+                    group_key_id,
+                    types::FamilyMember {
+                        key_id: member.key_id,
+                        joined_at: member.joined_at,
+                        role: member.role,
+                    },
+                )
+                .await
+            }
+            cohort::Cohort::Community => {
+                self.add_community_member(
+                    group_key_id,
+                    types::CommunityMember {
+                        key_id: member.key_id,
+                        joined_at: member.joined_at,
+                        role: member.role,
+                    },
+                )
+                .await
+            }
+            cohort::Cohort::SelfId => Err(Error::InvalidArgument(
+                "add_member: the `self` cohort admits members via \
+                 put_identity_occurrence (an occurrence carries device_class / \
+                 hardware_attestation / encryption_pubkeys a RosterMember cannot)"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// #249 Cut G1 (§1) — remove one member from a `cohort` roster uniformly,
+    /// via the append-only revocation table (the roster `members[]` is left
+    /// intact; the `active_*` reads compose against the revocation). Builds the
+    /// cohort's revocation row (`persist_row_hash` is backend-computed) and
+    /// dispatches to the matching `put_*_revocation`. `effective_at` may be
+    /// future-dated (the member stays active until it arrives).
+    async fn revoke_member(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        removed_key_id: &str,
+        spec: cohort::RevokeSpec,
+    ) -> Result<(), Error> {
+        let now = chrono::Utc::now();
+        let cohort::RevokeSpec {
+            effective_at,
+            reason,
+            witness_set,
+        } = spec;
+        match cohort {
+            cohort::Cohort::Family => {
+                self.put_family_membership_revocation(types::SignedFamilyMembershipRevocation {
+                    family_membership_revocation: types::FamilyMembershipRevocation {
+                        family_key_id: group_key_id.to_string(),
+                        removed_identity_key_id: removed_key_id.to_string(),
+                        removed_at: now,
+                        effective_at,
+                        reason,
+                        witness_set,
+                        persist_row_hash: String::new(),
+                    },
+                })
+                .await
+            }
+            cohort::Cohort::Community => {
+                self.put_community_membership_revocation(
+                    types::SignedCommunityMembershipRevocation {
+                        community_membership_revocation: types::CommunityMembershipRevocation {
+                            community_key_id: group_key_id.to_string(),
+                            removed_identity_key_id: removed_key_id.to_string(),
+                            removed_at: now,
+                            effective_at,
+                            reason,
+                            witness_set,
+                            persist_row_hash: String::new(),
+                        },
+                    },
+                )
+                .await
+            }
+            cohort::Cohort::SelfId => {
+                self.put_identity_occurrence_revocation(types::SignedIdentityOccurrenceRevocation {
+                    identity_occurrence_revocation: types::IdentityOccurrenceRevocation {
+                        identity_key_id: group_key_id.to_string(),
+                        occurrence_key_id: removed_key_id.to_string(),
+                        revoked_at: now,
+                        effective_at,
+                        reason,
+                        witness_set,
+                        persist_row_hash: String::new(),
+                    },
+                })
+                .await
+            }
+        }
+    }
+
+    /// #249 Cut G1 (§6) — atomically swap one member for another in a `family`
+    /// / `community` roster: [`Self::revoke_member`] the outgoing key, then
+    /// [`Self::add_member`] the incoming one. Returns the `add_member` result
+    /// (`Ok(true)` = genuine add).
+    ///
+    /// **Consistency note:** this default composes two writes, so it is
+    /// *eventually* consistent rather than single-transaction atomic — between
+    /// the two calls a concurrent reader sees the outgoing member revoked but
+    /// the incoming one not yet added (a transiently *smaller* roster, never a
+    /// double-counted one; the `roster − revocations` fold can never report
+    /// `out` as active). A backend-level single-transaction `swap` (one
+    /// `persist_row_hash` recompute, no torn read) is a Cut G2 hardening.
+    /// `self` is rejected ([`Error::InvalidArgument`]) — see [`Self::add_member`].
+    async fn swap_member(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        out_key_id: &str,
+        in_member: cohort::RosterMember,
+        spec: cohort::RevokeSpec,
+    ) -> Result<bool, Error> {
+        if cohort == cohort::Cohort::SelfId {
+            return Err(Error::InvalidArgument(
+                "swap_member: the `self` cohort manages occurrences via \
+                 put_identity_occurrence / put_identity_occurrence_revocation"
+                    .to_string(),
+            ));
+        }
+        self.revoke_member(cohort, group_key_id, out_key_id, spec)
+            .await?;
+        self.add_member(cohort, group_key_id, in_member).await
+    }
 
     /// #249 Cut B — the INBOUND delegation walk: every key that holds a
     /// `delegates_to` edge naming `key_id` as the recipient ("who delegated

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -15224,6 +15224,313 @@ impl PyEngine {
         })
     }
 
+    // ── #249 Cut G1 ── uniform cohort FFI (CIRISServer #249 §1/§2/§6) ──
+    //
+    // One cohort-parameterized surface (`cohort` ∈ {"self","family",
+    // "community"}) over the rostered-group read+write methods, so the
+    // KMP/Python consumers write rostered-group ops once instead of
+    // branching family-vs-community-vs-self. Each composes the
+    // [`crate::federation::cohort`] default methods (backend parity
+    // inherited). A hardware-hybrid engine needs no extra signer here —
+    // these are admission/read, not emit.
+
+    /// #249 Cut G1 (§1) — active roster of `group_key_id` in `cohort`. Returns
+    /// a JSON array of [`crate::federation::cohort::RosterMember`].
+    fn cohort_active_members_json(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let rows = b
+                                .active_members(cohort, &group_key_id)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            serde_json::to_string(&rows).map_err(|e| {
+                                PyValueError::new_err(format!(
+                                    "cohort active_members serialize: {e}"
+                                ))
+                            })
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§2) — active roster of `group_key_id` resolved to pinned
+    /// hybrid pubkeys. Returns a JSON array of
+    /// [`crate::federation::types::KeyRecord`]. Raises `ValueError` if a roster
+    /// member has no `federation_keys` row (fail-secure — see
+    /// [`FederationDirectory::active_member_keys`](crate::federation::FederationDirectory::active_member_keys)).
+    fn cohort_active_member_keys_json(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let rows = b
+                                .active_member_keys(cohort, &group_key_id)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            serde_json::to_string(&rows).map_err(|e| {
+                                PyValueError::new_err(format!(
+                                    "cohort active_member_keys serialize: {e}"
+                                ))
+                            })
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§1) — look up a group uniformly. Returns the
+    /// [`crate::federation::cohort::GroupRef`] JSON, or `None` if unknown.
+    fn cohort_lookup_group_json(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let row = b
+                                .lookup_group(cohort, &group_key_id)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            match row {
+                                Some(g) => serde_json::to_string(&g).map(Some).map_err(|e| {
+                                    PyValueError::new_err(format!(
+                                        "cohort lookup_group serialize: {e}"
+                                    ))
+                                }),
+                                None => Ok(None),
+                            }
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§1) — every group in `cohort` that `member_key_id` is
+    /// currently a member of. Returns a JSON array of
+    /// [`crate::federation::cohort::GroupRef`].
+    fn cohort_groups_of_json(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        member_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let member_key_id = member_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let rows = b
+                                .groups_of(cohort, &member_key_id)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            serde_json::to_string(&rows).map_err(|e| {
+                                PyValueError::new_err(format!("cohort groups_of serialize: {e}"))
+                            })
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§1) — admit a [`crate::federation::cohort::RosterMember`]
+    /// (JSON) into a `family`/`community` roster. Returns `True` on a genuine
+    /// add, `False` if already present. Raises `ValueError` for the `self`
+    /// cohort (occurrences are added via `put_identity_occurrence`).
+    fn cohort_add_member(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        member_json: &str,
+    ) -> PyResult<bool> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let member: crate::federation::cohort::RosterMember = serde_json::from_str(member_json)
+            .map_err(|e| PyValueError::new_err(format!("cohort_add_member member JSON: {e}")))?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            b.add_member(cohort, &group_key_id, member.clone())
+                                .await
+                                .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§1) — remove `removed_key_id` from a `cohort` roster via the
+    /// append-only revocation table. `revoke_spec_json` is a
+    /// [`crate::federation::cohort::RevokeSpec`] (`{effective_at, reason?,
+    /// witness_set?}`); `effective_at` may be future-dated.
+    fn cohort_revoke_member(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        removed_key_id: &str,
+        revoke_spec_json: &str,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let spec: crate::federation::cohort::RevokeSpec = serde_json::from_str(revoke_spec_json)
+            .map_err(|e| PyValueError::new_err(format!("revoke_spec_json: {e}")))?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            let removed_key_id = removed_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            b.revoke_member(cohort, &group_key_id, &removed_key_id, spec.clone())
+                                .await
+                                .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G1 (§6) — atomically swap `out_key_id` for the
+    /// [`crate::federation::cohort::RosterMember`] in `in_member_json` (revoke
+    /// then add) in a `family`/`community` roster. `revoke_spec_json` is a
+    /// [`crate::federation::cohort::RevokeSpec`]. Returns the add result.
+    fn cohort_swap_member(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        out_key_id: &str,
+        in_member_json: &str,
+        revoke_spec_json: &str,
+    ) -> PyResult<bool> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let in_member: crate::federation::cohort::RosterMember =
+            serde_json::from_str(in_member_json).map_err(|e| {
+                PyValueError::new_err(format!("cohort_swap_member in_member JSON: {e}"))
+            })?;
+        let spec: crate::federation::cohort::RevokeSpec = serde_json::from_str(revoke_spec_json)
+            .map_err(|e| PyValueError::new_err(format!("revoke_spec_json: {e}")))?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            let out_key_id = out_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            b.swap_member(
+                                cohort,
+                                &group_key_id,
+                                &out_key_id,
+                                in_member.clone(),
+                                spec.clone(),
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
     /// #249 Cut B — the FULL named-moderator set of `community_key_id` for
     /// `duty` (`moderate` / `takedown` / `review`): owner-bound authority
     /// roots ∪ their duty-scoped delegates. Returns a JSON array of key_ids.
@@ -21821,6 +22128,16 @@ fn base64_encode(bytes: &[u8]) -> String {
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine as _;
     B64.encode(bytes)
+}
+
+/// #249 Cut G1 — parse a cohort wire token (`"self"`/`"family"`/`"community"`)
+/// for the uniform cohort FFI. `ValueError` for a non-rostered scope.
+fn cohort_from_token(cohort: &str) -> PyResult<crate::federation::cohort::Cohort> {
+    crate::federation::cohort::Cohort::from_token(cohort).map_err(|bad| {
+        PyValueError::new_err(format!(
+            "unknown cohort {bad:?} (expected one of: self | family | community)"
+        ))
+    })
 }
 
 fn federation_err_to_py(e: crate::federation::Error) -> PyErr {


### PR DESCRIPTION
## v9.5.0 — #249 Cut G1: the uniform cohort **rostered-group** surface

The persist half of the CIRISServer #249 write+governance ask (first cut), §1/§2/§6. verify v6.8.0's `accord_genesis` is the crypto half of the same coordinated cut.

`self` / `family` / `community` are the three **rostered groups** — the same machine (`members[]` + an append-only revocation table + the `roster − effective revocations` fold) at three points on the visibility gradient. Persist exposed that machine **three times**; this cut is the single **cohort-parameterized** surface over them, so consumers (CIRISServer `family.rs`, the KMP UI) write rostered-group ops **once**.

### Surface
- **New `federation::cohort` module:** `Cohort` (`#[non_exhaustive]`; wire tokens `self`/`family`/`community`), `RosterMember`, `GroupRef`, `RevokeSpec`.
- **Seven default `FederationDirectory` methods** composing the existing per-backend methods — **backend parity inherited, zero overrides:** `active_members`, `active_member_keys` (§2, roster→pinned hybrid pubkeys, **fail-secure** on a missing key), `lookup_group`, `groups_of`, `add_member`, `revoke_member`, `swap_member` (§6).
- **FFI:** `cohort_*` JSON methods.
- **Q1:** `affiliations`/species/biosphere/federation stay non-rostered; `Cohort` is `#[non_exhaustive]` for a future CEG decision.

### Next cuts (on this v6.8.0 base — verify ships the crypto)
- **G2** — `supersede_group` + versioning/history (§3/§8).
- **G3** — quorum-authorized membership gate (§4/§5) consuming `ciris_verify_core::threshold` (`verify_quorum_policy` / `QuorumPolicy`); the general non-accord helper is filed as CIRISVerify#104.
- **G4** — rekey-on-revoke/swap (§7) + change-event hook (§9).

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1573/1573**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
