### PR TITLE
v9.7.0 — #249 Cut G3: quorum-authorized membership gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.7.0] — 2026-06-21
+
+### Added — #249 Cut G3: quorum-authorized membership gate (CIRISServer #249 §4/§5)
+
+The deferred v3.13+ admission gate, landed on CIRISVerify v6.8.0's threshold primitives. A membership change to a `quorum:M/N` family/community is now authorized **in the substrate** by ≥M valid hybrid member cosignatures over the canonical change payload — so **one-seat-per-human + M-of-N-to-change become invariants of the graph**, not properties any single server upholds. The change is authorized by the group's **current/prior** roster (the existing holders decide who joins or leaves; an incoming key never authorizes its own admission).
+
+- **`FederationDirectory::verify_membership_quorum(cohort, group_key_id, change_envelope, signatures)`** (default method, backend parity): looks up the group → parses its `consensus_protocol` to a `ciris_verify_core::threshold::QuorumPolicy` (rejecting non-`quorum:M/N` forms and non-strict-majority `2M>N`) → maps the active roster (`active_member_keys`, Cut G1 §2) to `ThresholdMember`s → canonicalizes `change_envelope` with `ciris_verify_core::jcs` (the §5 payload) → `verify_threshold_signatures_with_policy(.., M, HybridPolicy::RequireHybrid)`. A classical-only signature does **not** count at this federation-authority gate (CC 5.3.2.4.3.1). Returns the valid distinct-cosigner count.
+- **`supersede_family_with_quorum` / `supersede_community_with_quorum`** (default methods): verify the quorum against the prior group, THEN supersede (Cut G2), recording `{change_envelope, quorum_signatures}` as the superseded version's authorization (the §8 audit trail). A rejected quorum leaves the live row untouched (verify before mutation).
+- **FFI:** `cohort_verify_membership_quorum` / `cohort_supersede_group_with_quorum`.
+- **Test helpers:** `tier_ingest::test_support::{threshold_sign, register_hybrid_key}` (real deterministic Ed25519 + ML-DSA-65 hybrid signers, pubkeys matching the registered roster).
+- **Tested:** a `quorum:2/3` family expands to `quorum:3/5` only when 2 of the 3 prior members cosign the JCS payload; 1 cosignature is rejected (insufficient) and the live roster is untouched — on sqlite + live Postgres.
+
+This consumes verify v6.8.0 as-is; the optional general (role-agnostic, non-entrenched) `build/verify_membership_change` helper is tracked at CIRISVerify#104.
+
 ## [9.6.0] — 2026-06-21
 
 ### Added — #249 Cut G2: rostered-group **supersede + versioning** (CIRISServer #249 §3/§8)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.6.0"
+version = "9.7.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8342,6 +8342,147 @@ mod tests {
         supersede_versioning_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
     }
 
+    /// #249 Cut G3 — quorum-authorized membership gate (CIRISServer #249 §4/§5).
+    /// A `quorum:2/3` family expands to `quorum:3/5` ONLY when ≥M (=2) of the
+    /// PRIOR roster's real hybrid keys cosign the canonical change payload;
+    /// 1 cosignature is rejected and leaves the live row untouched. Real
+    /// Ed25519 + ML-DSA-65 signers; backend-generic body run on sqlite + pg.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn quorum_supersede_body<D>(d: &D, s: &str)
+    where
+        D: crate::federation::FederationDirectory + ?Sized,
+    {
+        use crate::federation::cohort::Cohort;
+        use crate::federation::tier_ingest::test_support::{register_hybrid_key, threshold_sign};
+        use crate::federation::types;
+
+        let fam = format!("g3-fam-{s}");
+        let m: Vec<String> = (0..5).map(|i| format!("g3-m{i}-{s}")).collect();
+        // Register the family key + all 5 member keys with REAL deterministic
+        // hybrid pubkeys (so threshold_sign's signatures verify against them).
+        register_hybrid_key(d, &fam).await;
+        for k in &m {
+            register_hybrid_key(d, k).await;
+        }
+        let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+        let mk = |n: usize| -> Vec<types::FamilyMember> {
+            m[..n]
+                .iter()
+                .map(|k| types::FamilyMember {
+                    key_id: k.clone(),
+                    joined_at: joined,
+                    role: Some("founder".into()),
+                })
+                .collect()
+        };
+
+        // Genesis: quorum:2/3 family (3 members, M=2).
+        d.put_family(crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "accord".into(),
+                members: mk(3),
+                founded_at: joined,
+                consensus_protocol: "quorum:2/3".into(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("genesis");
+
+        // Change payload (what the prior roster cosigns) → expand to 5 / 3-of-5.
+        let change_envelope = serde_json::json!({
+            "family_key_id": fam,
+            "new_member_key_ids": m,
+            "consensus_protocol": "quorum:3/5",
+        });
+        let bytes = ciris_verify_core::jcs::canonicalize(&change_envelope).unwrap();
+        let new5 = crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "accord".into(),
+                members: mk(5),
+                founded_at: joined,
+                consensus_protocol: "quorum:3/5".into(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            },
+        };
+
+        // 2 of the 3 PRIOR members cosign → meets quorum:2/3.
+        let sigs = vec![threshold_sign(&m[0], &bytes), threshold_sign(&m[1], &bytes)];
+        let v = d
+            .supersede_family_with_quorum(new5.clone(), change_envelope.clone(), sigs)
+            .await
+            .expect("2-of-3 quorum authorizes the expansion");
+        assert_eq!(v, 2, "supersede bumps to version 2");
+        let live = d.lookup_family(&fam).await.unwrap().unwrap();
+        assert_eq!(live.members.len(), 5);
+        assert_eq!(live.consensus_protocol, "quorum:3/5");
+        // The quorum envelope + signatures are recorded as the v1 authorization.
+        let hist = d.group_history(Cohort::Family, &fam).await.unwrap();
+        assert_eq!(hist[0].version, 1);
+        assert!(
+            hist[0].authorization.is_some(),
+            "superseded v1 carries the quorum authorization"
+        );
+
+        // Negative: the group is now quorum:3/5 (M=3); 1 cosignature is
+        // insufficient → rejected, and the live row is untouched.
+        let env2 = serde_json::json!({"family_key_id": fam, "note": "shrink attempt"});
+        let bytes2 = ciris_verify_core::jcs::canonicalize(&env2).unwrap();
+        let one = vec![threshold_sign(&m[0], &bytes2)];
+        let shrink = crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "accord".into(),
+                members: mk(3),
+                founded_at: joined,
+                consensus_protocol: "quorum:2/3".into(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            },
+        };
+        let err = d
+            .supersede_family_with_quorum(shrink, env2, one)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument");
+        let live2 = d.lookup_family(&fam).await.unwrap().unwrap();
+        assert_eq!(
+            live2.members.len(),
+            5,
+            "rejected supersede left the live roster untouched"
+        );
+        assert_eq!(live2.consensus_protocol, "quorum:3/5");
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn quorum_supersede_sqlite() {
+        let signer = crate::federation::tier_ingest::test_support::local_signer("g3");
+        let engine = Engine::with_signer(signer, "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        quorum_supersede_body(&*sq, "sq").await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn quorum_supersede_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let label = format!("g3-{}", uuid::Uuid::new_v4().simple());
+        let signer = crate::federation::tier_ingest::test_support::local_signer(&label);
+        let engine = Engine::with_signer(signer, &dsn).await.expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend").clone();
+        quorum_supersede_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
+    }
+
     /// #249 — `file_moderation` stores a `moderation:{allegation}` scores
     /// row when the signer is a named moderator (community founder, as-self
     /// duty-holder). Proves the §11.10 EMIT path is feature-free (no

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -1449,6 +1449,145 @@ pub trait FederationDirectory: Send + Sync {
             .find(|v| v.version == version))
     }
 
+    // ── #249 Cut G3 ── quorum-authorized membership gate (§4/§5) ──
+    //
+    // The deferred v3.13+ admission gate, landable on verify v6.8.0's
+    // threshold primitives. A membership change to a `quorum:M/N` group MUST
+    // carry ≥M valid hybrid member cosignatures over the canonical change
+    // payload — enforced HERE in the substrate, so one-seat-per-human +
+    // M-of-N-to-change become invariants of the graph, not properties any one
+    // server upholds. The PRIOR roster authorizes the change (the current
+    // holders decide who joins/leaves; an incoming key never authorizes its
+    // own admission). Default methods composing the trait + verify
+    // primitives, so backend parity is inherited.
+
+    /// #249 Cut G3 (§4/§5) — verify a membership change is authorized by the
+    /// group's **current** strict-majority quorum: ≥M of the live roster's
+    /// pinned hybrid keys ([`Self::active_member_keys`]) validly cosigned the
+    /// canonical `change_envelope` (its JCS bytes — the §5 payload). Returns
+    /// the count of valid distinct cosigners.
+    ///
+    /// [`Error::InvalidArgument`] if the group is unknown, its
+    /// `consensus_protocol` is not a `quorum:M/N` (`founder_only` / `unanimous`
+    /// have their own rules), the policy is not a strict majority (`2M>N`), or
+    /// fewer than M valid hybrid cosignatures are present.
+    /// `HybridPolicy::RequireHybrid` — a classical-only signature does NOT
+    /// count at this federation-authority gate (CC 5.3.2.4.3.1).
+    async fn verify_membership_quorum(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        change_envelope: &serde_json::Value,
+        signatures: &[ciris_verify_core::threshold::ThresholdSignature],
+    ) -> Result<usize, Error> {
+        use ciris_verify_core::threshold::{
+            verify_threshold_signatures_with_policy, HybridPolicy, QuorumPolicy, ThresholdMember,
+        };
+        let group = self
+            .lookup_group(cohort, group_key_id)
+            .await?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "verify_membership_quorum: unknown {} group {group_key_id:?}",
+                    cohort.as_str()
+                ))
+            })?;
+        let cp = group.consensus_protocol.ok_or_else(|| {
+            Error::InvalidArgument(
+                "verify_membership_quorum: group has no consensus_protocol (the `self` cohort \
+                 has no quorum)"
+                    .to_string(),
+            )
+        })?;
+        let policy = QuorumPolicy::parse(&cp).ok_or_else(|| {
+            Error::InvalidArgument(format!(
+                "verify_membership_quorum: consensus_protocol {cp:?} is not a quorum:M/N policy"
+            ))
+        })?;
+        policy.validate().map_err(|e| {
+            Error::InvalidArgument(format!(
+                "verify_membership_quorum: {cp:?} is not a strict-majority quorum: {e}"
+            ))
+        })?;
+        let members: Vec<ThresholdMember> = self
+            .active_member_keys(cohort, group_key_id)
+            .await?
+            .into_iter()
+            .map(|k| ThresholdMember {
+                member_id: k.key_id,
+                ed25519_public_key_base64: k.pubkey_ed25519_base64,
+                mldsa65_public_key_base64: k.pubkey_ml_dsa_65_base64,
+                role: None,
+            })
+            .collect();
+        let bytes = ciris_verify_core::jcs::canonicalize(change_envelope)
+            .map_err(|e| Error::Backend(format!("verify_membership_quorum canonicalize: {e}")))?;
+        // The threshold M is enforced inside the primitive (`Insufficient` if
+        // fewer than M distinct valid hybrid cosignatures); `RequireHybrid`
+        // makes a classical-only signature not count.
+        verify_threshold_signatures_with_policy(
+            &bytes,
+            &members,
+            signatures,
+            policy.m,
+            HybridPolicy::RequireHybrid,
+        )
+        .map_err(|e| {
+            Error::InvalidArgument(format!(
+                "verify_membership_quorum: quorum not met for {cp} ({}-of-{}): {e}",
+                policy.m, policy.n
+            ))
+        })
+    }
+
+    /// #249 Cut G3 (§3/§4/§5) — quorum-gated family supersede: verify the
+    /// current roster's strict-majority quorum cosigned `change_envelope` via
+    /// [`Self::verify_membership_quorum`], THEN [`Self::supersede_family`],
+    /// recording `{change_envelope, quorum_signatures}` as the superseded
+    /// version's authorization (the §8 audit trail). The quorum is checked
+    /// against the PRIOR group — the current holders authorize the change.
+    async fn supersede_family_with_quorum(
+        &self,
+        new: types::SignedFamily,
+        change_envelope: serde_json::Value,
+        signatures: Vec<ciris_verify_core::threshold::ThresholdSignature>,
+    ) -> Result<u32, Error> {
+        self.verify_membership_quorum(
+            cohort::Cohort::Family,
+            &new.family.family_key_id,
+            &change_envelope,
+            &signatures,
+        )
+        .await?;
+        let authorization = serde_json::json!({
+            "change_envelope": change_envelope,
+            "quorum_signatures": signatures,
+        });
+        self.supersede_family(new, Some(authorization)).await
+    }
+
+    /// #249 Cut G3 — quorum-gated community supersede. Mirror of
+    /// [`Self::supersede_family_with_quorum`].
+    async fn supersede_community_with_quorum(
+        &self,
+        new: types::SignedCommunity,
+        change_envelope: serde_json::Value,
+        signatures: Vec<ciris_verify_core::threshold::ThresholdSignature>,
+    ) -> Result<u32, Error> {
+        self.verify_membership_quorum(
+            cohort::Cohort::Community,
+            &new.community.community_key_id,
+            &change_envelope,
+            &signatures,
+        )
+        .await?;
+        let authorization = serde_json::json!({
+            "change_envelope": change_envelope,
+            "quorum_signatures": signatures,
+        });
+        self.supersede_community(new, Some(authorization)).await
+    }
+
     /// #249 Cut B — the INBOUND delegation walk: every key that holds a
     /// `delegates_to` edge naming `key_id` as the recipient ("who delegated
     /// TO me?"). The reverse of the forward-only

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -240,6 +240,63 @@ pub(crate) mod test_support {
         (ed_pk, Some(mldsa_pk))
     }
 
+    /// #249 Cut G3 — produce a [`ThresholdSignature`](ciris_verify_core::threshold::ThresholdSignature)
+    /// for `key_id` over `bytes` using `key_id`'s deterministic hybrid keypair
+    /// (the same pair [`hybrid_pubkeys`] registers). The ML-DSA-65 half signs
+    /// the bound message `bytes ‖ ed25519_sig` (the stripping-attack guard the
+    /// threshold verifier checks). Use to drive the quorum gate in tests.
+    pub fn threshold_sign(
+        key_id: &str,
+        bytes: &[u8],
+    ) -> ciris_verify_core::threshold::ThresholdSignature {
+        let ed_sig = ed_signer(key_id).sign(bytes).expect("ed sign");
+        let mut bound = bytes.to_vec();
+        bound.extend_from_slice(&ed_sig);
+        let pqc_sig = mldsa_signer(key_id).sign(&bound).expect("mldsa sign");
+        ciris_verify_core::threshold::ThresholdSignature {
+            member_id: key_id.to_string(),
+            ed25519_signature_base64: B64.encode(&ed_sig),
+            mldsa65_signature_base64: Some(B64.encode(&pqc_sig)),
+        }
+    }
+
+    /// #249 Cut G3 — register `key_id` with its REAL deterministic hybrid
+    /// pubkeys (matching [`hybrid_pubkeys`] / [`threshold_sign`]) via
+    /// `put_public_key`, so a cosignature this key produces verifies against
+    /// the stored roster. The registration row's own scrub fields are
+    /// placeholders (`put_public_key` does not hybrid-verify the
+    /// registration; only the PUBKEYS must be real).
+    pub async fn register_hybrid_key<D: crate::federation::FederationDirectory + ?Sized>(
+        dir: &D,
+        key_id: &str,
+    ) {
+        let (ed_pk, mldsa_pk) = hybrid_pubkeys(key_id);
+        let now = chrono::Utc::now();
+        let rec = crate::federation::KeyRecord {
+            key_id: key_id.to_owned(),
+            pubkey_ed25519_base64: ed_pk,
+            pubkey_ml_dsa_65_base64: mldsa_pk,
+            algorithm: crate::federation::types::algorithm::HYBRID.to_owned(),
+            identity_type: crate::federation::types::identity_type::AGENT.to_owned(),
+            identity_ref: key_id.to_owned(),
+            valid_from: now,
+            valid_until: None,
+            registration_envelope: serde_json::json!({ "id": key_id }),
+            original_content_hash: "deadbeef".to_owned(),
+            scrub_signature_classical: "c2lnbmF0dXJl".to_owned(),
+            scrub_signature_pqc: None,
+            scrub_key_id: key_id.to_owned(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+        };
+        dir.put_public_key(crate::federation::SignedKeyRecord { record: rec })
+            .await
+            .expect("register hybrid key");
+    }
+
     /// Build a PQC-configured [`crate::signing::LocalSigner`] whose
     /// Ed25519 + ML-DSA-65 keypair is the SAME deterministic pair as
     /// [`hybrid_pubkeys`] / [`sign_envelope`] for `key_id`. Use this to
@@ -339,7 +396,7 @@ mod tests {
     /// `put_public_key` does not hybrid-verify the registration (that gate
     /// is `register_federation_key`); only the PUBKEYS must be real for
     /// the federation-tier ingest gate to verify attestations.
-    async fn register_hybrid_key(dir: &dyn FederationDirectory, key_id: &str) {
+    pub async fn register_hybrid_key(dir: &dyn FederationDirectory, key_id: &str) {
         let (ed_pk, mldsa_pk) = hybrid_pubkeys(key_id);
         let now = chrono::Utc::now();
         let rec = KeyRecord {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -15695,6 +15695,139 @@ impl PyEngine {
         })
     }
 
+    // ── #249 Cut G3 ── quorum-authorized membership gate FFI (§4/§5) ──
+
+    /// #249 Cut G3 (§4/§5) — verify a membership change is authorized by the
+    /// group's current strict-majority quorum. `change_envelope_json` is the
+    /// canonical change payload (the bytes the members signed, as JSON);
+    /// `signatures_json` is a JSON array of
+    /// [`ciris_verify_core::threshold::ThresholdSignature`]. Returns the count
+    /// of valid distinct cosigners; raises `ValueError` if the quorum is not
+    /// met (or the group/policy is invalid).
+    fn cohort_verify_membership_quorum(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        change_envelope_json: &str,
+        signatures_json: &str,
+    ) -> PyResult<usize> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let change_envelope: serde_json::Value = serde_json::from_str(change_envelope_json)
+            .map_err(|e| PyValueError::new_err(format!("change_envelope_json: {e}")))?;
+        let signatures: Vec<ciris_verify_core::threshold::ThresholdSignature> =
+            serde_json::from_str(signatures_json)
+                .map_err(|e| PyValueError::new_err(format!("signatures_json: {e}")))?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            b.verify_membership_quorum(
+                                cohort,
+                                &group_key_id,
+                                &change_envelope,
+                                &signatures,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G3 (§3/§4/§5) — quorum-gated supersede: verify the current
+    /// roster's strict-majority quorum cosigned `change_envelope_json`, then
+    /// supersede `new_group_json` (raw `Family`/`Community`), recording the
+    /// envelope + signatures as the superseded version's authorization.
+    /// Returns the new version. `self` is rejected.
+    fn cohort_supersede_group_with_quorum(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        new_group_json: &str,
+        change_envelope_json: &str,
+        signatures_json: &str,
+    ) -> PyResult<u32> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let change_envelope: serde_json::Value = serde_json::from_str(change_envelope_json)
+            .map_err(|e| PyValueError::new_err(format!("change_envelope_json: {e}")))?;
+        let signatures: Vec<ciris_verify_core::threshold::ThresholdSignature> =
+            serde_json::from_str(signatures_json)
+                .map_err(|e| PyValueError::new_err(format!("signatures_json: {e}")))?;
+        use crate::federation::cohort::Cohort;
+        let family: Option<crate::federation::SignedFamily> = match cohort {
+            Cohort::Family => Some(crate::federation::SignedFamily {
+                family: serde_json::from_str(new_group_json)
+                    .map_err(|e| PyValueError::new_err(format!("supersede family JSON: {e}")))?,
+            }),
+            _ => None,
+        };
+        let community: Option<crate::federation::SignedCommunity> = match cohort {
+            Cohort::Community => Some(crate::federation::SignedCommunity {
+                community: serde_json::from_str(new_group_json)
+                    .map_err(|e| PyValueError::new_err(format!("supersede community JSON: {e}")))?,
+            }),
+            _ => None,
+        };
+        if cohort == Cohort::SelfId {
+            return Err(PyValueError::new_err(
+                "cohort_supersede_group_with_quorum: the `self` cohort is not versioned",
+            ));
+        }
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            match cohort {
+                                Cohort::Family => {
+                                    b.supersede_family_with_quorum(
+                                        family.clone().unwrap(),
+                                        change_envelope.clone(),
+                                        signatures.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::Community => {
+                                    b.supersede_community_with_quorum(
+                                        community.clone().unwrap(),
+                                        change_envelope.clone(),
+                                        signatures.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::SelfId => unreachable!(),
+                            }
+                            .map_err(federation_err_to_py)
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
     /// #249 Cut B — the FULL named-moderator set of `community_key_id` for
     /// `duty` (`moderate` / `takedown` / `review`): owner-bound authority
     /// roots ∪ their duty-scoped delegates. Returns a JSON array of key_ids.


### PR DESCRIPTION
## v9.7.0 — #249 Cut G3: quorum-authorized membership gate

The third cut of the CIRISServer #249 write+governance ask (§4/§5), stacked on G1 (v9.5.0) + G2 (v9.6.0). The deferred v3.13+ admission gate, landed on **CIRISVerify v6.8.0's threshold primitives**.

A membership change to a `quorum:M/N` family/community is now authorized **in the substrate** by ≥M valid **hybrid** member cosignatures over the canonical change payload — so **one-seat-per-human + M-of-N-to-change become invariants of the graph**, not properties any single server upholds. The change is authorized by the group's **current/prior** roster (the existing holders decide who joins/leaves; an incoming key never authorizes its own admission).

- **`FederationDirectory::verify_membership_quorum(cohort, group_key_id, change_envelope, signatures)`** (default method → backend parity): lookup group → parse `consensus_protocol` to `ciris_verify_core::threshold::QuorumPolicy` (rejects non-`quorum:M/N` + non-strict-majority `2M>N`) → map the active roster (`active_member_keys`, G1 §2) to `ThresholdMember`s → canonicalize via `ciris_verify_core::jcs` (the §5 payload) → `verify_threshold_signatures_with_policy(.., M, HybridPolicy::RequireHybrid)`. A classical-only signature does **not** count (CC 5.3.2.4.3.1).
- **`supersede_family_with_quorum` / `supersede_community_with_quorum`**: verify the quorum against the prior group, THEN supersede (G2), recording `{change_envelope, quorum_signatures}` as the superseded version's authorization (§8 audit trail). A rejected quorum leaves the live row untouched.
- **FFI:** `cohort_verify_membership_quorum` / `cohort_supersede_group_with_quorum`.
- **Test helpers:** `tier_ingest::test_support::{threshold_sign, register_hybrid_key}` (real Ed25519 + ML-DSA-65).
- **Tested:** a `quorum:2/3` family expands to `quorum:3/5` only when 2 of 3 prior members cosign; 1 cosignature rejected, live roster untouched — sqlite + live Postgres.

Consumes verify v6.8.0 as-is; the optional general (role-agnostic, non-entrenched) helper is CIRISVerify#104. Remaining: G4 (rekey-on-revoke §7 + change-event hook §9).

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1577/1577**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
