### PR TITLE
v9.7.1 — re-pin CIRISVerify v6.8.0 -> v6.9.0 (wheel concurrence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.7.1] — 2026-06-21
+
+### Changed — re-pin CIRISVerify v6.8.0 → v6.9.0 (wheel concurrence)
+
+- All six git-tag verify crates flipped in lockstep; `version = "6"` unchanged. v6.9.0 (CIRISVerify#105) lands the **general, role-agnostic `build_membership_change` / `verify_membership_change`** — exactly the helper persist filed as CIRISVerify#104, the optional consolidation Cut G3 (v9.7.0) referenced; v6.8.1 carried an ml-dsa 0.1.1 fix (the outer ML-DSA-65 `SigningKey` seed self-zeroizes + `from_seed_file` scrub, CIRISVerify#87). The ml-dsa bump touches `ciris-crypto::ml_dsa`, so this re-pin's green gate confirms `MlDsa65Signer::from_seed` stays API-stable (persist's `tier_ingest::test_support` + the Cut G3 quorum tests sign through it). No persist consumed-surface change (`verify_hybrid` / `canonical` / `jcs` / `threshold` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode`); wheel `Requires-Dist` floor stays `>=6.0.0,<7`.
+- **Forward pointer:** v9.8.0 adopts v6.9.0's general `verify_membership_change` to upgrade the Cut G3 quorum gate from count-only to the full fail-closed check (anti-replay `supersedes` binding + one-seat key-distinctness).
+
 ## [9.7.0] — 2026-06-21
 
 ### Added — #249 Cut G3: quorum-authorized membership gate (CIRISServer #249 §4/§5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.7.0"
+version = "9.7.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.8.0", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
## v9.7.1 — re-pin CIRISVerify v6.8.0 → v6.9.0 (wheel concurrence)

All six git-tag verify crates flipped in lockstep; `version = "6"` unchanged.

**v6.9.0 (CIRISVerify#105)** lands the **general, role-agnostic `build_membership_change` / `verify_membership_change`** — the helper persist filed as **CIRISVerify#104**, the optional consolidation Cut G3 (v9.7.0) referenced. **v6.8.1** carried an ml-dsa 0.1.1 fix (outer ML-DSA-65 `SigningKey` seed self-zeroizes + `from_seed_file` scrub, CIRISVerify#87).

The ml-dsa bump touches `ciris-crypto::ml_dsa`, so this re-pin's **green gate is the proof** that `MlDsa65Signer::from_seed` stays API-stable — persist's `tier_ingest::test_support` + the Cut G3 quorum tests sign through it. No persist consumed-surface change (`verify_hybrid` / `canonical` / `jcs` / `threshold` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode`); wheel `Requires-Dist` floor stays `>=6.0.0,<7`.

**Next:** v9.8.0 adopts v6.9.0's `verify_membership_change` to upgrade the Cut G3 quorum gate from count-only to the full fail-closed check (anti-replay `supersedes` binding + one-seat key-distinctness).

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1577/1577**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
