### PR TITLE
v9.8.0 — #249 Cut G3.5: robust quorum gate via verify 6.9.0 verify_membership_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.8.0] — 2026-06-21
+
+### Changed — #249 Cut G3.5: the quorum gate now composes verify 6.9.0's `verify_membership_change` (robust)
+
+The Cut G3 quorum gate (v9.7.0) was a count-only check (`verify_threshold_signatures_with_policy`). This cut upgrades `FederationDirectory::verify_membership_quorum` to compose **CIRISVerify v6.9.0's general `verify_membership_change`** (CIRISVerify#104/#105) — strictly stronger, with the canonical membership-change payload defined **once in verify** (portable + re-verifiable across the federation).
+
+- **New fail-closed guarantees** the count-only gate lacked: **one-seat key-distinctness** (the new roster must resolve to distinct pubkeys in the directory — no human seated under two `key_id`s) + **anti-replay** (`supersedes.prior_member_key_ids` must equal the actual prior roster) + **entrenchment-preserved** (`family_key_id` unchanged, no de-entrenchment), on top of distinct-members + strict-majority + the prior roster's hybrid quorum.
+- **`FederationDirectory::build_membership_change_envelope(cohort, group_key_id, new_member_key_ids, entrenched, consensus_protocol)`** (default method) — the §5 canonical payload builder, wrapping verify's `build_membership_change` with the live group's prior envelope. The prior roster cosigns its JCS bytes. New private `group_prior_envelope` derives the family-shaped prior envelope (a community maps `community_*` → the helper's `family_*` keys, `entrenched=false`).
+- **Verify-A-store-B guard:** `supersede_*_with_quorum` now assert the superseding row's roster + `consensus_protocol` + key exactly match the authorized `change_envelope` before persisting (`assert_change_envelope_matches`).
+- **API change (days-old surface):** `verify_membership_quorum` returns `Result<()>` (was `Result<usize>` in v9.7.0); FFI `cohort_verify_membership_quorum` returns `None` on success; new FFI `cohort_build_membership_change_envelope`. The accord path keeps `verify_accord_membership_change`.
+- **Tests:** the `quorum:2/3 → quorum:3/5` expansion now flows through `build_membership_change_envelope`; added **anti-replay** (tampered `supersedes` rejected despite a valid 3-of-5 quorum) and **one-seat** (a roster with two key_ids sharing one pubkey rejected) — sqlite + live Postgres.
+
 ## [9.7.1] — 2026-06-21
 
 ### Changed — re-pin CIRISVerify v6.8.0 → v6.9.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.7.1"
+version = "9.8.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8342,119 +8342,178 @@ mod tests {
         supersede_versioning_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
     }
 
-    /// #249 Cut G3 — quorum-authorized membership gate (CIRISServer #249 §4/§5).
-    /// A `quorum:2/3` family expands to `quorum:3/5` ONLY when ≥M (=2) of the
-    /// PRIOR roster's real hybrid keys cosign the canonical change payload;
-    /// 1 cosignature is rejected and leaves the live row untouched. Real
-    /// Ed25519 + ML-DSA-65 signers; backend-generic body run on sqlite + pg.
+    /// #249 Cut G3 (robust on G3.5) — quorum-authorized membership gate
+    /// (CIRISServer #249 §4/§5) composing CIRISVerify v6.9.0's
+    /// `verify_membership_change`. A `quorum:2/3` family expands to `quorum:3/5`
+    /// ONLY when ≥M (=2) of the PRIOR roster's real hybrid keys cosign the
+    /// canonical `build_membership_change_envelope` payload; insufficient
+    /// quorum, an anti-replay-tampered `supersedes`, and a one-seat
+    /// (duplicate-pubkey) roster are each rejected, live row untouched. Real
+    /// Ed25519 + ML-DSA-65 signers; sqlite + pg.
     #[cfg(any(feature = "sqlite", feature = "postgres"))]
     async fn quorum_supersede_body<D>(d: &D, s: &str)
     where
         D: crate::federation::FederationDirectory + ?Sized,
     {
         use crate::federation::cohort::Cohort;
-        use crate::federation::tier_ingest::test_support::{register_hybrid_key, threshold_sign};
+        use crate::federation::tier_ingest::test_support::{
+            register_hybrid_key, register_hybrid_key_aliased, threshold_sign,
+        };
         use crate::federation::types;
 
-        let fam = format!("g3-fam-{s}");
-        let m: Vec<String> = (0..5).map(|i| format!("g3-m{i}-{s}")).collect();
-        // Register the family key + all 5 member keys with REAL deterministic
-        // hybrid pubkeys (so threshold_sign's signatures verify against them).
+        let fam = format!("g35-fam-{s}");
+        let m: Vec<String> = (0..5).map(|i| format!("g35-m{i}-{s}")).collect();
         register_hybrid_key(d, &fam).await;
         for k in &m {
             register_hybrid_key(d, k).await;
         }
         let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
-        let mk = |n: usize| -> Vec<types::FamilyMember> {
-            m[..n]
-                .iter()
-                .map(|k| types::FamilyMember {
-                    key_id: k.clone(),
-                    joined_at: joined,
-                    role: Some("founder".into()),
-                })
-                .collect()
+        let fam_row = |members: Vec<String>, cp: &str| -> crate::federation::SignedFamily {
+            crate::federation::SignedFamily {
+                family: types::Family {
+                    family_key_id: fam.clone(),
+                    family_name: "accord".into(),
+                    members: members
+                        .into_iter()
+                        .map(|k| types::FamilyMember {
+                            key_id: k,
+                            joined_at: joined,
+                            role: Some("founder".into()),
+                        })
+                        .collect(),
+                    founded_at: joined,
+                    consensus_protocol: cp.into(),
+                    consensus_protocol_entrenched: true,
+                    persist_row_hash: String::new(),
+                },
+            }
         };
 
         // Genesis: quorum:2/3 family (3 members, M=2).
-        d.put_family(crate::federation::SignedFamily {
-            family: types::Family {
-                family_key_id: fam.clone(),
-                family_name: "accord".into(),
-                members: mk(3),
-                founded_at: joined,
-                consensus_protocol: "quorum:2/3".into(),
-                consensus_protocol_entrenched: true,
-                persist_row_hash: String::new(),
-            },
-        })
-        .await
-        .expect("genesis");
+        d.put_family(fam_row(m[..3].to_vec(), "quorum:2/3"))
+            .await
+            .expect("genesis");
 
-        // Change payload (what the prior roster cosigns) → expand to 5 / 3-of-5.
-        let change_envelope = serde_json::json!({
-            "family_key_id": fam,
-            "new_member_key_ids": m,
-            "consensus_protocol": "quorum:3/5",
-        });
-        let bytes = ciris_verify_core::jcs::canonicalize(&change_envelope).unwrap();
-        let new5 = crate::federation::SignedFamily {
-            family: types::Family {
-                family_key_id: fam.clone(),
-                family_name: "accord".into(),
-                members: mk(5),
-                founded_at: joined,
-                consensus_protocol: "quorum:3/5".into(),
-                consensus_protocol_entrenched: true,
-                persist_row_hash: String::new(),
-            },
-        };
+        // Build the canonical change payload via the substrate helper (verify's
+        // build_membership_change — carries the supersedes anti-replay binding).
+        let change = d
+            .build_membership_change_envelope(
+                Cohort::Family,
+                &fam,
+                &m[..5],
+                true,
+                Some("quorum:3/5"),
+            )
+            .await
+            .expect("build change envelope");
+        let bytes = ciris_verify_core::jcs::canonicalize(&change).unwrap();
 
         // 2 of the 3 PRIOR members cosign → meets quorum:2/3.
-        let sigs = vec![threshold_sign(&m[0], &bytes), threshold_sign(&m[1], &bytes)];
         let v = d
-            .supersede_family_with_quorum(new5.clone(), change_envelope.clone(), sigs)
+            .supersede_family_with_quorum(
+                fam_row(m[..5].to_vec(), "quorum:3/5"),
+                change.clone(),
+                vec![threshold_sign(&m[0], &bytes), threshold_sign(&m[1], &bytes)],
+            )
             .await
-            .expect("2-of-3 quorum authorizes the expansion");
-        assert_eq!(v, 2, "supersede bumps to version 2");
+            .expect("2-of-3 quorum authorizes the 3->5 expansion");
+        assert_eq!(v, 2);
         let live = d.lookup_family(&fam).await.unwrap().unwrap();
         assert_eq!(live.members.len(), 5);
         assert_eq!(live.consensus_protocol, "quorum:3/5");
-        // The quorum envelope + signatures are recorded as the v1 authorization.
         let hist = d.group_history(Cohort::Family, &fam).await.unwrap();
-        assert_eq!(hist[0].version, 1);
         assert!(
             hist[0].authorization.is_some(),
-            "superseded v1 carries the quorum authorization"
+            "v1 carries the authorization"
         );
 
-        // Negative: the group is now quorum:3/5 (M=3); 1 cosignature is
-        // insufficient → rejected, and the live row is untouched.
-        let env2 = serde_json::json!({"family_key_id": fam, "note": "shrink attempt"});
-        let bytes2 = ciris_verify_core::jcs::canonicalize(&env2).unwrap();
-        let one = vec![threshold_sign(&m[0], &bytes2)];
-        let shrink = crate::federation::SignedFamily {
-            family: types::Family {
-                family_key_id: fam.clone(),
-                family_name: "accord".into(),
-                members: mk(3),
-                founded_at: joined,
-                consensus_protocol: "quorum:2/3".into(),
-                consensus_protocol_entrenched: true,
-                persist_row_hash: String::new(),
-            },
-        };
+        // The group is now quorum:3/5 (M=3). Build a fresh change for the
+        // negatives (its supersedes binds to the current 5-roster).
+        let change2 = d
+            .build_membership_change_envelope(
+                Cohort::Family,
+                &fam,
+                &m[..5],
+                true,
+                Some("quorum:3/5"),
+            )
+            .await
+            .unwrap();
+        let bytes2 = ciris_verify_core::jcs::canonicalize(&change2).unwrap();
+
+        // (a) Insufficient quorum: 1 cosignature where M=3 → rejected.
         let err = d
-            .supersede_family_with_quorum(shrink, env2, one)
+            .supersede_family_with_quorum(
+                fam_row(m[..5].to_vec(), "quorum:3/5"),
+                change2.clone(),
+                vec![threshold_sign(&m[0], &bytes2)],
+            )
             .await
             .unwrap_err();
-        assert_eq!(err.kind(), "federation_invalid_argument");
-        let live2 = d.lookup_family(&fam).await.unwrap().unwrap();
         assert_eq!(
-            live2.members.len(),
-            5,
-            "rejected supersede left the live roster untouched"
+            err.kind(),
+            "federation_invalid_argument",
+            "insufficient quorum"
         );
+
+        // (b) Anti-replay: tamper the supersedes binding, cosign with a valid
+        // 3-of-5 quorum → rejected (supersedes.prior_member_key_ids mismatch).
+        let mut tampered = change2.clone();
+        tampered["supersedes"]["prior_member_key_ids"] = serde_json::json!(["ghost"]);
+        let tbytes = ciris_verify_core::jcs::canonicalize(&tampered).unwrap();
+        let err = d
+            .supersede_family_with_quorum(
+                fam_row(m[..5].to_vec(), "quorum:3/5"),
+                tampered,
+                vec![
+                    threshold_sign(&m[0], &tbytes),
+                    threshold_sign(&m[1], &tbytes),
+                    threshold_sign(&m[2], &tbytes),
+                ],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument", "anti-replay");
+
+        // (c) One-seat: a new roster with two key_ids sharing one pubkey
+        // (alias of m[0]) → rejected even with a valid quorum.
+        let alias = format!("g35-alias-{s}");
+        register_hybrid_key_aliased(d, &alias, &m[0]).await;
+        let seat_roster = vec![
+            m[0].clone(),
+            m[1].clone(),
+            m[2].clone(),
+            m[3].clone(),
+            alias.clone(),
+        ];
+        let seat_change = d
+            .build_membership_change_envelope(
+                Cohort::Family,
+                &fam,
+                &seat_roster,
+                true,
+                Some("quorum:3/5"),
+            )
+            .await
+            .unwrap();
+        let sbytes = ciris_verify_core::jcs::canonicalize(&seat_change).unwrap();
+        let err = d
+            .supersede_family_with_quorum(
+                fam_row(seat_roster, "quorum:3/5"),
+                seat_change,
+                vec![
+                    threshold_sign(&m[0], &sbytes),
+                    threshold_sign(&m[1], &sbytes),
+                    threshold_sign(&m[2], &sbytes),
+                ],
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument", "one-seat");
+
+        // Every rejection left the live row untouched (still v2, 5 members).
+        let live2 = d.lookup_family(&fam).await.unwrap().unwrap();
+        assert_eq!(live2.members.len(), 5);
         assert_eq!(live2.consensus_protocol, "quorum:3/5");
     }
 

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -230,6 +230,53 @@ where
         .collect()
 }
 
+/// #249 Cut G3.5 — the verify-A-store-B guard for quorum-gated supersede: the
+/// roster/protocol being persisted MUST be exactly the one the quorum
+/// authorized in `change_envelope` (`group_key_id` + member `key_id` set +
+/// `consensus_protocol` all match). Defends against verifying one membership
+/// change and storing another.
+fn assert_change_envelope_matches(
+    group_key_id: &str,
+    new_member_key_ids: &std::collections::BTreeSet<&str>,
+    new_consensus_protocol: &str,
+    change_envelope: &serde_json::Value,
+) -> Result<(), Error> {
+    let env_key = change_envelope
+        .get("family_key_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    if env_key != group_key_id {
+        return Err(Error::InvalidArgument(format!(
+            "supersede: change_envelope family_key_id {env_key:?} != group {group_key_id:?}"
+        )));
+    }
+    let env_cp = change_envelope
+        .get("consensus_protocol")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    if env_cp != new_consensus_protocol {
+        return Err(Error::InvalidArgument(format!(
+            "supersede: change_envelope consensus_protocol {env_cp:?} != superseding row \
+             {new_consensus_protocol:?}"
+        )));
+    }
+    let env_members: std::collections::BTreeSet<&str> = change_envelope
+        .get("members")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|m| m.get("key_id").and_then(|v| v.as_str()))
+                .collect()
+        })
+        .unwrap_or_default();
+    if &env_members != new_member_key_ids {
+        return Err(Error::InvalidArgument(
+            "supersede: change_envelope roster does not match the superseding roster".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Federation directory trait — the registry/lens/agent's read+write
 /// surface over persist's three federation tables.
 ///
@@ -1461,83 +1508,175 @@ pub trait FederationDirectory: Send + Sync {
     // own admission). Default methods composing the trait + verify
     // primitives, so backend parity is inherited.
 
-    /// #249 Cut G3 (§4/§5) — verify a membership change is authorized by the
-    /// group's **current** strict-majority quorum: ≥M of the live roster's
-    /// pinned hybrid keys ([`Self::active_member_keys`]) validly cosigned the
-    /// canonical `change_envelope` (its JCS bytes — the §5 payload). Returns
-    /// the count of valid distinct cosigners.
+    /// #249 Cut G3 (§4/§5), robust on Cut G3.5 — verify a membership change is
+    /// authorized by the group's **current** strict-majority quorum, composing
+    /// CIRISVerify v6.9.0's general
+    /// [`verify_membership_change`](ciris_verify_core::accord_genesis::verify_membership_change)
+    /// (CIRISVerify#104). `change_envelope` is the canonical membership-change
+    /// payload (build it with [`Self::build_membership_change_envelope`]); the
+    /// **prior** roster cosigned its JCS bytes.
     ///
-    /// [`Error::InvalidArgument`] if the group is unknown, its
-    /// `consensus_protocol` is not a `quorum:M/N` (`founder_only` / `unanimous`
-    /// have their own rules), the policy is not a strict majority (`2M>N`), or
-    /// fewer than M valid hybrid cosignatures are present.
-    /// `HybridPolicy::RequireHybrid` — a classical-only signature does NOT
-    /// count at this federation-authority gate (CC 5.3.2.4.3.1).
+    /// Inherits verify's full fail-closed gate — strictly stronger than the
+    /// v9.7.0 count-only check:
+    /// - well-formed + **distinct** member `key_id`s;
+    /// - **strict-majority** `quorum:M/N` (`2M>N`) over the new roster;
+    /// - **one-seat key-distinctness** — the new roster resolves to **distinct
+    ///   pubkeys** in the directory (no human seated under two `key_id`s);
+    /// - **entrenchment preserved** — `family_key_id` unchanged, an entrenched
+    ///   group cannot be de-entrenched;
+    /// - **anti-replay** — `supersedes.prior_member_key_ids` MUST equal the
+    ///   actual prior roster (no presenting the change against a different
+    ///   prior state);
+    /// - the **prior** roster's strict-majority quorum validly signed the new
+    ///   envelope (role-agnostic, hybrid; classical-only does not count —
+    ///   CC 5.3.2.4.3.1).
+    ///
+    /// The `directory` handed to verify is the authoritative `federation_keys`
+    /// pin set for the prior roster ∪ the new roster (resolved via
+    /// [`Self::lookup_public_key`]); authorization is exactly as strong as it.
+    /// [`Error::InvalidArgument`] (wrapping the verify-side `AccordGenesisError`)
+    /// on any failed check; the `self` cohort has no quorum.
     async fn verify_membership_quorum(
         &self,
         cohort: cohort::Cohort,
         group_key_id: &str,
         change_envelope: &serde_json::Value,
         signatures: &[ciris_verify_core::threshold::ThresholdSignature],
-    ) -> Result<usize, Error> {
-        use ciris_verify_core::threshold::{
-            verify_threshold_signatures_with_policy, HybridPolicy, QuorumPolicy, ThresholdMember,
-        };
-        let group = self
-            .lookup_group(cohort, group_key_id)
-            .await?
-            .ok_or_else(|| {
-                Error::InvalidArgument(format!(
-                    "verify_membership_quorum: unknown {} group {group_key_id:?}",
-                    cohort.as_str()
-                ))
-            })?;
-        let cp = group.consensus_protocol.ok_or_else(|| {
-            Error::InvalidArgument(
-                "verify_membership_quorum: group has no consensus_protocol (the `self` cohort \
-                 has no quorum)"
-                    .to_string(),
-            )
-        })?;
-        let policy = QuorumPolicy::parse(&cp).ok_or_else(|| {
-            Error::InvalidArgument(format!(
-                "verify_membership_quorum: consensus_protocol {cp:?} is not a quorum:M/N policy"
-            ))
-        })?;
-        policy.validate().map_err(|e| {
-            Error::InvalidArgument(format!(
-                "verify_membership_quorum: {cp:?} is not a strict-majority quorum: {e}"
-            ))
-        })?;
-        let members: Vec<ThresholdMember> = self
-            .active_member_keys(cohort, group_key_id)
-            .await?
-            .into_iter()
-            .map(|k| ThresholdMember {
-                member_id: k.key_id,
-                ed25519_public_key_base64: k.pubkey_ed25519_base64,
-                mldsa65_public_key_base64: k.pubkey_ml_dsa_65_base64,
-                role: None,
-            })
-            .collect();
-        let bytes = ciris_verify_core::jcs::canonicalize(change_envelope)
-            .map_err(|e| Error::Backend(format!("verify_membership_quorum canonicalize: {e}")))?;
-        // The threshold M is enforced inside the primitive (`Insufficient` if
-        // fewer than M distinct valid hybrid cosignatures); `RequireHybrid`
-        // makes a classical-only signature not count.
-        verify_threshold_signatures_with_policy(
-            &bytes,
-            &members,
+    ) -> Result<(), Error> {
+        use ciris_verify_core::threshold::ThresholdMember;
+        let prior_envelope = self.group_prior_envelope(cohort, group_key_id).await?;
+        // Directory = prior active roster ∪ the new envelope's members,
+        // resolved to their REGISTERED pinned hybrid pubkeys. verify resolves
+        // the NEW roster against this for the one-seat (distinct-pubkey) check
+        // and the PRIOR roster for the quorum count, so it must cover both.
+        let mut key_ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for m in self.active_members(cohort, group_key_id).await? {
+            key_ids.insert(m.key_id);
+        }
+        if let Some(arr) = change_envelope.get("members").and_then(|v| v.as_array()) {
+            for m in arr {
+                if let Some(k) = m.get("key_id").and_then(|v| v.as_str()) {
+                    key_ids.insert(k.to_string());
+                }
+            }
+        }
+        let mut directory: Vec<ThresholdMember> = Vec::with_capacity(key_ids.len());
+        for k in key_ids {
+            if let Some(rec) = self.lookup_public_key(&k).await? {
+                directory.push(ThresholdMember {
+                    member_id: rec.key_id,
+                    ed25519_public_key_base64: rec.pubkey_ed25519_base64,
+                    mldsa65_public_key_base64: rec.pubkey_ml_dsa_65_base64,
+                    role: None,
+                });
+            }
+        }
+        ciris_verify_core::accord_genesis::verify_membership_change(
+            &prior_envelope,
+            change_envelope,
             signatures,
-            policy.m,
-            HybridPolicy::RequireHybrid,
+            &directory,
         )
         .map_err(|e| {
             Error::InvalidArgument(format!(
-                "verify_membership_quorum: quorum not met for {cp} ({}-of-{}): {e}",
-                policy.m, policy.n
+                "verify_membership_quorum: membership change not authorized: {e}"
             ))
         })
+    }
+
+    /// #249 Cut G3.5 — the family-shaped **prior envelope** of the live
+    /// `family`/`community`: the input both
+    /// [`Self::build_membership_change_envelope`] and
+    /// [`Self::verify_membership_quorum`] derive from, so build-time and
+    /// verify-time agree byte-for-byte (the anti-replay `supersedes` binding
+    /// depends on it). verify's general helper reads `family_key_id` /
+    /// `family_name` / `members[].key_id` / `consensus_protocol` /
+    /// `consensus_protocol_entrenched` generically; a community maps its
+    /// `community_*` fields onto those keys (`entrenched=false`). `self` has no
+    /// quorum → [`Error::InvalidArgument`].
+    async fn group_prior_envelope(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+    ) -> Result<serde_json::Value, Error> {
+        fn members_json(members: Vec<(String, Option<String>)>) -> serde_json::Value {
+            serde_json::Value::Array(
+                members
+                    .into_iter()
+                    .map(|(key_id, role)| {
+                        serde_json::json!({
+                            "key_id": key_id,
+                            "role": role.unwrap_or_else(|| "member".into()),
+                        })
+                    })
+                    .collect(),
+            )
+        }
+        match cohort {
+            cohort::Cohort::Family => {
+                let f = self.lookup_family(group_key_id).await?.ok_or_else(|| {
+                    Error::InvalidArgument(format!("unknown family group {group_key_id:?}"))
+                })?;
+                Ok(serde_json::json!({
+                    "family_key_id": f.family_key_id,
+                    "family_name": f.family_name,
+                    "members": members_json(
+                        f.members.into_iter().map(|m| (m.key_id, m.role)).collect()
+                    ),
+                    "consensus_protocol": f.consensus_protocol,
+                    "consensus_protocol_entrenched": f.consensus_protocol_entrenched,
+                }))
+            }
+            cohort::Cohort::Community => {
+                let c = self.lookup_community(group_key_id).await?.ok_or_else(|| {
+                    Error::InvalidArgument(format!("unknown community group {group_key_id:?}"))
+                })?;
+                Ok(serde_json::json!({
+                    "family_key_id": c.community_key_id,
+                    "family_name": c.community_name,
+                    "members": members_json(
+                        c.members.into_iter().map(|m| (m.key_id, m.role)).collect()
+                    ),
+                    "consensus_protocol": c.consensus_protocol,
+                    "consensus_protocol_entrenched": false,
+                }))
+            }
+            cohort::Cohort::SelfId => Err(Error::InvalidArgument(
+                "the `self` cohort has no quorum / membership-change envelope".to_string(),
+            )),
+        }
+    }
+
+    /// #249 Cut G3.5 (§5) — build the canonical membership-change payload for a
+    /// roster change on `group_key_id`, via CIRISVerify v6.9.0's
+    /// [`build_membership_change`](ciris_verify_core::accord_genesis::build_membership_change).
+    /// The prior roster cosigns this envelope's JCS bytes; submit it + the
+    /// cosignatures to [`Self::supersede_family_with_quorum`] /
+    /// [`Self::supersede_community_with_quorum`]. Defined once in verify so the
+    /// payload is portable + re-verifiable across the federation. Role is
+    /// `Founder` for a `family` (entrenched M-of-N), `Member` for a `community`
+    /// (role is cosmetic — the general gate counts role-agnostically).
+    async fn build_membership_change_envelope(
+        &self,
+        cohort: cohort::Cohort,
+        group_key_id: &str,
+        new_member_key_ids: &[String],
+        entrenched: bool,
+        consensus_protocol: Option<&str>,
+    ) -> Result<serde_json::Value, Error> {
+        use ciris_verify_core::threshold::Role;
+        let prior_envelope = self.group_prior_envelope(cohort, group_key_id).await?;
+        let role = match cohort {
+            cohort::Cohort::Family => Role::Founder,
+            _ => Role::Member,
+        };
+        Ok(ciris_verify_core::accord_genesis::build_membership_change(
+            &prior_envelope,
+            new_member_key_ids,
+            role,
+            entrenched,
+            consensus_protocol,
+        ))
     }
 
     /// #249 Cut G3 (§3/§4/§5) — quorum-gated family supersede: verify the
@@ -1552,6 +1691,21 @@ pub trait FederationDirectory: Send + Sync {
         change_envelope: serde_json::Value,
         signatures: Vec<ciris_verify_core::threshold::ThresholdSignature>,
     ) -> Result<u32, Error> {
+        // Verify-A-store-B guard: the quorum authorized `change_envelope`, so
+        // the roster/protocol being stored MUST be exactly the one it
+        // describes — never verify one roster and persist another.
+        let members: std::collections::BTreeSet<&str> = new
+            .family
+            .members
+            .iter()
+            .map(|m| m.key_id.as_str())
+            .collect();
+        assert_change_envelope_matches(
+            &new.family.family_key_id,
+            &members,
+            &new.family.consensus_protocol,
+            &change_envelope,
+        )?;
         self.verify_membership_quorum(
             cohort::Cohort::Family,
             &new.family.family_key_id,
@@ -1574,6 +1728,18 @@ pub trait FederationDirectory: Send + Sync {
         change_envelope: serde_json::Value,
         signatures: Vec<ciris_verify_core::threshold::ThresholdSignature>,
     ) -> Result<u32, Error> {
+        let members: std::collections::BTreeSet<&str> = new
+            .community
+            .members
+            .iter()
+            .map(|m| m.key_id.as_str())
+            .collect();
+        assert_change_envelope_matches(
+            &new.community.community_key_id,
+            &members,
+            &new.community.consensus_protocol,
+            &change_envelope,
+        )?;
         self.verify_membership_quorum(
             cohort::Cohort::Community,
             &new.community.community_key_id,

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -270,7 +270,19 @@ pub(crate) mod test_support {
         dir: &D,
         key_id: &str,
     ) {
-        let (ed_pk, mldsa_pk) = hybrid_pubkeys(key_id);
+        register_hybrid_key_aliased(dir, key_id, key_id).await
+    }
+
+    /// #249 Cut G3.5 — register `key_id` carrying the hybrid pubkeys OF
+    /// `pubkey_source_key_id` (so two distinct `key_id`s can share one pubkey).
+    /// Used to drive verify's one-seat / one-human-one-seat rejection (two
+    /// key_ids backed by the same pubkey in a roster).
+    pub async fn register_hybrid_key_aliased<D: crate::federation::FederationDirectory + ?Sized>(
+        dir: &D,
+        key_id: &str,
+        pubkey_source_key_id: &str,
+    ) {
+        let (ed_pk, mldsa_pk) = hybrid_pubkeys(pubkey_source_key_id);
         let now = chrono::Utc::now();
         let rec = crate::federation::KeyRecord {
             key_id: key_id.to_owned(),

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -15697,13 +15697,69 @@ impl PyEngine {
 
     // ── #249 Cut G3 ── quorum-authorized membership gate FFI (§4/§5) ──
 
-    /// #249 Cut G3 (§4/§5) — verify a membership change is authorized by the
-    /// group's current strict-majority quorum. `change_envelope_json` is the
-    /// canonical change payload (the bytes the members signed, as JSON);
-    /// `signatures_json` is a JSON array of
-    /// [`ciris_verify_core::threshold::ThresholdSignature`]. Returns the count
-    /// of valid distinct cosigners; raises `ValueError` if the quorum is not
-    /// met (or the group/policy is invalid).
+    /// #249 Cut G3.5 (§5) — build the canonical membership-change payload for a
+    /// roster change on `group_key_id` (verify v6.9.0's `build_membership_change`,
+    /// with the anti-replay `supersedes` binding). `new_member_key_ids_json` is
+    /// a JSON array of key_ids; `consensus_protocol` `None` ⇒ strict-majority
+    /// for the new count. Returns the envelope JSON — the prior roster cosigns
+    /// its JCS bytes, then submit it to `cohort_supersede_group_with_quorum`.
+    #[pyo3(signature = (cohort, group_key_id, new_member_key_ids_json, entrenched, consensus_protocol=None))]
+    fn cohort_build_membership_change_envelope(
+        &self,
+        py: Python<'_>,
+        cohort: &str,
+        group_key_id: &str,
+        new_member_key_ids_json: &str,
+        entrenched: bool,
+        consensus_protocol: Option<&str>,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let cohort = cohort_from_token(cohort)?;
+        let new_member_key_ids: Vec<String> = serde_json::from_str(new_member_key_ids_json)
+            .map_err(|e| PyValueError::new_err(format!("new_member_key_ids_json: {e}")))?;
+        let cp = consensus_protocol.map(|s| s.to_owned());
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let group_key_id = group_key_id.to_owned();
+            py.detach(move || {
+                runtime.block_on(async move {
+                    use crate::federation::FederationDirectory;
+                    macro_rules! dispatch {
+                        ($backend:expr) => {{
+                            let b = $backend.clone();
+                            let env = b
+                                .build_membership_change_envelope(
+                                    cohort,
+                                    &group_key_id,
+                                    &new_member_key_ids,
+                                    entrenched,
+                                    cp.as_deref(),
+                                )
+                                .await
+                                .map_err(federation_err_to_py)?;
+                            serde_json::to_string(&env).map_err(|e| {
+                                PyValueError::new_err(format!("change envelope serialize: {e}"))
+                            })
+                        }};
+                    }
+                    match &self.backend {
+                        BackendDispatch::Postgres(pg) => dispatch!(pg),
+                        #[cfg(feature = "sqlite")]
+                        BackendDispatch::Sqlite(sq) => dispatch!(sq),
+                    }
+                })
+            })
+        })
+    }
+
+    /// #249 Cut G3 (§4/§5), robust on G3.5 — verify a membership change is
+    /// authorized by the group's current strict-majority quorum (composes
+    /// verify v6.9.0's `verify_membership_change`: distinct + strict-majority +
+    /// one-seat + entrenchment + anti-replay + prior-quorum). `change_envelope_json`
+    /// is the `cohort_build_membership_change_envelope` output the members
+    /// cosigned; `signatures_json` is a JSON array of
+    /// [`ciris_verify_core::threshold::ThresholdSignature`]. Returns `None` on
+    /// success; raises `ValueError` if not authorized.
     fn cohort_verify_membership_quorum(
         &self,
         py: Python<'_>,
@@ -15711,7 +15767,7 @@ impl PyEngine {
         group_key_id: &str,
         change_envelope_json: &str,
         signatures_json: &str,
-    ) -> PyResult<usize> {
+    ) -> PyResult<()> {
         self.ensure_usable()?;
         let cohort = cohort_from_token(cohort)?;
         let change_envelope: serde_json::Value = serde_json::from_str(change_envelope_json)


### PR DESCRIPTION
## v9.8.0 — #249 Cut G3.5: robust quorum gate via verify 6.9.0's `verify_membership_change`

The Cut G3 gate (v9.7.0) was a **count-only** check. This cut composes **CIRISVerify v6.9.0's general `verify_membership_change`** (CIRISVerify#104/#105) — the canonical membership-change payload now defined **once in verify** (portable + re-verifiable across the federation), and the gate inherits verify's full fail-closed checks.

### New guarantees (strictly stronger than count-only)
- **one-seat key-distinctness** — the new roster must resolve to distinct pubkeys in the directory (no human seated under two `key_id`s);
- **anti-replay** — `supersedes.prior_member_key_ids` must equal the actual prior roster (no presenting the change against a different prior state);
- **entrenchment preserved** — `family_key_id` unchanged, no de-entrenchment;
- on top of distinct-members + strict-majority + the prior roster's hybrid quorum.

### Surface
- `verify_membership_quorum` now composes `verify_membership_change` (returns `Result<()>`, was `Result<usize>`).
- **`build_membership_change_envelope`** — the §5 canonical payload builder (wraps verify's `build_membership_change`); the prior roster cosigns its JCS bytes.
- **Verify-A-store-B guard** — `supersede_*_with_quorum` assert the superseding row matches the authorized `change_envelope`.
- **FFI:** new `cohort_build_membership_change_envelope`; `cohort_verify_membership_quorum` returns `None` on success.
- Accord path keeps `verify_accord_membership_change`.

### Tests
`quorum:2/3 → quorum:3/5` via `build_membership_change_envelope`; **anti-replay** (tampered `supersedes` rejected despite a valid 3-of-5 quorum) and **one-seat** (roster with two key_ids sharing one pubkey rejected) — sqlite + live Postgres; rejections leave the live row untouched.

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1577/1577**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
