### PR TITLE
v9.6.0 — #249 Cut G2: supersede + versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.6.0] — 2026-06-21
+
+### Added — #249 Cut G2: rostered-group **supersede + versioning** (CIRISServer #249 §3/§8)
+
+THE write gap (CIRISServer #249 §3): `put_family` / `put_community` error on differing content and `add`/`revoke` can't touch the `consensus_protocol`, so there was **no way** to change an entrenched group's M/N threshold or atomically re-baseline its roster — `expand 3→5` (which forces `quorum:2/3 → quorum:3/5` under the strict-majority rule `2M>N`) was impossible. `supersede` REPLACES the live row as a **new version**, snapshotting the prior version into an append-only history (§8 — the accord's recovery/expansion audit trail).
+
+- **Migration V089** (pg + sqlite): a `version` column on `federation_families` / `federation_communities` (`DEFAULT 1`; **not** part of `persist_row_hash` — the structs don't carry it — so every legacy row hashes byte-identically) + a `federation_group_versions` history table. (`change_authorization`, not `authorization` — the latter is a PostgreSQL reserved word.)
+- **Trait:** `supersede_group_row` + `list_group_versions` (backend primitives — the supersede is ONE transaction: snapshot prior → replace live → bump version) + default `supersede_family` / `supersede_community` (validate `consensus_protocol` form, then compose) + `group_history` / `group_at` (§8 reads). Backends: sqlite (rusqlite tx), postgres (`cirislens` tx), memory (parity).
+- **New `cohort::GroupVersion`** read type (the live + each superseded version share one shape).
+- **FFI:** `cohort_supersede_group` / `cohort_group_history` / `cohort_group_at`.
+- **Tested:** the `quorum:2/3` (3) → `quorum:3/5` (5) expansion + the full version chain (`group_history` carries the prior `quorum:2/3` snapshot + its authorization; `group_at` pins a version) on sqlite + live Postgres.
+
+The authorization recorded on a superseded version is where Cut G3's quorum envelope + cosignatures land (the next cut wires `ciris_verify_core::threshold` quorum enforcement — verify v6.8.0 ships the crypto; the optional general non-accord helper is CIRISVerify#104).
+
 ## [9.5.0] — 2026-06-21
 
 ### Added — #249 Cut G1: the uniform cohort **rostered-group** surface (CIRISServer #249 §1/§2/§6)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.5.0"
+version = "9.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V089__group_supersede_versioning.sql
+++ b/migrations/postgres/lens/V089__group_supersede_versioning.sql
@@ -1,0 +1,41 @@
+-- V089 — #249 Cut G2: rostered-group supersede + versioning (Postgres dialect)
+--        (CIRISPersist#249 §3/§8; CIRISServer #249 write+governance ask).
+--
+-- §3 (THE write gap): there is no way to change an entrenched group's
+-- consensus_protocol (M/N) or re-baseline its roster — put_family errors on
+-- differing content, and add/revoke can't touch the threshold. So expand
+-- 3→5 (which forces quorum:2/3 → quorum:3/5 under the strict-majority rule)
+-- is impossible today. `supersede` REPLACES the live row as a NEW version,
+-- snapshotting the prior version into an append-only history table (§8 —
+-- the accord's recovery/expansion audit trail).
+--
+-- `version` is substrate metadata, NOT part of persist_row_hash (the Family
+-- / Community structs do not carry the column), so DEFAULT 1 keeps every
+-- legacy row's hash byte-identical.
+
+ALTER TABLE cirislens.federation_families
+    ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE cirislens.federation_communities
+    ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1;
+
+-- ─── append-only group-version history (§8) ────────────────────────
+--
+-- One row per SUPERSEDED prior version (the live row holds the current
+-- version). `snapshot` is the full Family/Community JSONB at that version;
+-- `authorization` is the membership-change authorization that justified the
+-- supersession (the Cut G3 quorum envelope + cosignatures), or NULL.
+CREATE TABLE IF NOT EXISTS cirislens.federation_group_versions (
+    cohort            TEXT NOT NULL
+        CHECK (cohort IN ('family', 'community')),
+    group_key_id      TEXT NOT NULL,
+    version           INTEGER NOT NULL,
+    snapshot          JSONB NOT NULL,
+    change_authorization JSONB,
+    superseded_at     TIMESTAMPTZ NOT NULL,
+    persist_row_hash  TEXT NOT NULL,
+    PRIMARY KEY (cohort, group_key_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS federation_group_versions_by_group
+    ON cirislens.federation_group_versions (cohort, group_key_id);

--- a/migrations/sqlite/lens/V089__group_supersede_versioning.sql
+++ b/migrations/sqlite/lens/V089__group_supersede_versioning.sql
@@ -1,0 +1,45 @@
+-- V089 — #249 Cut G2: rostered-group supersede + versioning (SQLite dialect)
+--        (CIRISPersist#249 §3/§8; CIRISServer #249 write+governance ask).
+--
+-- Postgres parity: postgres/lens/V089. See that file for the design
+-- rationale. The Rust substrate surface is `Engine`/`FederationDirectory`
+-- supersede_family / supersede_community / list_group_versions and the
+-- `federation::cohort::GroupVersion` read type.
+--
+-- §3 (THE write gap): there is no way to change an entrenched group's
+-- consensus_protocol (M/N) or re-baseline its roster — put_family errors on
+-- differing content. supersede REPLACES the live row as a NEW version,
+-- snapshotting the prior version into an append-only history table (§8).
+--
+-- `version` is substrate metadata, NOT part of persist_row_hash, so the
+-- DEFAULT 1 keeps every legacy row's hash byte-identical (the Family /
+-- Community structs do not carry the column).
+
+ALTER TABLE federation_families
+    ADD COLUMN version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE federation_communities
+    ADD COLUMN version INTEGER NOT NULL DEFAULT 1;
+
+-- ─── append-only group-version history (§8) ────────────────────────
+--
+-- One row per SUPERSEDED prior version (the live row holds the current
+-- version). `snapshot` is the full Family/Community JSON at that version;
+-- `authorization` is the membership-change authorization that justified the
+-- supersession (the Cut G3 quorum envelope + cosignatures), or NULL.
+CREATE TABLE IF NOT EXISTS federation_group_versions (
+    cohort            TEXT NOT NULL
+        CHECK (cohort IN ('family', 'community')),
+    group_key_id      TEXT NOT NULL,
+    version           INTEGER NOT NULL,
+    snapshot          TEXT NOT NULL
+        CHECK (json_valid(snapshot)),
+    change_authorization TEXT
+        CHECK (change_authorization IS NULL OR json_valid(change_authorization)),
+    superseded_at     TEXT NOT NULL,    -- RFC-3339
+    persist_row_hash  TEXT NOT NULL,
+    PRIMARY KEY (cohort, group_key_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS federation_group_versions_by_group
+    ON federation_group_versions (cohort, group_key_id);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8198,6 +8198,150 @@ mod tests {
         cohort_surface_roundtrip_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
     }
 
+    /// #249 Cut G2 — supersede + versioning round-trip (CIRISServer #249 §3/§8):
+    /// expand a `quorum:2/3` family of 3 to a `quorum:3/5` family of 5 (the
+    /// strict-majority threshold MUST track the roster), and verify the version
+    /// chain (`group_history` / `group_at`) preserves the prior version with
+    /// its authorization. Backend-generic body; sqlite + live Postgres.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn supersede_versioning_body<D>(d: &D, s: &str)
+    where
+        D: crate::federation::FederationDirectory + ?Sized,
+    {
+        use crate::federation::cohort::Cohort;
+        use crate::federation::types;
+
+        let fam = format!("g2-fam-{s}");
+        let m: Vec<String> = (0..5).map(|i| format!("g2-m{i}-{s}")).collect();
+        for k in std::iter::once(&fam).chain(m.iter()) {
+            d.put_public_key(sweeper_test_key(k))
+                .await
+                .expect("seed key");
+        }
+        let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+        let mk_members = |n: usize| -> Vec<types::FamilyMember> {
+            m[..n]
+                .iter()
+                .map(|k| types::FamilyMember {
+                    key_id: k.clone(),
+                    joined_at: joined,
+                    role: Some("founder".into()),
+                })
+                .collect()
+        };
+
+        // Genesis: 3-member quorum:2/3 family (version 1).
+        d.put_family(crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "accord".into(),
+                members: mk_members(3),
+                founded_at: joined,
+                consensus_protocol: "quorum:2/3".into(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("genesis put_family");
+
+        // Supersede → 5-member quorum:3/5 (the expansion the write gap blocked).
+        let auth = serde_json::json!({"membership_change": "expand 3->5", "quorum": "2/3"});
+        let new_version = d
+            .supersede_family(
+                crate::federation::SignedFamily {
+                    family: types::Family {
+                        family_key_id: fam.clone(),
+                        family_name: "accord".into(),
+                        members: mk_members(5),
+                        founded_at: joined,
+                        consensus_protocol: "quorum:3/5".into(),
+                        consensus_protocol_entrenched: true,
+                        persist_row_hash: String::new(),
+                    },
+                },
+                Some(auth.clone()),
+            )
+            .await
+            .expect("supersede 3->5");
+        assert_eq!(new_version, 2, "supersede bumps version 1 -> 2");
+
+        // Live row is the new 5-member quorum:3/5.
+        let live = d.lookup_family(&fam).await.unwrap().expect("live family");
+        assert_eq!(live.members.len(), 5);
+        assert_eq!(live.consensus_protocol, "quorum:3/5");
+
+        // History chain: v1 (superseded, quorum:2/3, carries authorization) +
+        // v2 (current, quorum:3/5).
+        let hist = d
+            .group_history(Cohort::Family, &fam)
+            .await
+            .expect("history");
+        assert_eq!(hist.len(), 2, "two versions in the chain");
+        assert_eq!(hist[0].version, 1);
+        assert!(!hist[0].is_current);
+        assert!(hist[0].superseded_at.is_some());
+        assert_eq!(hist[0].authorization.as_ref(), Some(&auth));
+        assert_eq!(hist[0].snapshot["consensus_protocol"], "quorum:2/3");
+        assert_eq!(hist[1].version, 2);
+        assert!(hist[1].is_current);
+        assert!(hist[1].superseded_at.is_none());
+
+        // group_at pins a specific version.
+        let v1 = d
+            .group_at(Cohort::Family, &fam, 1)
+            .await
+            .unwrap()
+            .expect("v1 exists");
+        assert_eq!(v1.snapshot["consensus_protocol"], "quorum:2/3");
+        assert!(d.group_at(Cohort::Family, &fam, 9).await.unwrap().is_none());
+
+        // supersede on an unknown group is rejected.
+        let err = d
+            .supersede_family(
+                crate::federation::SignedFamily {
+                    family: types::Family {
+                        family_key_id: format!("g2-ghost-{s}"),
+                        family_name: "ghost".into(),
+                        members: vec![],
+                        founded_at: joined,
+                        consensus_protocol: "quorum:2/3".into(),
+                        consensus_protocol_entrenched: true,
+                        persist_row_hash: String::new(),
+                    },
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument");
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn supersede_versioning_sqlite() {
+        let signer = crate::federation::tier_ingest::test_support::local_signer("g2");
+        let engine = Engine::with_signer(signer, "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        supersede_versioning_body(&*sq, "sq").await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn supersede_versioning_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let label = format!("g2-{}", uuid::Uuid::new_v4().simple());
+        let signer = crate::federation::tier_ingest::test_support::local_signer(&label);
+        let engine = Engine::with_signer(signer, &dsn).await.expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend").clone();
+        supersede_versioning_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
+    }
+
     /// #249 — `file_moderation` stores a `moderation:{allegation}` scores
     /// row when the signer is a named moderator (community founder, as-self
     /// duty-holder). Proves the §11.10 EMIT path is feature-free (no

--- a/src/federation/cohort.rs
+++ b/src/federation/cohort.rs
@@ -185,6 +185,33 @@ impl From<types::Community> for GroupRef {
     }
 }
 
+/// One version of a rostered group's history (#249 Cut G2 §8). The live
+/// (current) version and every superseded prior version share this shape, so
+/// `group_history` returns a uniform chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GroupVersion {
+    /// Which rostered-group kind (`family` / `community`; `self` is not
+    /// versioned).
+    pub cohort: Cohort,
+    /// The group's `federation_keys.key_id`.
+    pub group_key_id: String,
+    /// Monotonic version number (genesis = 1; each `supersede` increments).
+    pub version: u32,
+    /// The full `Family` / `Community` row at this version (JSON).
+    pub snapshot: serde_json::Value,
+    /// The membership-change authorization that PRODUCED this version (the Cut
+    /// G3 quorum envelope + cosignatures), or `None` (genesis / a plain
+    /// pre-supersede `put`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<serde_json::Value>,
+    /// When this version was superseded by the next. `None` ⇒ the live
+    /// (current) version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_at: Option<DateTime<Utc>>,
+    /// `true` for the current live version, `false` for a historical one.
+    pub is_current: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -135,7 +135,7 @@ pub use blobs::{
     PutBlobAttestation, ScopeBlobSymbol, CHUNK_MANIFEST_VERSION, DEFAULT_INLINE_BYTES_CAP,
     HOLDS_BYTES_ATTESTATION_TYPE_PREFIX, HOLDS_BYTES_PREFIX_HEX_LEN,
 };
-pub use cohort::{Cohort, GroupRef, RevokeSpec, RosterMember};
+pub use cohort::{Cohort, GroupRef, GroupVersion, RevokeSpec, RosterMember};
 pub use goal::{
     canonicalize_goal_text, DeliberationRef, Goal, GoalScope, GoalsFilter, M1Dimension,
     MetaGoalAlignment,
@@ -1345,6 +1345,108 @@ pub trait FederationDirectory: Send + Sync {
         self.revoke_member(cohort, group_key_id, out_key_id, spec)
             .await?;
         self.add_member(cohort, group_key_id, in_member).await
+    }
+
+    // ── #249 Cut G2 ── supersede + versioning (CIRISServer #249 §3/§8) ──
+    //
+    // THE write gap: `put_family` / `put_community` error on differing
+    // content and `add`/`revoke` can't touch the `consensus_protocol`, so
+    // there is no way to change an entrenched group's M/N threshold or
+    // atomically re-baseline its roster — `expand 3→5` (which forces
+    // `quorum:2/3 → quorum:3/5` under strict majority) is impossible.
+    // `supersede` REPLACES the live row as a NEW version, snapshotting the
+    // prior version into the append-only `federation_group_versions` history
+    // (§8). `self` is not versioned (occurrences are managed individually).
+    //
+    // `supersede_group_row` + `list_group_versions` are the backend
+    // primitives (the supersede is one transaction: snapshot prior → replace
+    // live → bump version); the typed `supersede_family` / `supersede_community`
+    // and the `group_history` / `group_at` reads are default methods.
+
+    /// #249 Cut G2 — backend primitive: atomically supersede the live
+    /// `family`/`community` row named by `new_snapshot`'s key with the new
+    /// content, snapshotting the prior version into `federation_group_versions`
+    /// and bumping `version`. `new_snapshot` is the full `Family`/`Community`
+    /// JSON (the backend recomputes its `persist_row_hash`). `authorization`
+    /// records the membership-change justification (the Cut G3 quorum envelope
+    /// + cosignatures) on the superseded prior row, or `None`. Returns the new
+    /// version. [`Error::InvalidArgument`] if the group does not exist or the
+    /// cohort is `self`. Prefer the typed [`Self::supersede_family`] /
+    /// [`Self::supersede_community`] wrappers.
+    async fn supersede_group_row(
+        &self,
+        cohort: cohort::Cohort,
+        new_snapshot: serde_json::Value,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, Error>;
+
+    /// #249 Cut G2 (§8) — the full version chain of a `family`/`community`:
+    /// every superseded prior version (from `federation_group_versions`) plus
+    /// the live current version, ascending by `version`. Empty for an unknown
+    /// group; the live version always has `is_current = true` and
+    /// `superseded_at = None`.
+    async fn list_group_versions(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<cohort::GroupVersion>, Error>;
+
+    /// #249 Cut G2 (§3) — supersede a family with new content (a re-baselined
+    /// roster and/or a new `consensus_protocol`) as a new version. Validates
+    /// the new `consensus_protocol` form, then composes
+    /// [`Self::supersede_group_row`]. `authorization` is the membership-change
+    /// justification recorded on the superseded prior version.
+    async fn supersede_family(
+        &self,
+        new: types::SignedFamily,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, Error> {
+        check_consensus_protocol_form(&new.family.consensus_protocol)?;
+        let snapshot = serde_json::to_value(&new.family)
+            .map_err(|e| Error::Backend(format!("supersede_family snapshot serialize: {e}")))?;
+        self.supersede_group_row(cohort::Cohort::Family, snapshot, authorization)
+            .await
+    }
+
+    /// #249 Cut G2 (§3) — supersede a community with new content as a new
+    /// version. Mirror of [`Self::supersede_family`].
+    async fn supersede_community(
+        &self,
+        new: types::SignedCommunity,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, Error> {
+        check_consensus_protocol_form(&new.community.consensus_protocol)?;
+        let snapshot = serde_json::to_value(&new.community)
+            .map_err(|e| Error::Backend(format!("supersede_community snapshot serialize: {e}")))?;
+        self.supersede_group_row(cohort::Cohort::Community, snapshot, authorization)
+            .await
+    }
+
+    /// #249 Cut G2 (§8) — alias for [`Self::list_group_versions`]: the
+    /// supersession audit trail (who superseded whom, when, authorized by
+    /// which quorum).
+    async fn group_history(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<cohort::GroupVersion>, Error> {
+        self.list_group_versions(cohort, group_key_id).await
+    }
+
+    /// #249 Cut G2 (§8) — the `family`/`community` at a specific `version`
+    /// (historical or current). Default filters [`Self::list_group_versions`];
+    /// `Ok(None)` if that version does not exist.
+    async fn group_at(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        version: u32,
+    ) -> Result<Option<cohort::GroupVersion>, Error> {
+        Ok(self
+            .list_group_versions(cohort, group_key_id)
+            .await?
+            .into_iter()
+            .find(|v| v.version == version))
     }
 
     /// #249 Cut B — the INBOUND delegation walk: every key that holds a

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -15531,6 +15531,170 @@ impl PyEngine {
         })
     }
 
+    // ── #249 Cut G2 ── supersede + versioning FFI (CIRISServer #249 §3/§8) ──
+
+    /// #249 Cut G2 (§3) — supersede a `family`/`community` with new content
+    /// (`new_group_json` is the raw `Family`/`Community` object, like
+    /// `put_family_json`) as a new version. `authorization_json` is the
+    /// optional membership-change justification (Cut G3 quorum envelope +
+    /// cosignatures) recorded on the superseded prior version. Returns the new
+    /// version number. `self` is rejected.
+    #[pyo3(signature = (cohort, new_group_json, authorization_json=None))]
+    fn cohort_supersede_group(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        new_group_json: &str,
+        authorization_json: Option<&str>,
+    ) -> PyResult<u32> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let authorization: Option<serde_json::Value> = match authorization_json {
+            Some(s) if !s.is_empty() => Some(
+                serde_json::from_str(s)
+                    .map_err(|e| PyValueError::new_err(format!("authorization_json: {e}")))?,
+            ),
+            _ => None,
+        };
+        use crate::federation::cohort::Cohort;
+        let family: Option<crate::federation::SignedFamily> = match cohort {
+            Cohort::Family => Some(crate::federation::SignedFamily {
+                family: serde_json::from_str(new_group_json)
+                    .map_err(|e| PyValueError::new_err(format!("supersede family JSON: {e}")))?,
+            }),
+            _ => None,
+        };
+        let community: Option<crate::federation::SignedCommunity> = match cohort {
+            Cohort::Community => Some(crate::federation::SignedCommunity {
+                community: serde_json::from_str(new_group_json)
+                    .map_err(|e| PyValueError::new_err(format!("supersede community JSON: {e}")))?,
+            }),
+            _ => None,
+        };
+        if cohort == Cohort::SelfId {
+            return Err(PyValueError::new_err(
+                "cohort_supersede_group: the `self` cohort is not versioned",
+            ));
+        }
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            match cohort {
+                                Cohort::Family => {
+                                    b.supersede_family(
+                                        family.clone().unwrap(),
+                                        authorization.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::Community => {
+                                    b.supersede_community(
+                                        community.clone().unwrap(),
+                                        authorization.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::SelfId => unreachable!(),
+                            }
+                            .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G2 (§8) — the full version chain of a `family`/`community`
+    /// (superseded history + the live current). Returns a JSON array of
+    /// [`crate::federation::cohort::GroupVersion`].
+    fn cohort_group_history(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let rows = b
+                                .group_history(cohort, &group_key_id)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            serde_json::to_string(&rows).map_err(|e| {
+                                PyValueError::new_err(format!("group_history serialize: {e}"))
+                            })
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G2 (§8) — the `family`/`community` at a specific `version`.
+    /// Returns the [`crate::federation::cohort::GroupVersion`] JSON or `None`.
+    fn cohort_group_at(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        version: u32,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let row = b
+                                .group_at(cohort, &group_key_id, version)
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            match row {
+                                Some(v) => serde_json::to_string(&v).map(Some).map_err(|e| {
+                                    PyValueError::new_err(format!("group_at serialize: {e}"))
+                                }),
+                                None => Ok(None),
+                            }
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
     /// #249 Cut B — the FULL named-moderator set of `community_key_id` for
     /// `duty` (`moderate` / `takedown` / `review`): owner-bound authority
     /// roots ∪ their duty-scoped delegates. Returns a JSON array of key_ids.

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -97,6 +97,14 @@ struct State {
     /// v4.0 (CEG 0.8 §8.1.13.3) — community rows keyed by
     /// `community_key_id`. Mirrors V060 PG/SQLite PK.
     federation_communities: HashMap<String, crate::federation::Community>,
+    /// #249 Cut G2 — current live version per group, keyed by
+    /// `(cohort, group_key_id)` (`cohort` ∈ `family`/`community`). Mirrors
+    /// the V089 `version` column; absent ⇒ 1.
+    federation_group_current_version: HashMap<(String, String), u32>,
+    /// #249 Cut G2 (§8) — append-only superseded version history, keyed by
+    /// `(cohort, group_key_id)`. Mirrors V089 `federation_group_versions`.
+    federation_group_versions:
+        HashMap<(String, String), Vec<crate::federation::cohort::GroupVersion>>,
     /// v4.8.0 (CIRISPersist#161, CEG §11.7.1) — Option-A forward-secrecy
     /// removal/revocation rows. Keyed by the V067 composite PKs.
     federation_identity_occurrence_revocations:
@@ -200,6 +208,8 @@ impl Default for MemoryBackend {
                 federation_identity_occurrences: HashMap::new(),
                 federation_families: HashMap::new(),
                 federation_communities: HashMap::new(),
+                federation_group_current_version: HashMap::new(),
+                federation_group_versions: HashMap::new(),
                 federation_identity_occurrence_revocations: HashMap::new(),
                 federation_family_membership_revocations: HashMap::new(),
                 federation_community_membership_revocations: HashMap::new(),
@@ -1632,6 +1642,169 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         community.members.push(member);
         community.persist_row_hash = crate::federation::types::compute_persist_row_hash(community)?;
         Ok(true)
+    }
+
+    // #249 Cut G2 — supersede + versioning (CIRISServer #249 §3/§8).
+    async fn supersede_group_row(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        new_snapshot: serde_json::Value,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, crate::federation::Error> {
+        use crate::federation::cohort::{Cohort, GroupVersion};
+        use crate::federation::Error;
+        let cohort_str = match cohort {
+            Cohort::Family => "family".to_string(),
+            Cohort::Community => "community".to_string(),
+            Cohort::SelfId => {
+                return Err(Error::InvalidArgument(
+                    "supersede: the `self` cohort is not versioned".to_string(),
+                ))
+            }
+        };
+        let now = chrono::Utc::now();
+        let mut state = self.state.lock().expect("memory backend lock");
+        match cohort {
+            Cohort::Family => {
+                let mut new_fam: crate::federation::Family = serde_json::from_value(new_snapshot)
+                    .map_err(|e| {
+                    Error::InvalidArgument(format!("supersede family snapshot decode: {e}"))
+                })?;
+                new_fam.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_fam)?;
+                let key = new_fam.family_key_id.clone();
+                let prior = state
+                    .federation_families
+                    .get(&key)
+                    .cloned()
+                    .ok_or_else(|| {
+                        Error::InvalidArgument(format!(
+                            "supersede: unknown family group {key:?} (nothing to supersede)"
+                        ))
+                    })?;
+                let cur_ver = *state
+                    .federation_group_current_version
+                    .get(&(cohort_str.clone(), key.clone()))
+                    .unwrap_or(&1);
+                let snapshot = serde_json::to_value(&prior).unwrap_or(serde_json::Value::Null);
+                state
+                    .federation_group_versions
+                    .entry((cohort_str.clone(), key.clone()))
+                    .or_default()
+                    .push(GroupVersion {
+                        cohort,
+                        group_key_id: key.clone(),
+                        version: cur_ver,
+                        snapshot,
+                        authorization,
+                        superseded_at: Some(now),
+                        is_current: false,
+                    });
+                state.federation_families.insert(key.clone(), new_fam);
+                let next = cur_ver + 1;
+                state
+                    .federation_group_current_version
+                    .insert((cohort_str, key), next);
+                Ok(next)
+            }
+            Cohort::Community => {
+                let mut new_comm: crate::federation::Community =
+                    serde_json::from_value(new_snapshot).map_err(|e| {
+                        Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
+                    })?;
+                new_comm.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_comm)?;
+                let key = new_comm.community_key_id.clone();
+                let prior = state
+                    .federation_communities
+                    .get(&key)
+                    .cloned()
+                    .ok_or_else(|| {
+                        Error::InvalidArgument(format!(
+                            "supersede: unknown community group {key:?} (nothing to supersede)"
+                        ))
+                    })?;
+                let cur_ver = *state
+                    .federation_group_current_version
+                    .get(&(cohort_str.clone(), key.clone()))
+                    .unwrap_or(&1);
+                let snapshot = serde_json::to_value(&prior).unwrap_or(serde_json::Value::Null);
+                state
+                    .federation_group_versions
+                    .entry((cohort_str.clone(), key.clone()))
+                    .or_default()
+                    .push(GroupVersion {
+                        cohort,
+                        group_key_id: key.clone(),
+                        version: cur_ver,
+                        snapshot,
+                        authorization,
+                        superseded_at: Some(now),
+                        is_current: false,
+                    });
+                state.federation_communities.insert(key.clone(), new_comm);
+                let next = cur_ver + 1;
+                state
+                    .federation_group_current_version
+                    .insert((cohort_str, key), next);
+                Ok(next)
+            }
+            Cohort::SelfId => unreachable!("guarded above"),
+        }
+    }
+
+    // #249 Cut G2 (§8) — full version chain: history rows + the live current.
+    async fn list_group_versions(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<crate::federation::cohort::GroupVersion>, crate::federation::Error> {
+        use crate::federation::cohort::{Cohort, GroupVersion};
+        use crate::federation::Error;
+        if cohort == Cohort::SelfId {
+            return Err(Error::InvalidArgument(
+                "list_group_versions: the `self` cohort is not versioned".to_string(),
+            ));
+        }
+        let cohort_str = if cohort == Cohort::Family {
+            "family".to_string()
+        } else {
+            "community".to_string()
+        };
+        let state = self.state.lock().expect("memory backend lock");
+        let mut out: Vec<GroupVersion> = state
+            .federation_group_versions
+            .get(&(cohort_str.clone(), group_key_id.to_string()))
+            .cloned()
+            .unwrap_or_default();
+        let cur_ver = *state
+            .federation_group_current_version
+            .get(&(cohort_str, group_key_id.to_string()))
+            .unwrap_or(&1);
+        let live = match cohort {
+            Cohort::Family => state
+                .federation_families
+                .get(group_key_id)
+                .map(|f| serde_json::to_value(f).unwrap_or(serde_json::Value::Null)),
+            Cohort::Community => state
+                .federation_communities
+                .get(group_key_id)
+                .map(|c| serde_json::to_value(c).unwrap_or(serde_json::Value::Null)),
+            Cohort::SelfId => None,
+        };
+        if let Some(snapshot) = live {
+            out.push(GroupVersion {
+                cohort,
+                group_key_id: group_key_id.to_string(),
+                version: cur_ver,
+                snapshot,
+                authorization: None,
+                superseded_at: None,
+                is_current: true,
+            });
+        }
+        out.sort_by_key(|v| v.version);
+        Ok(out)
     }
 
     async fn list_families_for_member(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2978,6 +2978,279 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         Ok(true)
     }
 
+    // #249 Cut G2 — supersede + versioning (CIRISServer #249 §3/§8).
+    async fn supersede_group_row(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        new_snapshot: serde_json::Value,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, crate::federation::Error> {
+        use crate::federation::cohort::Cohort;
+        use crate::federation::Error;
+        match cohort {
+            Cohort::SelfId => {
+                return Err(Error::InvalidArgument(
+                    "supersede: the `self` cohort is not versioned".to_string(),
+                ))
+            }
+            Cohort::Family | Cohort::Community => {}
+        }
+        let now = chrono::Utc::now();
+        let mut client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+        let next: i32 = match cohort {
+            Cohort::Family => {
+                let mut new_fam: crate::federation::Family = serde_json::from_value(new_snapshot)
+                    .map_err(|e| {
+                    Error::InvalidArgument(format!("supersede family snapshot decode: {e}"))
+                })?;
+                new_fam.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_fam)?;
+                let members_value = serde_json::to_value(&new_fam.members)
+                    .map_err(|e| Error::Backend(format!("members serialize: {e}")))?;
+                let tx = client
+                    .transaction()
+                    .await
+                    .map_err(|e| Error::Backend(format!("begin tx: {e}")))?;
+                let prior = tx
+                    .query_opt(
+                        "SELECT version, family_key_id, family_name, members, founded_at, \
+                                consensus_protocol, consensus_protocol_entrenched, persist_row_hash \
+                         FROM cirislens.federation_families WHERE family_key_id = $1",
+                        &[&new_fam.family_key_id],
+                    )
+                    .await
+                    .map_err(|e| Error::Backend(format!("supersede read prior family: {e}")))?
+                    .ok_or_else(|| {
+                        Error::InvalidArgument(format!(
+                            "supersede: unknown family group {:?} (nothing to supersede)",
+                            new_fam.family_key_id
+                        ))
+                    })?;
+                let prior_version: i32 = prior.get("version");
+                let prior_fam = pg_row_to_family(prior)?;
+                let snapshot = serde_json::to_value(&prior_fam)
+                    .map_err(|e| Error::Backend(format!("snapshot serialize: {e}")))?;
+                tx.execute(
+                    "INSERT INTO cirislens.federation_group_versions \
+                        (cohort, group_key_id, version, snapshot, change_authorization, \
+                         superseded_at, persist_row_hash) \
+                     VALUES ('family', $1, $2, $3, $4, $5, $6)",
+                    &[
+                        &new_fam.family_key_id,
+                        &prior_version,
+                        &snapshot,
+                        &authorization,
+                        &now,
+                        &prior_fam.persist_row_hash,
+                    ],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("insert group version: {e}")))?;
+                let next = prior_version + 1;
+                tx.execute(
+                    "UPDATE cirislens.federation_families SET \
+                        family_name = $2, members = $3, founded_at = $4, \
+                        consensus_protocol = $5, consensus_protocol_entrenched = $6, \
+                        persist_row_hash = $7, version = $8 \
+                     WHERE family_key_id = $1",
+                    &[
+                        &new_fam.family_key_id,
+                        &new_fam.family_name,
+                        &members_value,
+                        &new_fam.founded_at,
+                        &new_fam.consensus_protocol,
+                        &new_fam.consensus_protocol_entrenched,
+                        &new_fam.persist_row_hash,
+                        &next,
+                    ],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("update family: {e}")))?;
+                tx.commit()
+                    .await
+                    .map_err(|e| Error::Backend(format!("commit: {e}")))?;
+                next
+            }
+            Cohort::Community => {
+                let mut new_comm: crate::federation::Community =
+                    serde_json::from_value(new_snapshot).map_err(|e| {
+                        Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
+                    })?;
+                new_comm.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_comm)?;
+                let members_value = serde_json::to_value(&new_comm.members)
+                    .map_err(|e| Error::Backend(format!("members serialize: {e}")))?;
+                let tx = client
+                    .transaction()
+                    .await
+                    .map_err(|e| Error::Backend(format!("begin tx: {e}")))?;
+                let prior = tx
+                    .query_opt(
+                        "SELECT version, community_key_id, community_name, members, founded_at, \
+                                consensus_protocol, policy_blob, persist_row_hash \
+                         FROM cirislens.federation_communities WHERE community_key_id = $1",
+                        &[&new_comm.community_key_id],
+                    )
+                    .await
+                    .map_err(|e| Error::Backend(format!("supersede read prior community: {e}")))?
+                    .ok_or_else(|| {
+                        Error::InvalidArgument(format!(
+                            "supersede: unknown community group {:?} (nothing to supersede)",
+                            new_comm.community_key_id
+                        ))
+                    })?;
+                let prior_version: i32 = prior.get("version");
+                let prior_comm = pg_row_to_community(prior)?;
+                let snapshot = serde_json::to_value(&prior_comm)
+                    .map_err(|e| Error::Backend(format!("snapshot serialize: {e}")))?;
+                tx.execute(
+                    "INSERT INTO cirislens.federation_group_versions \
+                        (cohort, group_key_id, version, snapshot, change_authorization, \
+                         superseded_at, persist_row_hash) \
+                     VALUES ('community', $1, $2, $3, $4, $5, $6)",
+                    &[
+                        &new_comm.community_key_id,
+                        &prior_version,
+                        &snapshot,
+                        &authorization,
+                        &now,
+                        &prior_comm.persist_row_hash,
+                    ],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("insert group version: {e}")))?;
+                let next = prior_version + 1;
+                tx.execute(
+                    "UPDATE cirislens.federation_communities SET \
+                        community_name = $2, members = $3, founded_at = $4, \
+                        consensus_protocol = $5, policy_blob = $6, \
+                        persist_row_hash = $7, version = $8 \
+                     WHERE community_key_id = $1",
+                    &[
+                        &new_comm.community_key_id,
+                        &new_comm.community_name,
+                        &members_value,
+                        &new_comm.founded_at,
+                        &new_comm.consensus_protocol,
+                        &new_comm.policy_blob,
+                        &new_comm.persist_row_hash,
+                        &next,
+                    ],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("update community: {e}")))?;
+                tx.commit()
+                    .await
+                    .map_err(|e| Error::Backend(format!("commit: {e}")))?;
+                next
+            }
+            Cohort::SelfId => unreachable!("guarded above"),
+        };
+        Ok(next as u32)
+    }
+
+    // #249 Cut G2 (§8) — full version chain: history rows + the live current.
+    async fn list_group_versions(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<crate::federation::cohort::GroupVersion>, crate::federation::Error> {
+        use crate::federation::cohort::{Cohort, GroupVersion};
+        use crate::federation::Error;
+        if cohort == Cohort::SelfId {
+            return Err(Error::InvalidArgument(
+                "list_group_versions: the `self` cohort is not versioned".to_string(),
+            ));
+        }
+        let cohort_str = if cohort == Cohort::Family {
+            "family"
+        } else {
+            "community"
+        };
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT version, snapshot, change_authorization, superseded_at \
+                 FROM cirislens.federation_group_versions \
+                 WHERE cohort = $1 AND group_key_id = $2 ORDER BY version ASC",
+                &[&cohort_str, &group_key_id],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("list_group_versions: {e}")))?;
+        let mut out: Vec<GroupVersion> = Vec::new();
+        for r in rows {
+            let version: i32 = r.get("version");
+            let snapshot: serde_json::Value = r.get("snapshot");
+            let authorization: Option<serde_json::Value> = r.get("change_authorization");
+            let superseded_at: chrono::DateTime<chrono::Utc> = r.get("superseded_at");
+            out.push(GroupVersion {
+                cohort,
+                group_key_id: group_key_id.to_string(),
+                version: version as u32,
+                snapshot,
+                authorization,
+                superseded_at: Some(superseded_at),
+                is_current: false,
+            });
+        }
+        let live = if cohort == Cohort::Family {
+            client
+                .query_opt(
+                    "SELECT version, family_key_id, family_name, members, founded_at, \
+                            consensus_protocol, consensus_protocol_entrenched, persist_row_hash \
+                     FROM cirislens.federation_families WHERE family_key_id = $1",
+                    &[&group_key_id],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("list_group_versions live family: {e}")))?
+                .map(|r| {
+                    let v: i32 = r.get("version");
+                    let fam = pg_row_to_family(r)?;
+                    let snap = serde_json::to_value(&fam)
+                        .map_err(|e| Error::Backend(format!("live snapshot: {e}")))?;
+                    Ok::<_, Error>((v, snap))
+                })
+                .transpose()?
+        } else {
+            client
+                .query_opt(
+                    "SELECT version, community_key_id, community_name, members, founded_at, \
+                            consensus_protocol, policy_blob, persist_row_hash \
+                     FROM cirislens.federation_communities WHERE community_key_id = $1",
+                    &[&group_key_id],
+                )
+                .await
+                .map_err(|e| Error::Backend(format!("list_group_versions live community: {e}")))?
+                .map(|r| {
+                    let v: i32 = r.get("version");
+                    let comm = pg_row_to_community(r)?;
+                    let snap = serde_json::to_value(&comm)
+                        .map_err(|e| Error::Backend(format!("live snapshot: {e}")))?;
+                    Ok::<_, Error>((v, snap))
+                })
+                .transpose()?
+        };
+        if let Some((version, snapshot)) = live {
+            out.push(GroupVersion {
+                cohort,
+                group_key_id: group_key_id.to_string(),
+                version: version as u32,
+                snapshot,
+                authorization: None,
+                superseded_at: None,
+                is_current: true,
+            });
+        }
+        out.sort_by_key(|v| v.version);
+        Ok(out)
+    }
+
     async fn lookup_family(
         &self,
         family_key_id: &str,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2623,6 +2623,298 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         Ok(true)
     }
 
+    // #249 Cut G2 — supersede + versioning (CIRISServer #249 §3/§8).
+    async fn supersede_group_row(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        new_snapshot: serde_json::Value,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, crate::federation::Error> {
+        use crate::federation::cohort::Cohort;
+        use crate::federation::Error;
+        let conn = self.conn.clone();
+        let now = chrono::Utc::now().to_rfc3339();
+        let auth_json = match authorization {
+            Some(v) => Some(
+                serde_json::to_string(&v)
+                    .map_err(|e| Error::Backend(format!("authorization serialize: {e}")))?,
+            ),
+            None => None,
+        };
+        // Map a "group does not exist" sentinel back to a typed error.
+        let not_found = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let nf = not_found.clone();
+        let cohort_str = match cohort {
+            Cohort::Family => "family",
+            Cohort::Community => "community",
+            Cohort::SelfId => {
+                return Err(Error::InvalidArgument(
+                    "supersede: the `self` cohort is not versioned (manage occurrences via \
+                     put_identity_occurrence / put_identity_occurrence_revocation)"
+                        .to_string(),
+                ))
+            }
+        };
+
+        let new_version = match cohort {
+            Cohort::Family => {
+                let mut new_fam: crate::federation::Family = serde_json::from_value(new_snapshot)
+                    .map_err(|e| {
+                    Error::InvalidArgument(format!("supersede family snapshot decode: {e}"))
+                })?;
+                new_fam.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_fam)?;
+                let members_json = serde_json::to_string(&new_fam.members)
+                    .map_err(|e| Error::Backend(format!("members serialize: {e}")))?;
+                (move || -> Result<u32, rusqlite::Error> {
+                    let mut conn = conn.lock();
+                    let tx = conn.transaction()?;
+                    let prior = tx
+                        .query_row(
+                            "SELECT version, family_key_id, family_name, members, founded_at, \
+                                    consensus_protocol, consensus_protocol_entrenched, \
+                                    persist_row_hash \
+                             FROM federation_families WHERE family_key_id = ?1",
+                            [&new_fam.family_key_id],
+                            |r| Ok((r.get::<_, u32>("version")?, sqlite_row_to_family(r)?)),
+                        )
+                        .optional()?;
+                    let (prior_version, prior_fam) = match prior {
+                        Some(p) => p,
+                        None => {
+                            nf.store(true, std::sync::atomic::Ordering::SeqCst);
+                            return Err(rusqlite::Error::QueryReturnedNoRows);
+                        }
+                    };
+                    let snapshot = serde_json::to_string(&prior_fam)
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+                    tx.execute(
+                        "INSERT INTO federation_group_versions \
+                            (cohort, group_key_id, version, snapshot, change_authorization, \
+                             superseded_at, persist_row_hash) \
+                         VALUES ('family', ?1, ?2, ?3, ?4, ?5, ?6)",
+                        rusqlite::params![
+                            new_fam.family_key_id,
+                            prior_version,
+                            snapshot,
+                            auth_json,
+                            now,
+                            prior_fam.persist_row_hash,
+                        ],
+                    )?;
+                    let next = prior_version + 1;
+                    tx.execute(
+                        "UPDATE federation_families SET \
+                            family_name = ?2, members = ?3, founded_at = ?4, \
+                            consensus_protocol = ?5, consensus_protocol_entrenched = ?6, \
+                            persist_row_hash = ?7, version = ?8 \
+                         WHERE family_key_id = ?1",
+                        rusqlite::params![
+                            new_fam.family_key_id,
+                            new_fam.family_name,
+                            members_json,
+                            new_fam.founded_at.to_rfc3339(),
+                            new_fam.consensus_protocol,
+                            new_fam.consensus_protocol_entrenched as i64,
+                            new_fam.persist_row_hash,
+                            next,
+                        ],
+                    )?;
+                    tx.commit()?;
+                    Ok(next)
+                })()
+            }
+            Cohort::Community => {
+                let mut new_comm: crate::federation::Community =
+                    serde_json::from_value(new_snapshot).map_err(|e| {
+                        Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
+                    })?;
+                new_comm.persist_row_hash =
+                    crate::federation::types::compute_persist_row_hash(&new_comm)?;
+                let members_json = serde_json::to_string(&new_comm.members)
+                    .map_err(|e| Error::Backend(format!("members serialize: {e}")))?;
+                let policy_json = match &new_comm.policy_blob {
+                    Some(v) => Some(
+                        serde_json::to_string(v)
+                            .map_err(|e| Error::Backend(format!("policy_blob serialize: {e}")))?,
+                    ),
+                    None => None,
+                };
+                (move || -> Result<u32, rusqlite::Error> {
+                    let mut conn = conn.lock();
+                    let tx = conn.transaction()?;
+                    let prior = tx
+                        .query_row(
+                            "SELECT version, community_key_id, community_name, members, \
+                                    founded_at, consensus_protocol, policy_blob, persist_row_hash \
+                             FROM federation_communities WHERE community_key_id = ?1",
+                            [&new_comm.community_key_id],
+                            |r| Ok((r.get::<_, u32>("version")?, sqlite_row_to_community(r)?)),
+                        )
+                        .optional()?;
+                    let (prior_version, prior_comm) = match prior {
+                        Some(p) => p,
+                        None => {
+                            nf.store(true, std::sync::atomic::Ordering::SeqCst);
+                            return Err(rusqlite::Error::QueryReturnedNoRows);
+                        }
+                    };
+                    let snapshot = serde_json::to_string(&prior_comm)
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+                    tx.execute(
+                        "INSERT INTO federation_group_versions \
+                            (cohort, group_key_id, version, snapshot, change_authorization, \
+                             superseded_at, persist_row_hash) \
+                         VALUES ('community', ?1, ?2, ?3, ?4, ?5, ?6)",
+                        rusqlite::params![
+                            new_comm.community_key_id,
+                            prior_version,
+                            snapshot,
+                            auth_json,
+                            now,
+                            prior_comm.persist_row_hash,
+                        ],
+                    )?;
+                    let next = prior_version + 1;
+                    tx.execute(
+                        "UPDATE federation_communities SET \
+                            community_name = ?2, members = ?3, founded_at = ?4, \
+                            consensus_protocol = ?5, policy_blob = ?6, \
+                            persist_row_hash = ?7, version = ?8 \
+                         WHERE community_key_id = ?1",
+                        rusqlite::params![
+                            new_comm.community_key_id,
+                            new_comm.community_name,
+                            members_json,
+                            new_comm.founded_at.to_rfc3339(),
+                            new_comm.consensus_protocol,
+                            policy_json,
+                            new_comm.persist_row_hash,
+                            next,
+                        ],
+                    )?;
+                    tx.commit()?;
+                    Ok(next)
+                })()
+            }
+            Cohort::SelfId => unreachable!("guarded above"),
+        }
+        .map_err(|e| {
+            if not_found.load(std::sync::atomic::Ordering::SeqCst) {
+                Error::InvalidArgument(format!(
+                    "supersede: unknown {cohort_str} group (nothing to supersede)"
+                ))
+            } else {
+                Error::Backend(format!("supersede {cohort_str}: {e}"))
+            }
+        })?;
+        Ok(new_version)
+    }
+
+    // #249 Cut G2 (§8) — full version chain: history rows + the live current.
+    async fn list_group_versions(
+        &self,
+        cohort: crate::federation::cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<Vec<crate::federation::cohort::GroupVersion>, crate::federation::Error> {
+        use crate::federation::cohort::{Cohort, GroupVersion};
+        use crate::federation::Error;
+        if cohort == Cohort::SelfId {
+            return Err(Error::InvalidArgument(
+                "list_group_versions: the `self` cohort is not versioned".to_string(),
+            ));
+        }
+        let cohort_str = if cohort == Cohort::Family {
+            "family"
+        } else {
+            "community"
+        };
+        let conn = self.conn.clone();
+        let key = group_key_id.to_owned();
+        let cs = cohort_str.to_owned();
+        (move || -> Result<Vec<GroupVersion>, rusqlite::Error> {
+            let conn = conn.lock();
+            // Superseded prior versions.
+            let mut out: Vec<GroupVersion> = Vec::new();
+            let mut stmt = conn.prepare(
+                "SELECT version, snapshot, change_authorization, superseded_at \
+                 FROM federation_group_versions \
+                 WHERE cohort = ?1 AND group_key_id = ?2 ORDER BY version ASC",
+            )?;
+            let rows = stmt.query_map(rusqlite::params![cs, key], |r| {
+                let version: u32 = r.get("version")?;
+                let snapshot_text: String = r.get("snapshot")?;
+                let auth_text: Option<String> = r.get("change_authorization")?;
+                let superseded_at: String = r.get("superseded_at")?;
+                Ok((version, snapshot_text, auth_text, superseded_at))
+            })?;
+            for row in rows {
+                let (version, snapshot_text, auth_text, superseded_at) = row?;
+                let snapshot: serde_json::Value =
+                    serde_json::from_str(&snapshot_text).unwrap_or(serde_json::Value::Null);
+                let authorization =
+                    auth_text.and_then(|t| serde_json::from_str::<serde_json::Value>(&t).ok());
+                out.push(GroupVersion {
+                    cohort,
+                    group_key_id: key.clone(),
+                    version,
+                    snapshot,
+                    authorization,
+                    superseded_at: Some(parse_rfc3339(&superseded_at)),
+                    is_current: false,
+                });
+            }
+            // The live current version.
+            let live: Option<(u32, serde_json::Value)> = if cohort == Cohort::Family {
+                conn.query_row(
+                    "SELECT version, family_key_id, family_name, members, founded_at, \
+                            consensus_protocol, consensus_protocol_entrenched, persist_row_hash \
+                     FROM federation_families WHERE family_key_id = ?1",
+                    [&key],
+                    |r| {
+                        let v: u32 = r.get("version")?;
+                        let fam = sqlite_row_to_family(r)?;
+                        Ok((
+                            v,
+                            serde_json::to_value(&fam).unwrap_or(serde_json::Value::Null),
+                        ))
+                    },
+                )
+                .optional()?
+            } else {
+                conn.query_row(
+                    "SELECT version, community_key_id, community_name, members, founded_at, \
+                            consensus_protocol, policy_blob, persist_row_hash \
+                     FROM federation_communities WHERE community_key_id = ?1",
+                    [&key],
+                    |r| {
+                        let v: u32 = r.get("version")?;
+                        let comm = sqlite_row_to_community(r)?;
+                        Ok((
+                            v,
+                            serde_json::to_value(&comm).unwrap_or(serde_json::Value::Null),
+                        ))
+                    },
+                )
+                .optional()?
+            };
+            if let Some((version, snapshot)) = live {
+                out.push(GroupVersion {
+                    cohort,
+                    group_key_id: key.clone(),
+                    version,
+                    snapshot,
+                    authorization: None,
+                    superseded_at: None,
+                    is_current: true,
+                });
+            }
+            out.sort_by_key(|v| v.version);
+            Ok(out)
+        })()
+        .map_err(|e| Error::Backend(format!("list_group_versions: {e}")))
+    }
+
     async fn lookup_family(
         &self,
         family_key_id: &str,


### PR DESCRIPTION
## v9.6.0 — #249 Cut G2: rostered-group **supersede + versioning**

The second cut of the CIRISServer #249 write+governance ask (§3/§8), stacked on Cut G1 (v9.5.0).

**THE write gap (§3):** `put_family`/`put_community` error on differing content and `add`/`revoke` can't touch the `consensus_protocol`, so changing a group's M/N threshold or atomically re-baselining its roster — `expand 3→5` (which forces `quorum:2/3 → quorum:3/5` under strict majority `2M>N`) — was impossible. `supersede` REPLACES the live row as a **new version**, snapshotting the prior version into an append-only history (§8 — the accord's recovery/expansion audit trail).

- **Migration V089** (pg + sqlite): a `version` column on `federation_families`/`federation_communities` (`DEFAULT 1`, **not** in `persist_row_hash` — structs don't carry it — so legacy rows hash byte-identically) + a `federation_group_versions` history table. The history-authorization column is `change_authorization` (**`authorization` is a PostgreSQL reserved word** — 42601).
- **Trait:** `supersede_group_row` + `list_group_versions` (backend primitives, one transaction: snapshot prior → replace live → bump version) + default `supersede_family`/`supersede_community` + `group_history`/`group_at`. Backends: sqlite (rusqlite tx), postgres (`cirislens` tx), memory (parity).
- **`cohort::GroupVersion`** read type; FFI `cohort_supersede_group` / `cohort_group_history` / `cohort_group_at`.
- **Tested:** `quorum:2/3` (3) → `quorum:3/5` (5) expansion + the full version chain (prior `quorum:2/3` snapshot + its authorization preserved; `group_at` pins a version; unknown-group supersede rejected) on sqlite + live Postgres.

Cut G3 (next) wires `ciris_verify_core::threshold` quorum enforcement onto the `authorization` recorded here.

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1575/1575**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
