### PR TITLE
v9.10.0 — #227: list_held_fountain_content (publisher-facing held enumerator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.10.0] — 2026-06-21
+
+### Added — #227: `list_held_fountain_content` (publisher-facing held enumerator)
+
+A publisher can now enumerate the fountain-coded content persist holds **for them** and watch it fade — the #227 "fades but can't be falsified" property made observable without fetching symbol bytes.
+
+- **`Backend::list_held_fountain_content(publisher_key_id) -> Vec<FountainHeldMeta>`** (sqlite + postgres + memory): filters `content_manifest` to `pqc_key_id = publisher_key_id` (the manifest signer) and joins the **current** `COUNT(content_symbols)`. `FountainHeldMeta` carries the manifest essentials (`content_id`, `corpus_kind`, `pqc_key_id`, `original_content_length`, `n_source`, `k_repair`, `min_viable_symbols`, `symbol_size`, `admitted_at`) plus the **degradation state**: `held_symbols` (currently retained, post-eviction) and `recoverable` (`held_symbols >= min_viable_symbols` — is the content still decodable from what persist holds?). No symbol payload is read. Ordered by `admitted_at` desc.
+- **`Engine::list_held_fountain_content`** (pg/sqlite) + **FFI `list_held_fountain_content(publisher_key_id) -> JSON`** (mirrors the existing `*_fountain_content` surface).
+- Memory parity (`admitted_at` empty — the in-memory manifest map keeps no admission timestamp; the Engine/FFI fountain surface is pg/sqlite only).
+- **Tested** (sqlite + live Postgres, in `run_fountain_assertions`): full content lists with `held_symbols == n+k` + `recoverable`; after evicting to the lowest tier the publisher sees `held_symbols` drop (the fade) with `recoverable` tracking the count; an unknown publisher lists empty.
+
 ## [9.9.1] — 2026-06-21
 
 ### Changed — re-pin CIRISVerify v6.9.0 → v6.11.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.9.1"
+version = "9.10.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1101,6 +1101,26 @@ impl Engine {
         }
     }
 
+    /// #227 — list the fountain-coded content a **publisher** holds (filtered
+    /// to `pqc_key_id = publisher_key_id`), as
+    /// [`FountainHeldMeta`](crate::fountain::FountainHeldMeta): the manifest
+    /// essentials + the current degradation state (`held_symbols` vs
+    /// `min_viable_symbols` ⇒ `recoverable`), so a publisher can watch their
+    /// content fade (#227) without fetching symbol bytes.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, crate::store::Error> {
+        use crate::store::Backend;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.list_held_fountain_content(publisher_key_id).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.list_held_fountain_content(publisher_key_id).await,
+        }
+    }
+
     /// v8.0.0 (CIRISPersist#227) — evict a content unit's symbols down to
     /// the given [`FountainTier`](crate::fountain::FountainTier) keep-
     /// count (highest `retention_priority` first). The manifest is never

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -8198,6 +8198,47 @@ impl PyEngine {
     ///  "symbols":[{...FountainSymbolV1...}, ...]}   # absent for envelope_only
     /// ```
     ///
+    /// #227 — list the fountain-coded content a **publisher** holds
+    /// (`pqc_key_id == publisher_key_id`). Returns a JSON array of
+    /// [`crate::fountain::FountainHeldMeta`] — manifest essentials + the
+    /// current degradation state (`held_symbols` vs `min_viable_symbols` ⇒
+    /// `recoverable`), no symbol bytes. The publisher's view of their content
+    /// fading (#227) without a fetch.
+    fn list_held_fountain_content(
+        &self,
+        py: Python<'_>,
+        publisher_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        let publisher = publisher_key_id.to_owned();
+        let rows = catch_panic(|| {
+            let runtime = self.runtime.clone();
+            py.detach(move || {
+                match &self.backend {
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            use crate::store::Backend;
+                            backend.list_held_fountain_content(&publisher).await
+                        })
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            use crate::store::Backend;
+                            backend.list_held_fountain_content(&publisher).await
+                        })
+                    }
+                }
+                .map_err(fountain_store_err_to_py)
+            })
+        })?;
+        serde_json::to_string(&rows).map_err(|e| {
+            PyValueError::new_err(format!("list_held_fountain_content serialize: {e}"))
+        })
+    }
+
     /// Each present symbol's SHA-256 is re-verified against the signed
     /// `symbol_hashes` on read; a mismatch raises a `ValueError`
     /// (`fountain_integrity`) rather than returning unauthenticated

--- a/src/fountain/mod.rs
+++ b/src/fountain/mod.rs
@@ -59,5 +59,6 @@ pub use retention::{
     holding_claim_counts, map_consent_state, resolve_retention_action, RetentionAction,
 };
 pub use types::{
-    FountainContent, FountainManifestV1, FountainReadClass, FountainSymbolV1, MANIFEST_VERSION_V1,
+    FountainContent, FountainHeldMeta, FountainManifestV1, FountainReadClass, FountainSymbolV1,
+    MANIFEST_VERSION_V1,
 };

--- a/src/fountain/types.rs
+++ b/src/fountain/types.rs
@@ -265,3 +265,40 @@ mod tests {
         assert_eq!(m.total_symbols(), 6);
     }
 }
+
+/// #227 — publisher-facing metadata for one HELD fountain-coded content item.
+///
+/// What a publisher gets from
+/// [`list_held_fountain_content`](crate::store::Backend::list_held_fountain_content):
+/// the manifest essentials + the **current degradation state**
+/// (`held_symbols` vs `min_viable_symbols` ⇒ `recoverable`), so a publisher can
+/// watch their content fade (#227 "fades but can't be falsified") without
+/// fetching any symbol bytes. No symbol payload is returned.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FountainHeldMeta {
+    /// The content's id (`content_manifest.content_id`).
+    pub content_id: String,
+    /// The corpus kind (`content_manifest.corpus_kind`).
+    pub corpus_kind: String,
+    /// The publisher's PQC key_id — the manifest signer
+    /// (`content_manifest.pqc_key_id`); the filter key.
+    pub pqc_key_id: String,
+    /// Decoded length of the original content.
+    pub original_content_length: u64,
+    /// Source-symbol count `n`.
+    pub n_source: u32,
+    /// Repair-symbol count `k`.
+    pub k_repair: u32,
+    /// Minimum symbols needed to reconstruct (`min_viable_symbols`).
+    pub min_viable_symbols: u32,
+    /// Per-symbol size (bytes).
+    pub symbol_size: u32,
+    /// Symbols CURRENTLY retained for this content (post-eviction /
+    /// degradation) — `COUNT(content_symbols)`.
+    pub held_symbols: u32,
+    /// `held_symbols >= min_viable_symbols` — is the content still decodable
+    /// from what persist currently holds?
+    pub recoverable: bool,
+    /// Admission timestamp (ISO-8601 UTC, as stored in `admitted_at`).
+    pub admitted_at: String,
+}

--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -416,6 +416,18 @@ pub trait Backend: Send + Sync {
         corpus_kind: &str,
     ) -> impl Future<Output = Result<Option<crate::fountain::FountainContent>, Error>> + Send;
 
+    /// #227 — list the fountain-coded content a **publisher** holds, as
+    /// [`FountainHeldMeta`](crate::fountain::FountainHeldMeta) (manifest
+    /// essentials + the current degradation state: `held_symbols` vs
+    /// `min_viable_symbols` ⇒ `recoverable`). Filtered to
+    /// `content_manifest.pqc_key_id = publisher_key_id` (the manifest signer);
+    /// no symbol bytes are read. Ordered by `admitted_at` descending. Empty
+    /// when the publisher holds nothing.
+    fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> impl Future<Output = Result<Vec<crate::fountain::FountainHeldMeta>, Error>> + Send;
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
     //
     // The forever-memory storage half of operator 2. persist is

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -983,6 +983,44 @@ impl Backend for MemoryBackend {
         Ok(Some(assemble_fountain_content(manifest, symbols)?))
     }
 
+    // #227 — publisher-facing held fountain-content enumerator. Memory parity
+    // for the pg/sqlite query; `admitted_at` is empty (the in-memory manifest
+    // map does not retain an admission timestamp — the Engine/FFI fountain
+    // surface is pg/sqlite only).
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut out: Vec<crate::fountain::FountainHeldMeta> = state
+            .fountain_manifests
+            .iter()
+            .filter(|((_, _), m)| m.pqc_key_id == publisher_key_id)
+            .map(|((content_id, corpus_kind), m)| {
+                let held = state
+                    .fountain_symbols
+                    .get(content_id)
+                    .map(|b| b.len())
+                    .unwrap_or(0) as u32;
+                crate::fountain::FountainHeldMeta {
+                    content_id: content_id.clone(),
+                    corpus_kind: corpus_kind.clone(),
+                    pqc_key_id: m.pqc_key_id.clone(),
+                    original_content_length: m.original_content_length,
+                    n_source: m.n_source,
+                    k_repair: m.k_repair,
+                    min_viable_symbols: m.min_viable_symbols,
+                    symbol_size: m.symbol_size,
+                    held_symbols: held,
+                    recoverable: held >= m.min_viable_symbols,
+                    admitted_at: String::new(),
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| b.content_id.cmp(&a.content_id));
+        Ok(out)
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1605,6 +1605,60 @@ impl Backend for PostgresBackend {
         )?))
     }
 
+    // #227 — publisher-facing held fountain-content enumerator.
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, Error> {
+        let client = self.get_client().await?;
+        let rows = client
+            .query(
+                "SELECT m.content_id, m.corpus_kind, m.pqc_key_id, \
+                        m.original_content_length, m.n_source, m.k_repair, \
+                        m.min_viable_symbols, m.symbol_size, m.admitted_at, \
+                        (SELECT COUNT(*) FROM cirislens.content_symbols s \
+                         WHERE s.content_id = m.content_id) AS held \
+                 FROM cirislens.content_manifest m WHERE m.pqc_key_id = $1 \
+                 ORDER BY m.admitted_at DESC, m.content_id ASC",
+                &[&publisher_key_id],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("list_held_fountain_content: {e}")))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            let min_viable: i64 = r.safe_get_with("min_viable_symbols", Error::Backend)?;
+            let held: i64 = r.safe_get_with("held", Error::Backend)?;
+            let admitted_at: chrono::DateTime<chrono::Utc> =
+                r.safe_get_with("admitted_at", Error::Backend)?;
+            out.push(crate::fountain::FountainHeldMeta {
+                content_id: r.safe_get_with("content_id", Error::Backend)?,
+                corpus_kind: r.safe_get_with("corpus_kind", Error::Backend)?,
+                pqc_key_id: r.safe_get_with("pqc_key_id", Error::Backend)?,
+                original_content_length: u64::try_from(
+                    r.safe_get_with::<i64, _, _, _>("original_content_length", Error::Backend)?,
+                )
+                .unwrap_or(0),
+                n_source: u32::try_from(
+                    r.safe_get_with::<i64, _, _, _>("n_source", Error::Backend)?,
+                )
+                .unwrap_or(0),
+                k_repair: u32::try_from(
+                    r.safe_get_with::<i64, _, _, _>("k_repair", Error::Backend)?,
+                )
+                .unwrap_or(0),
+                min_viable_symbols: u32::try_from(min_viable).unwrap_or(0),
+                symbol_size: u32::try_from(
+                    r.safe_get_with::<i64, _, _, _>("symbol_size", Error::Backend)?,
+                )
+                .unwrap_or(0),
+                held_symbols: u32::try_from(held).unwrap_or(0),
+                recoverable: held >= min_viable,
+                admitted_at: admitted_at.to_rfc3339(),
+            });
+        }
+        Ok(out)
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1176,6 +1176,48 @@ impl Backend for SqliteBackend {
         )?))
     }
 
+    // #227 — publisher-facing held fountain-content enumerator.
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, Error> {
+        let conn = self.conn.clone();
+        let publisher = publisher_key_id.to_owned();
+        (move || -> Result<Vec<crate::fountain::FountainHeldMeta>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT m.content_id, m.corpus_kind, m.pqc_key_id, \
+                        m.original_content_length, m.n_source, m.k_repair, \
+                        m.min_viable_symbols, m.symbol_size, m.admitted_at, \
+                        (SELECT COUNT(*) FROM content_symbols s \
+                         WHERE s.content_id = m.content_id) AS held \
+                 FROM content_manifest m WHERE m.pqc_key_id = ?1 \
+                 ORDER BY m.admitted_at DESC, m.content_id ASC",
+            )?;
+            let rows = stmt
+                .query_map(rusqlite::params![publisher], |row| {
+                    let min_viable: i64 = row.get(6)?;
+                    let held: i64 = row.get(9)?;
+                    Ok(crate::fountain::FountainHeldMeta {
+                        content_id: row.get(0)?,
+                        corpus_kind: row.get(1)?,
+                        pqc_key_id: row.get(2)?,
+                        original_content_length: u64::try_from(row.get::<_, i64>(3)?).unwrap_or(0),
+                        n_source: u32::try_from(row.get::<_, i64>(4)?).unwrap_or(0),
+                        k_repair: u32::try_from(row.get::<_, i64>(5)?).unwrap_or(0),
+                        min_viable_symbols: u32::try_from(min_viable).unwrap_or(0),
+                        symbol_size: u32::try_from(row.get::<_, i64>(7)?).unwrap_or(0),
+                        held_symbols: u32::try_from(held).unwrap_or(0),
+                        recoverable: held >= min_viable,
+                        admitted_at: row.get(8)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })()
+        .map_err(|e| Error::Backend(format!("list_held_fountain_content: {e}")))
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(

--- a/tests/fountain_content.rs
+++ b/tests/fountain_content.rs
@@ -338,6 +338,68 @@ async fn run_fountain_assertions<B: Backend>(backend: &B, suffix: &str) {
         0,
         "(i) zero symbols survive revocation HardDelete"
     );
+
+    // (#227 publisher view) list_held_fountain_content — the publisher sees
+    // their held content + its degradation state without fetching symbols.
+    let hcid = format!("c-held-{suffix}");
+    let (hmanifest, hsymbols) =
+        build_manifest_and_symbols(&hcid, n_source, k_repair, symbol_size, true).await;
+    backend
+        .put_fountain_content(&hmanifest, &hsymbols)
+        .await
+        .expect("admit held-list content");
+    // Full: all N+K symbols held, recoverable (held >= min_viable_symbols=2).
+    let held = backend
+        .list_held_fountain_content("fountain-mldsa")
+        .await
+        .expect("list_held_fountain_content");
+    assert!(
+        held.iter().all(|m| m.pqc_key_id == "fountain-mldsa"),
+        "filtered to the publisher"
+    );
+    let mine = held
+        .iter()
+        .find(|m| m.content_id == hcid)
+        .expect("admitted content is listed for its publisher");
+    assert_eq!(mine.held_symbols, total, "all symbols held when full");
+    assert_eq!(mine.min_viable_symbols, 2);
+    assert!(mine.recoverable, "full content is recoverable");
+    assert_eq!(
+        mine.recoverable,
+        mine.held_symbols >= mine.min_viable_symbols,
+        "recoverable == held >= min_viable"
+    );
+    // Degrade: evict to the lowest tier — the publisher SEES the fade (#227).
+    backend
+        .evict_fountain_content_to_tier(&hcid, corpus, FountainTier::T5)
+        .await
+        .expect("evict to T5");
+    let after = backend
+        .list_held_fountain_content("fountain-mldsa")
+        .await
+        .expect("list after evict");
+    let faded = after
+        .iter()
+        .find(|m| m.content_id == hcid)
+        .expect("still listed after eviction (manifest intact)");
+    assert!(
+        faded.held_symbols < total,
+        "held_symbols dropped after eviction — the fade is visible to the publisher"
+    );
+    assert_eq!(
+        faded.recoverable,
+        faded.held_symbols >= faded.min_viable_symbols,
+        "recoverable tracks the post-eviction symbol count"
+    );
+    // A publisher who holds nothing → empty.
+    assert!(
+        backend
+            .list_held_fountain_content("no-such-publisher")
+            .await
+            .unwrap()
+            .is_empty(),
+        "unknown publisher holds nothing"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## v9.10.0 — #227: `list_held_fountain_content`

A **publisher** can enumerate the fountain-coded content persist holds for them (filtered to `content_manifest.pqc_key_id`) and watch it fade — the #227 "fades but can't be falsified" property made observable without fetching symbol bytes.

- **`Backend::list_held_fountain_content(publisher_key_id) -> Vec<FountainHeldMeta>`** (sqlite + postgres + memory). `FountainHeldMeta` = manifest essentials + **degradation state**: `held_symbols` (post-eviction `COUNT(content_symbols)`) and `recoverable` (`held_symbols >= min_viable_symbols`). No symbol payload read; ordered by `admitted_at` desc. pg reads via the approved `PgRowExt::safe_get_with`.
- **`Engine::list_held_fountain_content`** (pg/sqlite) + **FFI** `list_held_fountain_content` (mirrors the existing `*_fountain_content` surface).
- Memory parity (`admitted_at` empty — in-memory manifests keep no admission ts; Engine/FFI fountain surface is pg/sqlite).
- **Tested** sqlite + live pg (`run_fountain_assertions`): full → `held == n+k` + recoverable; evict to lowest tier → the publisher sees `held_symbols` drop with `recoverable` tracking the count; unknown publisher → empty.

Stacked on v9.9.1 (verify 6.11.0).

Gate: **1579/1579** nextest (full features, live postgres:16 + sqlite + memory) + clippy -D + fmt + 3 no-backend combos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)