### PR TITLE
v9.11.0 — re-pin CIRISVerify v6.13.0 → v7.2.0 (verify MAJOR) + #268 admit FIPS YubiKey PIV accord holders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [9.11.0] — 2026-06-23
+
+### Changed — re-pin CIRISVerify v6.13.0 → v7.2.0 (verify MAJOR)
+
+- All six git-tag verify crates flipped in lockstep; family floor `version = "6"` → `"7"`, and the wheel `Requires-Dist` floor `ciris-verify>=6.0.0,<7` → `>=7.0.0,<8` (the verify-MAJOR knob). The 7.x line is the **accord trio**: 7.0.0 hash-commits the ML-DSA-65 pubkey in the custody attestation (CIRISVerify#116), 7.1.0 bridges custody attestation → persist `attestation_evidence` (CIRISVerify#117), 7.2.0 bakes the HUMANITY_ACCORD genesis recognition root (CIRISVerify#107). The only consumed-surface delta is `ciris-keyring`'s new `PlatformAttestation::ExternalSecureElement` variant (see below); persist's other consumed APIs (`verify_hybrid` / `canonical` / `jcs` / `threshold` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode`) are unchanged.
+
+### Fixed — #268: admit FIPS YubiKey PIV (external secure element) accord holders
+
+The `accord_holder` hardware-attestation gate (`src/federation/hardware_attestation.rs`) could admit Android/iOS/TPM holders but **not** a FIPS YubiKey PIV token — the canonical HUMANITY_ACCORD holder custody (`portable_2fa`). So real YubiKey-backed accord holders 409'd at admission ("seat is not a registered, custody-verified accord_holder") and genesis entrenchment was blocked. verify 7.x adds the missing `ciris_keyring::PlatformAttestation::ExternalSecureElement(ExternalSecureElementAttestation)` variant (CIRISVerify#117); persist now consumes it:
+
+- **`platform_to_hardware_type`** maps `ExternalSecureElement(_)` → `HardwareType::ExternalSecureElement`.
+- **`required_field_gaps`** for the variant requires the leaf attestation cert (`attestation_cert_der` — a YubiKey's slot-9c attestation certificate), the chain above it (`attestation_chain_der`, leaf-first up to but excluding the pinned root), and the `hardware_class`. `fips_certified` / `touch_always` are bools (always present). Structural shape + nonce-freshness only — chain validation to the pinned Yubico root stays registry-side (consistent with the Android/TPM path; persist preserves the audit trail).
+- **`HardwareAttestationPolicy::default().accepted_hardware_types`** now includes `ExternalSecureElement` (12 of the 13 non-`SoftwareOnly` variants).
+- No FFI change: the variant flows through the existing `put_public_key` `attestation_evidence` JSON path via serde.
+- **Tested**: variant→hardware-type mapping; default policy accepts the variant; a full FIPS YubiKey 5.7.4 slot-9c attestation admits; missing cert/chain reports `AttestationEvidenceIncomplete` with `attestation_cert_der` / `attestation_chain_der` gaps.
+
 ## [9.10.2] — 2026-06-22
 
 ### Changed — re-pin CIRISVerify v6.12.0 → v6.13.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.10.2"
+version = "9.11.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.13.0", version = "6", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 # pip resolution conflict. Floor is v6.0.0 to track the v6 family floor,
 # coherent with the Rust pin.
 dependencies = [
-    "ciris-verify>=6.0.0,<7",
+    "ciris-verify>=7.0.0,<8",
 ]
 dynamic = ["version"]
 

--- a/src/federation/hardware_attestation.rs
+++ b/src/federation/hardware_attestation.rs
@@ -44,7 +44,7 @@
 //! hardware-attested, period. Everything finer (which HSMs are
 //! production-grade, which require firmware vs discrete TPM, etc.) is
 //! the consumer's call. [`HardwareAttestationPolicy::default()`]'s
-//! accepted set drops `SoftwareOnly` and accepts the other 11 variants;
+//! accepted set drops `SoftwareOnly` and accepts the other 12 variants;
 //! deployments tighten further (e.g. AWS HSM-only) by overriding.
 
 use std::collections::HashSet;
@@ -76,7 +76,7 @@ pub const DEFAULT_MAX_NONCE_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 ///
 /// # Default (FSD-002 §7.3)
 ///
-/// - `accepted_hardware_types`: all 11 non-`SoftwareOnly` variants.
+/// - `accepted_hardware_types`: all 12 non-`SoftwareOnly` variants.
 ///   The one structural floor Verify draws is
 ///   `SoftwareOnly.supports_professional_license() == false`; that
 ///   floor is operationally absorbed here.
@@ -96,7 +96,7 @@ pub struct HardwareAttestationPolicy {
 
 impl Default for HardwareAttestationPolicy {
     fn default() -> Self {
-        // All 12 variants minus SoftwareOnly. Listed explicitly so
+        // All 13 variants minus SoftwareOnly. Listed explicitly so
         // adding a future variant in ciris-keyring lights up a
         // compile error here (good — forces a policy decision).
         let accepted = [
@@ -111,6 +111,11 @@ impl Default for HardwareAttestationPolicy {
             HardwareType::AzureHsm,
             HardwareType::GcpCloudHsm,
             HardwareType::YubiHsm,
+            // CIRISPersist#268 (v9.11.0) — external secure element /
+            // FIPS YubiKey PIV token. The canonical HUMANITY_ACCORD holder
+            // custody (`portable_2fa`); without it real YubiKey-backed
+            // accord holders cannot be admitted and genesis entrenchment 409s.
+            HardwareType::ExternalSecureElement,
         ];
         Self {
             accepted_hardware_types: accepted.into_iter().collect(),
@@ -257,6 +262,7 @@ pub(crate) fn platform_to_hardware_type(att: &PlatformAttestation) -> HardwareTy
                 HardwareType::TpmFirmware
             }
         }
+        PlatformAttestation::ExternalSecureElement(_) => HardwareType::ExternalSecureElement,
         PlatformAttestation::Software(_) => HardwareType::SoftwareOnly,
     }
 }
@@ -323,6 +329,22 @@ pub(crate) fn required_field_gaps(att: &PlatformAttestation) -> Vec<String> {
                 }
             }
         }
+        PlatformAttestation::ExternalSecureElement(e) => {
+            // §9.4 external secure element (YubiKey PIV / smartcard). The
+            // load-bearing evidence is the leaf attestation cert (a YubiKey's
+            // slot-9c attestation certificate) plus the chain above it up to
+            // the pinned root. `hardware_class` names the §9.4 class.
+            // `fips_certified` / `touch_always` are bools — always present.
+            if e.hardware_class.is_empty() {
+                gaps.push("hardware_class".into());
+            }
+            if e.attestation_cert_der.is_empty() {
+                gaps.push("attestation_cert_der".into());
+            }
+            if e.attestation_chain_der.is_empty() {
+                gaps.push("attestation_chain_der".into());
+            }
+        }
         PlatformAttestation::Software(_) => {
             gaps.push("software_only_not_accepted".into());
         }
@@ -333,7 +355,9 @@ pub(crate) fn required_field_gaps(att: &PlatformAttestation) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ciris_keyring::{AndroidAttestation, IosAttestation, SoftwareAttestation};
+    use ciris_keyring::{
+        AndroidAttestation, ExternalSecureElementAttestation, IosAttestation, SoftwareAttestation,
+    };
 
     fn android_full() -> PlatformAttestation {
         PlatformAttestation::Android(AndroidAttestation {
@@ -405,14 +429,28 @@ mod tests {
         PlatformAttestation::Software(SoftwareAttestation::default())
     }
 
+    /// A fully-populated FIPS YubiKey PIV slot-9c attestation — the
+    /// canonical HUMANITY_ACCORD holder custody (CIRISPersist#268).
+    fn external_se_yubikey_full() -> PlatformAttestation {
+        PlatformAttestation::ExternalSecureElement(ExternalSecureElementAttestation {
+            hardware_class: "YubiKey_5_FIPS".into(),
+            attestation_cert_der: vec![0x30, 0x82, 0x01, 0x00], // slot-9c leaf
+            attestation_chain_der: vec![vec![0x30, 0x82, 0x02, 0x00]], // [f9, ..]
+            firmware: Some("5.7.4".into()),
+            serial: Some(12_345_678),
+            fips_certified: true,
+            touch_always: true,
+        })
+    }
+
     #[test]
     fn default_policy_drops_software_only() {
         let p = HardwareAttestationPolicy::default();
         assert!(!p
             .accepted_hardware_types
             .contains(&HardwareType::SoftwareOnly));
-        // 11 of the 12 variants accepted.
-        assert_eq!(p.accepted_hardware_types.len(), 11);
+        // 12 of the 13 variants accepted.
+        assert_eq!(p.accepted_hardware_types.len(), 12);
     }
 
     #[test]
@@ -544,6 +582,62 @@ mod tests {
         };
         let v = serde_json::to_value(&ev).unwrap();
         p.check("k1", Some(&v), Utc::now()).unwrap();
+    }
+
+    #[test]
+    fn platform_to_hardware_type_maps_external_se() {
+        assert_eq!(
+            platform_to_hardware_type(&external_se_yubikey_full()),
+            HardwareType::ExternalSecureElement
+        );
+    }
+
+    #[test]
+    fn default_policy_accepts_external_secure_element() {
+        // CIRISPersist#268 — the FIPS YubiKey PIV admission path must be
+        // open by default, else genesis entrenchment 409s.
+        let p = HardwareAttestationPolicy::default();
+        assert!(p
+            .accepted_hardware_types
+            .contains(&HardwareType::ExternalSecureElement));
+    }
+
+    #[test]
+    fn check_accepts_full_yubikey_piv() {
+        let p = HardwareAttestationPolicy::default();
+        let ev = AttestationEvidence {
+            platform_attestation: external_se_yubikey_full(),
+            nonce_captured_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        p.check("k1", Some(&v), Utc::now()).unwrap();
+    }
+
+    #[test]
+    fn check_reports_missing_cert_and_chain_for_external_se() {
+        let p = HardwareAttestationPolicy::default();
+        let mut att = external_se_yubikey_full();
+        if let PlatformAttestation::ExternalSecureElement(ref mut e) = att {
+            e.attestation_cert_der.clear();
+            e.attestation_chain_der.clear();
+        }
+        let ev = AttestationEvidence {
+            platform_attestation: att,
+            nonce_captured_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        let err = p.check("k1", Some(&v), Utc::now()).unwrap_err();
+        match err {
+            Error::AttestationEvidenceIncomplete {
+                hardware_type,
+                missing_fields,
+            } => {
+                assert_eq!(hardware_type, "ExternalSecureElement");
+                assert!(missing_fields.iter().any(|f| f == "attestation_cert_der"));
+                assert!(missing_fields.iter().any(|f| f == "attestation_chain_der"));
+            }
+            other => panic!("expected AttestationEvidenceIncomplete, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A **verify-MAJOR** re-pin (6.13.0 → 7.2.0) that pulls in the new `ciris_keyring::PlatformAttestation::ExternalSecureElement` variant, then uses it to **fix #268** — the `accord_holder` gate could not admit a FIPS YubiKey PIV token (the canonical HUMANITY_ACCORD holder custody), which was the only step blocking genesis entrenchment.

## Re-pin (verify MAJOR 6 → 7)

- 6 git-tag verify crates flipped to `v7.2.0` in lockstep
- family floor `version = "6"` → `"7"`
- wheel `Requires-Dist` `ciris-verify>=6.0.0,<7` → `>=7.0.0,<8`
- 7.x = the **accord trio**: 7.0.0 hash-commits the ML-DSA-65 pubkey in the custody attestation (CIRISVerify#116), 7.1.0 bridges custody attestation → persist `attestation_evidence` (CIRISVerify#117), 7.2.0 bakes the HUMANITY_ACCORD genesis recognition root (CIRISVerify#107). Only consumed-surface delta is keyring's new `ExternalSecureElement` variant — `verify_hybrid` / `canonical` / `jcs` / `threshold` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode` unchanged.

## Fixes #268 — admit FIPS YubiKey PIV (external secure element) accord holders

`src/federation/hardware_attestation.rs`:
- `platform_to_hardware_type`: `ExternalSecureElement(_)` → `HardwareType::ExternalSecureElement`
- `required_field_gaps`: require `attestation_cert_der` (YubiKey slot-9c leaf), `attestation_chain_der` (chain leaf-first to the pinned root), `hardware_class`. `fips_certified` / `touch_always` are bools (always present). Structural shape + nonce-freshness only — chain validation to the pinned Yubico root stays registry-side, consistent with the Android/TPM path.
- `HardwareAttestationPolicy::default()` accepts `ExternalSecureElement` (12 of 13 non-`SoftwareOnly` variants)
- No FFI change: the variant flows through the existing `put_public_key` `attestation_evidence` JSON path via serde.

## Test

- 4 new unit tests: variant→hardware-type mapping; default policy accepts the variant; full FIPS YubiKey 5.7.4 slot-9c attestation admits; missing cert/chain → `AttestationEvidenceIncomplete` with the right gaps.
- Full local gate green: **1583 passed, 0 failed** (`cargo nextest --all-targets --test-threads=1`, plain postgres:16), clippy `-D warnings`, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)