### PR TITLE
v9.9.0 — #249 Cut G4: rekey-on-revoke + change-event hook (rostered-ops DX complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.9.0] — 2026-06-21
+
+### Added — #249 Cut G4: rekey-on-revoke (§7) + membership change-event hook (§9) — the rostered-ops DX is complete
+
+The final cut of the CIRISServer #249 rostered-ops write+governance surface.
+
+- **§7 forward-secrecy rekey-on-revoke** — `at_rest_cascade::orchestrate::rekey_community_member_revoke` (+ `Engine::rekey_community_member_revoke`): records the community membership revocation, **bumps the community DEK epoch** (CC 4.4.3.2.2) so the next `encrypt_and_cascade_community` mints a fresh DEK wrapped only to the remaining members — the departed member's keys can never unwrap content sealed after removal — and emits the §9 removed event. Returns the new epoch. **Community-only by construction:** `self`/`family` use a *fresh-per-write* DEK (`CryptoTier::InvisibleEncrypted`), so a removed member is excluded from all future writes **inherently** — there is no shared epoch to bump (forward secrecy holds without a re-key; documented + tested).
+- **§9 membership change-event hook** — the cohort `add_member` / `revoke_member` (and therefore `swap_member`) now emit `family_membership_change` / `community_membership_change` hard-case events (`change_kind: added`/`removed`, idempotent on the event_id) so consumers reconcile via the existing `list_hard_case_events` instead of polling — mirroring the consent reconciler. (`self` keeps its occurrence-revocation event path.)
+- **Tested** (sqlite + live Postgres): community rekey-on-revoke bumps the epoch + excludes the removed member from the active roster + emits the removed event; family `add_member`/`revoke_member` emit the added/removed events.
+
+**The rostered-ops DX is now complete** — CIRISServer's `family.rs` collapses to thin pass-throughs over `cohort` (G1) + supersede/versioning (G2) + the quorum gate (G3/G3.5) + rekey/events (G4); **one-seat-per-human and M-of-N-to-change are substrate invariants**, the HUMANITY_ACCORD mesh genesis stands on this surface.
+
 ## [9.8.0] — 2026-06-21
 
 ### Changed — #249 Cut G3.5: the quorum gate now composes verify 6.9.0's `verify_membership_change` (robust)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.8.0"
+version = "9.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2478,6 +2478,49 @@ impl Engine {
         }
     }
 
+    /// #249 Cut G4 (§7) — forward-secrecy re-key on **community** member
+    /// REMOVAL (the symmetric of [`rekey_family_member_add`](Engine::rekey_family_member_add)):
+    /// records the community membership revocation, **bumps the community DEK
+    /// epoch** (CC 4.4.3.2.2) so the next cascade mints a fresh DEK wrapped only
+    /// to the remaining members, and emits the §9 `community_membership_change`
+    /// removed event. Returns the new epoch.
+    ///
+    /// Community-only by construction: `self`/`family` use a fresh-per-write DEK,
+    /// so a removed member is excluded from future writes inherently (no epoch
+    /// to bump) — use [`Engine::revoke_member`](crate::federation::FederationDirectory::revoke_member)
+    /// there (it still emits the §9 event).
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn rekey_community_member_revoke(
+        &self,
+        community_key_id: &str,
+        removed_identity_key_id: &str,
+    ) -> Result<u64, crate::federation::BlobError> {
+        use crate::federation::at_rest_cascade::orchestrate::rekey_community_member_revoke;
+        let now = chrono::Utc::now();
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(arc) => {
+                rekey_community_member_revoke(
+                    arc.as_ref(),
+                    community_key_id,
+                    removed_identity_key_id,
+                    now,
+                )
+                .await
+            }
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(arc) => {
+                rekey_community_member_revoke(
+                    arc.as_ref(),
+                    community_key_id,
+                    removed_identity_key_id,
+                    now,
+                )
+                .await
+            }
+        }
+    }
+
     /// v6.1.0 (CIRISPersist#161 Ask 2/4, CEG §11.7.1 / §10.1.4) — the
     /// retroactive ADD re-wrap for a **self** occurrence-add: a person
     /// admitting new device-occurrence(s) into their self-collective. Same
@@ -8540,6 +8583,197 @@ mod tests {
         let engine = Engine::with_signer(signer, &dsn).await.expect("pg engine");
         let pg = engine.postgres_backend().expect("pg backend").clone();
         quorum_supersede_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
+    }
+
+    /// #249 Cut G4 — forward-secrecy rekey-on-revoke (§7) + change-event hook
+    /// (§9). Community removal bumps the DEK epoch (so the next cascade excludes
+    /// the departed member) and emits a `community_membership_change` removed
+    /// event; the cohort `revoke_member`/`add_member` paths emit the §9 events
+    /// (family/community) consumers reconcile via `list_hard_case_events`.
+    /// sqlite + pg.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn g4_rekey_events_body<D>(d: &D, s: &str)
+    where
+        D: crate::federation::FederationDirectory + crate::federation::BlobStorage + Sync,
+    {
+        use crate::federation::at_rest_cascade;
+        use crate::federation::cohort::{Cohort, RevokeSpec, RosterMember};
+        use crate::federation::hard_case::{change_kind, kind, HardCaseFilter};
+        use crate::federation::types;
+
+        // G4 rekey/events don't verify member signatures, so members are
+        // registered as PRIMITIVE keys (sweeper_test_key) — non-node/agent, so
+        // they pass the CC 3.2 community owner-binding gate without owner-binds.
+        let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+
+        // ── §7 community rekey-on-revoke (epoch bump) ──
+        let comm = format!("g4-comm-{s}");
+        let cm: Vec<String> = (0..3).map(|i| format!("g4-cm{i}-{s}")).collect();
+        d.put_public_key(sweeper_test_key(&comm))
+            .await
+            .expect("seed");
+        for k in &cm {
+            d.put_public_key(sweeper_test_key(k)).await.expect("seed");
+        }
+        d.put_community(crate::federation::SignedCommunity {
+            community: types::Community {
+                community_key_id: comm.clone(),
+                community_name: "c".into(),
+                members: cm
+                    .iter()
+                    .map(|k| types::CommunityMember {
+                        key_id: k.clone(),
+                        joined_at: joined,
+                        role: None,
+                    })
+                    .collect(),
+                founded_at: joined,
+                consensus_protocol: "founder_only".into(),
+                policy_blob: None,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("put_community");
+
+        let e1 = d
+            .community_dek_bump_epoch(&comm)
+            .await
+            .expect("genesis epoch");
+        let e2 = at_rest_cascade::orchestrate::rekey_community_member_revoke(
+            d,
+            &comm,
+            &cm[0],
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("rekey on revoke");
+        assert!(
+            e2 > e1,
+            "removal bumps the community DEK epoch (forward secrecy)"
+        );
+        let active: Vec<String> = d
+            .active_members(Cohort::Community, &comm)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(
+            !active.contains(&cm[0]),
+            "removed member excluded from active roster"
+        );
+        let evs = d
+            .list_hard_case_events(HardCaseFilter {
+                kind: Some(kind::COMMUNITY_MEMBERSHIP_CHANGE.into()),
+                since: None,
+            })
+            .await
+            .expect("list events");
+        assert!(
+            evs.iter()
+                .any(|e| e.subject_key_id.as_deref() == Some(cm[0].as_str())
+                    && e.detail["change_kind"] == change_kind::REMOVED),
+            "§9 community removed event emitted"
+        );
+
+        // ── §9 family cohort revoke + add events ──
+        let fam = format!("g4-fam-{s}");
+        let fmk: Vec<String> = (0..3).map(|i| format!("g4-fm{i}-{s}")).collect();
+        d.put_public_key(sweeper_test_key(&fam))
+            .await
+            .expect("seed");
+        for k in &fmk {
+            d.put_public_key(sweeper_test_key(k)).await.expect("seed");
+        }
+        d.put_family(crate::federation::SignedFamily {
+            family: types::Family {
+                family_key_id: fam.clone(),
+                family_name: "f".into(),
+                members: vec![types::FamilyMember {
+                    key_id: fmk[0].clone(),
+                    joined_at: joined,
+                    role: None,
+                }],
+                founded_at: joined,
+                consensus_protocol: "founder_only".into(),
+                consensus_protocol_entrenched: false,
+                persist_row_hash: String::new(),
+            },
+        })
+        .await
+        .expect("put_family");
+
+        // add → §9 added event
+        assert!(d
+            .add_member(
+                Cohort::Family,
+                &fam,
+                RosterMember {
+                    key_id: fmk[1].clone(),
+                    joined_at: joined,
+                    role: None
+                },
+            )
+            .await
+            .expect("add_member"));
+        // revoke → §9 removed event (family FS is inherent fresh-per-write)
+        d.revoke_member(
+            Cohort::Family,
+            &fam,
+            &fmk[0],
+            RevokeSpec {
+                effective_at: chrono::Utc::now(),
+                reason: None,
+                witness_set: vec![],
+            },
+        )
+        .await
+        .expect("revoke_member");
+        let fevs = d
+            .list_hard_case_events(HardCaseFilter {
+                kind: Some(kind::FAMILY_MEMBERSHIP_CHANGE.into()),
+                since: None,
+            })
+            .await
+            .expect("list family events");
+        assert!(
+            fevs.iter()
+                .any(|e| e.subject_key_id.as_deref() == Some(fmk[1].as_str())
+                    && e.detail["change_kind"] == change_kind::ADDED),
+            "§9 family added event"
+        );
+        assert!(
+            fevs.iter()
+                .any(|e| e.subject_key_id.as_deref() == Some(fmk[0].as_str())
+                    && e.detail["change_kind"] == change_kind::REMOVED),
+            "§9 family removed event"
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn g4_rekey_events_sqlite() {
+        let signer = crate::federation::tier_ingest::test_support::local_signer("g4");
+        let engine = Engine::with_signer(signer, "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        g4_rekey_events_body(&*sq, "sq").await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn g4_rekey_events_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let label = format!("g4-{}", uuid::Uuid::new_v4().simple());
+        let signer = crate::federation::tier_ingest::test_support::local_signer(&label);
+        let engine = Engine::with_signer(signer, &dsn).await.expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend").clone();
+        g4_rekey_events_body(&*pg, &uuid::Uuid::new_v4().simple().to_string()).await;
     }
 
     /// #249 — `file_moderation` stores a `moderation:{allegation}` scores

--- a/src/federation/at_rest_cascade.rs
+++ b/src/federation/at_rest_cascade.rs
@@ -879,6 +879,70 @@ pub mod orchestrate {
         Ok(result)
     }
 
+    /// #249 Cut G4 (§7) — forward-secrecy re-key on **community** member
+    /// REMOVAL: the symmetric of [`rekey_family_member_add`]. Records the
+    /// community membership revocation (forward-only; the active fold drops the
+    /// member), then **bumps the community DEK epoch** (CC 4.4.3.2.2) so the
+    /// next [`encrypt_and_cascade_community`](crate::federation::community_dek::encrypt_and_cascade_community)
+    /// mints a FRESH DEK wrapped only to the REMAINING members — the removed
+    /// member's keys can never unwrap content sealed after this point. Emits the
+    /// [`membership_removed_event`](crate::federation::hard_case::membership_removed_event)
+    /// (§9). Returns the new epoch.
+    ///
+    /// **Community-only by construction.** `self`/`family` use a *fresh-per-write*
+    /// DEK ([`CryptoTier::InvisibleEncrypted`](crate::federation::types::cohort_scope::CryptoTier)):
+    /// every write's wrap set is the active roster at write time, so a removed
+    /// member is excluded from all FUTURE writes **inherently** — there is no
+    /// shared epoch to bump (forward secrecy holds without a re-key). Only the
+    /// community tier shares one DEK per `(community, epoch)` and therefore must
+    /// rotate on removal.
+    pub async fn rekey_community_member_revoke<B>(
+        backend: &B,
+        community_key_id: &str,
+        removed_identity_key_id: &str,
+        observed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, BlobError>
+    where
+        B: FederationDirectory + BlobStorage + Sync,
+    {
+        use crate::federation::hard_case;
+        // 1. Record the removal (append-only; the roster-minus-effective-
+        //    revocations fold stops counting the member from `effective_at`).
+        backend
+            .put_community_membership_revocation(
+                crate::federation::types::SignedCommunityMembershipRevocation {
+                    community_membership_revocation:
+                        crate::federation::types::CommunityMembershipRevocation {
+                            community_key_id: community_key_id.to_string(),
+                            removed_identity_key_id: removed_identity_key_id.to_string(),
+                            removed_at: observed_at,
+                            effective_at: observed_at,
+                            reason: None,
+                            witness_set: Vec::new(),
+                            persist_row_hash: String::new(),
+                        },
+                },
+            )
+            .await
+            .map_err(map_dir_err)?;
+        // 2. Forward secrecy: bump the epoch. The next community cascade mints a
+        //    fresh DEK and wraps it only to the remaining members (the wrap
+        //    fan-out reads the active roster, which now excludes this member).
+        let new_epoch = backend.community_dek_bump_epoch(community_key_id).await?;
+        // 3. §9 — emit the membership-removed change event (consumers reconcile
+        //    via list_hard_case_events instead of polling).
+        backend
+            .record_hard_case(hard_case::membership_removed_event(
+                hard_case::kind::COMMUNITY_MEMBERSHIP_CHANGE,
+                community_key_id,
+                removed_identity_key_id,
+                observed_at,
+            ))
+            .await
+            .map_err(|e| BlobError::Backend(format!("emit membership_removed: {e}")))?;
+        Ok(new_epoch)
+    }
+
     /// The default-tier read: recover the plaintext blob body for a
     /// granted viewer. Persist unwraps the DEK (via its content-master
     /// self-retention grant), AES-GCM-decrypts, and returns the bytes.

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -1262,8 +1262,9 @@ pub trait FederationDirectory: Send + Sync {
         group_key_id: &str,
         member: cohort::RosterMember,
     ) -> Result<bool, Error> {
-        match cohort {
-            cohort::Cohort::Family => {
+        let member_key_id = member.key_id.clone();
+        let (added, change_kind) = match cohort {
+            cohort::Cohort::Family => (
                 self.add_family_member(
                     group_key_id,
                     types::FamilyMember {
@@ -1272,9 +1273,10 @@ pub trait FederationDirectory: Send + Sync {
                         role: member.role,
                     },
                 )
-                .await
-            }
-            cohort::Cohort::Community => {
+                .await?,
+                hard_case::kind::FAMILY_MEMBERSHIP_CHANGE,
+            ),
+            cohort::Cohort::Community => (
                 self.add_community_member(
                     group_key_id,
                     types::CommunityMember {
@@ -1283,15 +1285,38 @@ pub trait FederationDirectory: Send + Sync {
                         role: member.role,
                     },
                 )
-                .await
+                .await?,
+                hard_case::kind::COMMUNITY_MEMBERSHIP_CHANGE,
+            ),
+            cohort::Cohort::SelfId => {
+                return Err(Error::InvalidArgument(
+                    "add_member: the `self` cohort admits members via \
+                     put_identity_occurrence (an occurrence carries device_class / \
+                     hardware_attestation / encryption_pubkeys a RosterMember cannot)"
+                        .to_string(),
+                ))
             }
-            cohort::Cohort::SelfId => Err(Error::InvalidArgument(
-                "add_member: the `self` cohort admits members via \
-                 put_identity_occurrence (an occurrence carries device_class / \
-                 hardware_attestation / encryption_pubkeys a RosterMember cannot)"
-                    .to_string(),
-            )),
+        };
+        // #249 Cut G4 (§9) — notify on "joined" (only on a genuine add, not the
+        // idempotent no-op) so consumers reconcile via `list_hard_case_events`.
+        // change_kind=ADDED; idempotent on the event_id.
+        if added {
+            let now = chrono::Utc::now();
+            self.record_hard_case(hard_case::HardCaseEvent {
+                event_id: hard_case::membership_change_event_id(group_key_id, &member_key_id, now),
+                kind: change_kind.to_string(),
+                target_key_id: Some(group_key_id.to_string()),
+                subject_key_id: Some(member_key_id.clone()),
+                detail: serde_json::json!({
+                    "change_kind": hard_case::change_kind::ADDED,
+                    "subject_key_id": member_key_id,
+                    "cohort_key_id": group_key_id,
+                }),
+                emitted_at: now,
+            })
+            .await?;
         }
+        Ok(added)
     }
 
     /// #249 Cut G1 (§1) — remove one member from a `cohort` roster uniformly,
@@ -1313,6 +1338,14 @@ pub trait FederationDirectory: Send + Sync {
             reason,
             witness_set,
         } = spec;
+        // #249 Cut G4 (§9) — `kind` of the membership-change "removed" event to
+        // emit after a family/community revocation (`self` uses the occurrence
+        // path, which carries its own events). `None` ⇒ no membership event.
+        let change_kind = match cohort {
+            cohort::Cohort::Family => Some(hard_case::kind::FAMILY_MEMBERSHIP_CHANGE),
+            cohort::Cohort::Community => Some(hard_case::kind::COMMUNITY_MEMBERSHIP_CHANGE),
+            cohort::Cohort::SelfId => None,
+        };
         match cohort {
             cohort::Cohort::Family => {
                 self.put_family_membership_revocation(types::SignedFamilyMembershipRevocation {
@@ -1326,7 +1359,7 @@ pub trait FederationDirectory: Send + Sync {
                         persist_row_hash: String::new(),
                     },
                 })
-                .await
+                .await?;
             }
             cohort::Cohort::Community => {
                 self.put_community_membership_revocation(
@@ -1342,23 +1375,40 @@ pub trait FederationDirectory: Send + Sync {
                         },
                     },
                 )
-                .await
+                .await?;
             }
             cohort::Cohort::SelfId => {
-                self.put_identity_occurrence_revocation(types::SignedIdentityOccurrenceRevocation {
-                    identity_occurrence_revocation: types::IdentityOccurrenceRevocation {
-                        identity_key_id: group_key_id.to_string(),
-                        occurrence_key_id: removed_key_id.to_string(),
-                        revoked_at: now,
-                        effective_at,
-                        reason,
-                        witness_set,
-                        persist_row_hash: String::new(),
+                self.put_identity_occurrence_revocation(
+                    types::SignedIdentityOccurrenceRevocation {
+                        identity_occurrence_revocation: types::IdentityOccurrenceRevocation {
+                            identity_key_id: group_key_id.to_string(),
+                            occurrence_key_id: removed_key_id.to_string(),
+                            revoked_at: now,
+                            effective_at,
+                            reason,
+                            witness_set,
+                            persist_row_hash: String::new(),
+                        },
                     },
-                })
-                .await
+                )
+                .await?;
             }
         }
+        // #249 Cut G4 (§9) — notify on "left" so consumers reconcile via
+        // `list_hard_case_events` instead of polling. Idempotent on the event_id
+        // (keyed on effective_at). NOT a forward-secrecy re-key — for community
+        // that is `at_rest_cascade::rekey_community_member_revoke` (epoch bump);
+        // for self/family it is inherent (fresh-per-write DEK).
+        if let Some(kind) = change_kind {
+            self.record_hard_case(hard_case::membership_removed_event(
+                kind,
+                group_key_id,
+                removed_key_id,
+                effective_at,
+            ))
+            .await?;
+        }
+        Ok(())
     }
 
     /// #249 Cut G1 (§6) — atomically swap one member for another in a `family`


### PR DESCRIPTION
## v9.9.0 — #249 Cut G4: rekey-on-revoke (§7) + change-event hook (§9) — **the rostered-ops DX is complete**

The final cut of the CIRISServer #249 rostered-ops write+governance surface.

### §7 — forward-secrecy rekey-on-revoke
`at_rest_cascade::orchestrate::rekey_community_member_revoke` (+ `Engine::rekey_community_member_revoke`): records the community membership revocation, **bumps the community DEK epoch** (CC 4.4.3.2.2) so the next `encrypt_and_cascade_community` mints a fresh DEK wrapped only to the remaining members — the departed member's keys can never unwrap content sealed after removal — and emits the §9 removed event. Returns the new epoch.

**Community-only by construction (honest):** `self`/`family` use a *fresh-per-write* DEK (`CryptoTier::InvisibleEncrypted`), so a removed member is excluded from every future write **inherently** — there is no shared epoch to bump. Documented + tested rather than faked with a no-op re-key.

### §9 — membership change-event hook
The cohort `add_member` / `revoke_member` (and `swap_member`) now emit `family_membership_change` / `community_membership_change` hard-case events (`change_kind: added`/`removed`, idempotent on the event_id) so consumers reconcile via the existing `list_hard_case_events` instead of polling — mirroring the consent reconciler.

### Tests (sqlite + live Postgres)
Community rekey-on-revoke bumps the epoch + excludes the removed member from the active roster + emits the removed event; family `add_member`/`revoke_member` emit the added/removed events.

### DX complete
`cohort` (G1 §1/§2/§6) + supersede/versioning (G2 §3/§8) + quorum gate (G3 §4/§5, hardened G3.5 with verify 6.9.0 `verify_membership_change`) + rekey/events (G4 §7/§9). CIRISServer's `family.rs` collapses to thin pass-throughs; **one-seat-per-human + M-of-N-to-change are substrate invariants**; the HUMANITY_ACCORD mesh genesis stands on this surface.

### Gate — all green
- nextest `--all-targets` (full features, live postgres:16 + sqlite + memory): **1579/1579**.
- clippy `-D warnings`, fmt, 3 no-backend `-D warnings` combos: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
