### PR TITLE
v10.0.0 — public-surface completion: #270/#271/#272/#273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.0.0] — 2026-06-23
+
+The **public-surface-completion** major: four downstream consumers
+(CIRISEdge swarm/login, CIRISConformance §9 forensic suite, CIRISServer
+SCOPE_PRIVACY) were each reaching around the canonical persist surface —
+adapter traits, hand-rolled walks, raw-SQLite inspection, a verify-core
+layering inversion. This cut collapses all four onto persist's own
+interface. The one BREAKING change is the `FederationDirectory` trait
+gaining required methods (#270); everything else is additive.
+
+### Changed (BREAKING) — #270: fountain methods promoted to the public `FederationDirectory` trait
+
+`list_held_fountain_content`, `evict_fountain_content_to_tier`, and
+`evict_fountain_content_hard_delete` are now **required methods on the
+public `FederationDirectory` trait** (previously only on the concrete
+`Engine` / the `Backend` trait). CIRISEdge's `FountainSwarmRuntime` can
+now be constructed against `Arc<dyn FederationDirectory>` alone, dropping
+its `FountainHoldingsSource` / `FountainTierEvict` / `FountainEvictHardDelete`
+adapter traits (CIRISEdge#143), the same shape as `ReplicationRuntime`.
+
+- **BREAKING**: any external `impl FederationDirectory` must add the three
+  methods. All three in-tree backends (memory/sqlite/postgres) implement
+  them by delegating to the existing `Backend` methods
+  (`<Self as Backend>::…`, recursion-safe), bridging `store::Error` →
+  `federation::Error::Backend`. No feature gating needed (the fountain
+  module is unconditional).
+
+### Added — #271: `put_scope_blob` / `get_scope_blob` Python FFI
+
+PyO3 bindings for the v9.2.0 scope-blob surface so CIRISConformance's
+`test_410_scope_privacy_forensic.py` can verify cold-state opacity through
+the wheel (in addition to its raw-SQLite check), and CIRISServer#38 can
+publish/retrieve scope blobs from Python.
+
+- New `PyEngine.put_scope_blob(record_id: bytes, symbol_index: int, nonce: bytes, ciphertext: bytes, tag: bytes, group_dek_ref_json: str)` and `get_scope_blob(record_id, symbol_index) -> Optional[(nonce, ciphertext, tag)]`, plus thin `Engine` wrappers (dispatch via `BlobStorage`, cfg-gated). `group_dek_ref` is a **JSON string** (`{"community_key_id","epoch"}`), not a dict — matching every other structured-input FFI method (the crate has no `pythonize` dep). The 3-tuple intentionally omits `group_dek_epoch` (opaque-holder property).
+
+### Added — #272: `reachable_under_scope_with_reasons` (typed refusal verdict)
+
+The refusal-reason companion of `reachable_under_scope`. Same §11.10
+scope-bearing `delegates_to` walk, but returns a typed
+`ReachabilityVerdict` (`Reachable` | `RetractedAtRoot` | `MissingScope` |
+`SignerUnreached` | `SubstrateUnavailable` | `NoTrustRoots`) instead of
+collapsing every "no" into `false`. CIRISEdge's
+`verify_self_at_login_delegation` can now drop its hand-rolled
+scope-discriminating walk (the last graph-DX adoption gap, CIRISEdge#179)
+and route a distinct forensic audit entry per reason.
+
+- `admission::reachable_under_scope_with_reasons` (free fn, same arg shape as the bool walk) + `Engine::reachable_under_scope_with_reasons` + FFI returning a stable snake_case token. `ReachabilityVerdict` is `#[non_exhaustive]` and re-exported at `crate::federation`. The reachability decision is byte-identical to the bool walk — only the classification of the "no" is new. Substrate read failures classify as `SubstrateUnavailable` (not `Err`) so the consumer's `match` stays total — the one contract difference from the bool walk.
+- **Tested**: all five verdicts discriminated on a MemoryBackend fixture, with a parity assertion that `Reachable` ⟺ the bool walk's `true`.
+
+### Added — #273: `ceg_produce_canonicalize` exported through `prelude`
+
+The produce-side source-of-truth canonicalizer (`verify::canonical`) is
+now re-exported through `crate::verify` and `crate::prelude`, so downstream
+consumers (CIRISEdge v6.3.2 fixture-sig helpers, CIRISConformance's
+cross-impl `record_id` test) canonicalize signing payloads through the
+persist boundary instead of calling `ciris_verify_core::jcs` directly — the
+layering inversion is removed; persist stays the single owner of the
+produce-canon-version flip.
+
 ## [9.11.0] — 2026-06-23
 
 ### Changed — re-pin CIRISVerify v6.13.0 → v7.2.0 (verify MAJOR)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "9.11.0"
+version = "10.0.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3026,6 +3026,72 @@ impl Engine {
         }
     }
 
+    /// v9.1.0 (CC 1.13.3 / FSD §2.4, CIRISPersist#243) — Engine-facade for
+    /// [`BlobStorage::put_scope_blob`](crate::federation::BlobStorage::put_scope_blob):
+    /// admit one caller-pre-encrypted (XChaCha20-Poly1305) RaptorQ symbol
+    /// addressed by `(record_id, symbol_index)`. Persist never
+    /// encrypts/decrypts; it stores opaque ciphertext only. See the trait
+    /// method's doc for the first-write-wins idempotency contract and the
+    /// opaque-holder property.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn put_scope_blob(
+        &self,
+        record_id: [u8; 32],
+        symbol_index: u16,
+        nonce: [u8; 24],
+        ciphertext: Vec<u8>,
+        tag: [u8; 16],
+        group_dek_ref: crate::federation::GroupDekRef,
+    ) -> Result<(), crate::federation::BlobError> {
+        use crate::federation::BlobStorage;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(arc) => {
+                arc.put_scope_blob(
+                    record_id,
+                    symbol_index,
+                    nonce,
+                    ciphertext,
+                    tag,
+                    group_dek_ref,
+                )
+                .await
+            }
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(arc) => {
+                arc.put_scope_blob(
+                    record_id,
+                    symbol_index,
+                    nonce,
+                    ciphertext,
+                    tag,
+                    group_dek_ref,
+                )
+                .await
+            }
+        }
+    }
+
+    /// v9.1.0 (FSD §2.4, CIRISPersist#243) — Engine-facade for
+    /// [`BlobStorage::get_scope_blob`](crate::federation::BlobStorage::get_scope_blob):
+    /// read one scope-blob symbol back by `(record_id, symbol_index)`, or
+    /// `None` if absent. Bumps the row's `last_accessed_at` (the LRU
+    /// signal). Bytes round-trip exactly what `put_scope_blob` admitted.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn get_scope_blob(
+        &self,
+        record_id: [u8; 32],
+        symbol_index: u16,
+    ) -> Result<Option<crate::federation::ScopeBlobSymbol>, crate::federation::BlobError> {
+        use crate::federation::BlobStorage;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(arc) => arc.get_scope_blob(record_id, symbol_index).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(arc) => arc.get_scope_blob(record_id, symbol_index).await,
+        }
+    }
+
     /// v1.11.0 (CIRISPersist#90) — borrow a per-backend
     /// [`NodeCoreService`](crate::cirisnode::NodeCoreService) handle
     /// wrapping the Engine's underlying backend Arc.
@@ -3215,6 +3281,31 @@ impl Engine {
         max_depth: usize,
     ) -> Result<bool, crate::federation::Error> {
         crate::federation::admission::reachable_under_scope(
+            self.federation_directory().as_ref(),
+            issuer_key_id,
+            target_key_id,
+            scope,
+            max_depth,
+        )
+        .await
+    }
+
+    /// v10.0.0 (CIRISPersist#272) — the refusal-reason companion of
+    /// [`reachable_under_scope`](Self::reachable_under_scope): the same
+    /// scope-bearing `delegates_to` walk, returning a typed
+    /// [`ReachabilityVerdict`](crate::federation::ReachabilityVerdict) so
+    /// callers route a distinct forensic audit-trail entry per refusal
+    /// reason. See
+    /// [`admission::reachable_under_scope_with_reasons`](crate::federation::admission::reachable_under_scope_with_reasons).
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn reachable_under_scope_with_reasons(
+        &self,
+        issuer_key_id: &str,
+        target_key_id: &str,
+        scope: &str,
+        max_depth: usize,
+    ) -> Result<crate::federation::ReachabilityVerdict, crate::federation::Error> {
+        crate::federation::admission::reachable_under_scope_with_reasons(
             self.federation_directory().as_ref(),
             issuer_key_id,
             target_key_id,

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -1501,6 +1501,204 @@ pub async fn reachable_under_scope(
     .await
 }
 
+/// v10.0.0 (CIRISPersist#272) — the typed verdict returned by
+/// [`reachable_under_scope_with_reasons`]. Where
+/// [`reachable_under_scope`] collapses every "no" into `false`, this
+/// discriminates WHY, so a consumer (CIRISEdge's
+/// `verify_self_at_login_delegation`) can route a distinct forensic
+/// audit-trail entry per refusal reason instead of hand-rolling its own
+/// scope-discriminating walk.
+///
+/// `#[non_exhaustive]` — future walk refinements may add reasons (or
+/// attach payloads to the existing ones) without a further major bump.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReachabilityVerdict {
+    /// A `delegates_to` chain from the issuer reaches the target where
+    /// every edge carries `scope` (§11.10 attenuation/deputization
+    /// satisfied) and no edge on the path is withdrawn/recanted.
+    Reachable,
+    /// A scope-bearing `delegates_to` edge to the target exists, but its
+    /// granter has `withdraws`/`recants`-retracted it (UCAN-style edge
+    /// retraction). Named for the depth-1 login case where the issuer
+    /// (root) retracts its own edge to the target.
+    RetractedAtRoot,
+    /// A `delegates_to` edge to the target exists but does NOT grant the
+    /// required `scope`.
+    MissingScope,
+    /// The issuer emitted delegation edges, but none — after the scope,
+    /// retraction, ⊆-attenuation, deputization, and depth gates — reach
+    /// the target. The target was never established as a scoped delegate.
+    SignerUnreached,
+    /// A substrate read failed mid-walk. Unlike [`reachable_under_scope`]
+    /// (which propagates substrate failures as `Err`), the with-reasons
+    /// walk classifies them so the consumer's `match` over the verdict
+    /// stays total and can emit an "unavailable" audit entry. This is the
+    /// one contract difference between the two walks.
+    SubstrateUnavailable,
+    /// The issuer emitted no `delegates_to` edges at all — there is no
+    /// trust root to seed the walk from.
+    NoTrustRoots,
+}
+
+/// v10.0.0 (CIRISPersist#272) — the **refusal-reason** companion of
+/// [`reachable_under_scope`]. Runs the identical §11.10
+/// [`MODERATION_DUTY`] scope-bearing `delegates_to` walk (⊆-parent
+/// attenuation + `sub_delegation`-gated deputization past depth 1 +
+/// per-edge `withdraws`/`recants` skipping + depth cap), but returns a
+/// typed [`ReachabilityVerdict`] instead of `bool`.
+///
+/// # Refusal precedence (when not [`Reachable`](ReachabilityVerdict::Reachable))
+///
+/// The walk records, across every edge-to-target it encounters, whether
+/// that edge was *scope-bearing-but-retracted* or *present-but-unscoped*,
+/// plus whether the issuer emitted any delegation at all. On a "no" it
+/// returns the most specific signal, in order:
+///
+/// 1. [`RetractedAtRoot`](ReachabilityVerdict::RetractedAtRoot) — a
+///    scope-bearing edge to the target was explicitly retracted.
+/// 2. [`MissingScope`](ReachabilityVerdict::MissingScope) — an edge to
+///    the target exists but does not carry `scope`.
+/// 3. [`NoTrustRoots`](ReachabilityVerdict::NoTrustRoots) — the issuer
+///    emitted no delegation edges whatsoever.
+/// 4. [`SignerUnreached`](ReachabilityVerdict::SignerUnreached) — edges
+///    exist but no scoped path reaches the target.
+///
+/// A substrate read failure short-circuits to
+/// [`SubstrateUnavailable`](ReachabilityVerdict::SubstrateUnavailable).
+///
+/// The reachability decision is byte-identical to
+/// [`reachable_under_scope`]: this returns
+/// [`Reachable`](ReachabilityVerdict::Reachable) in exactly the cases the
+/// `bool` form returns `true`. Only the classification of the "no" is new.
+///
+/// [`MODERATION_DUTY`]: DelegationWalkPolicy::MODERATION_DUTY
+pub async fn reachable_under_scope_with_reasons(
+    directory: &dyn super::FederationDirectory,
+    issuer_key_id: &str,
+    target_key_id: &str,
+    scope: &str,
+    max_depth: usize,
+) -> Result<ReachabilityVerdict, Error> {
+    use std::collections::{HashSet, VecDeque};
+    let policy = DelegationWalkPolicy::MODERATION_DUTY;
+    let effective_depth = max_depth.min(MAX_WITHDRAWS_DELEGATION_DEPTH);
+    if effective_depth == 0 {
+        return Ok(ReachabilityVerdict::SignerUnreached);
+    }
+    // Same per-node walk state as the predicate walk; see
+    // `issuer_reaches_target_via_scoped_delegation`.
+    struct Node {
+        key: String,
+        depth: usize,
+        parent_scope: Option<HashSet<String>>,
+        parent_sub_delegation: bool,
+    }
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<Node> = VecDeque::new();
+    queue.push_back(Node {
+        key: issuer_key_id.to_owned(),
+        depth: 0,
+        parent_scope: None,
+        parent_sub_delegation: false,
+    });
+    visited.insert(issuer_key_id.to_owned());
+
+    // Observations that classify a "no" — see the precedence in the
+    // doc comment. None of these influence the reachability decision
+    // itself (that stays identical to the predicate walk).
+    let mut issuer_emitted_delegation = false;
+    let mut saw_target_edge_retracted = false;
+    let mut saw_target_edge_missing_scope = false;
+
+    while let Some(node) = queue.pop_front() {
+        if node.depth >= effective_depth {
+            continue;
+        }
+        if policy.enforce_attenuation_and_sub_delegation
+            && node.parent_scope.is_some()
+            && !node.parent_sub_delegation
+        {
+            continue;
+        }
+        let rows = match directory.list_attestations_by(&node.key).await {
+            Ok(rows) => rows,
+            Err(_) => return Ok(ReachabilityVerdict::SubstrateUnavailable),
+        };
+        let mut retracted: HashSet<String> = HashSet::new();
+        if policy.skip_withdrawn_edges {
+            for r in &rows {
+                if r.attestation_type == attestation_type::WITHDRAWS
+                    || r.attestation_type == attestation_type::RECANTS
+                {
+                    retracted.insert(r.attested_key_id.clone());
+                }
+            }
+        }
+        let is_issuer = node.depth == 0;
+        for r in rows {
+            if r.attestation_type != attestation_type::DELEGATES_TO {
+                continue;
+            }
+            if is_issuer {
+                issuer_emitted_delegation = true;
+            }
+            let to_target = r.attested_key_id == target_key_id;
+            // Scope gate (checked first, mirroring the predicate walk).
+            if !delegation_scope_grants(&r.attestation_envelope, scope) {
+                if to_target {
+                    saw_target_edge_missing_scope = true;
+                }
+                continue;
+            }
+            // Retraction gate.
+            if policy.skip_withdrawn_edges && retracted.contains(&r.attested_key_id) {
+                if to_target {
+                    saw_target_edge_retracted = true;
+                }
+                continue;
+            }
+            // ⊆-parent attenuation gate. A pruned edge here is neither a
+            // clean missing-scope nor a retraction — the duty just cannot
+            // validly flow down this path; it contributes only to a
+            // SignerUnreached "no".
+            if policy.enforce_attenuation_and_sub_delegation {
+                if let Some(parent_scope) = &node.parent_scope {
+                    let child_scope = delegation_scope_set(&r.attestation_envelope);
+                    if !child_scope.is_subset(parent_scope) {
+                        continue;
+                    }
+                }
+            }
+            if to_target {
+                return Ok(ReachabilityVerdict::Reachable);
+            }
+            if !visited.contains(&r.attested_key_id) && node.depth + 1 < effective_depth {
+                visited.insert(r.attested_key_id.clone());
+                queue.push_back(Node {
+                    key: r.attested_key_id,
+                    depth: node.depth + 1,
+                    parent_scope: Some(delegation_scope_set(&r.attestation_envelope)),
+                    parent_sub_delegation: delegation_grants_sub_delegation(
+                        &r.attestation_envelope,
+                    ),
+                });
+            }
+        }
+    }
+
+    if saw_target_edge_retracted {
+        return Ok(ReachabilityVerdict::RetractedAtRoot);
+    }
+    if saw_target_edge_missing_scope {
+        return Ok(ReachabilityVerdict::MissingScope);
+    }
+    if !issuer_emitted_delegation {
+        return Ok(ReachabilityVerdict::NoTrustRoots);
+    }
+    Ok(ReachabilityVerdict::SignerUnreached)
+}
+
 /// #249 Cut B — the **enumeration** companion of
 /// [`issuer_reaches_target_via_scoped_delegation`]. Where the predicate
 /// answers "does `issuer` reach SOME target?", this collects EVERY key

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -125,7 +125,7 @@ pub(crate) mod serde_bytes_b64 {
 pub use admission::{
     check_cohort_scope, check_consensus_protocol_form, check_device_class,
     check_encryption_pubkeys, check_observed_region, AttestationLadderTransitionPolicy,
-    DimensionAdmissionPolicy, DimensionRejectionReason, ReservedPrefixRule,
+    DimensionAdmissionPolicy, DimensionRejectionReason, ReachabilityVerdict, ReservedPrefixRule,
     ATTESTATION_LADDER_MECHANISMS,
 };
 pub use blackhole::{BlackholeRecord, BlackholeRules, RETICULUM_IDENTITY_HASH_LEN};
@@ -2774,6 +2774,58 @@ pub trait FederationDirectory: Send + Sync {
         }
         Ok(report)
     }
+
+    // ─── v10.0.0 — fountain holdings/eviction surface (CIRISPersist#270) ──
+    //
+    // Promoted from the concrete `Backend` trait onto the PUBLIC
+    // `FederationDirectory` so downstream consumers holding
+    // `Arc<dyn FederationDirectory>` (CIRISEdge#143 swarm runtime) can call
+    // the fountain store-and-evict half directly — collapsing the
+    // `FountainHoldingsSource` / `FountainTierEvict` / `FountainEvictHardDelete`
+    // adapter traits onto this one surface. Each mirrors the identically
+    // named [`crate::store::Backend`] method 1:1.
+
+    /// v10.0.0 (CIRISPersist#270) — list the fountain-coded content a
+    /// **publisher** holds, as [`FountainHeldMeta`](crate::fountain::FountainHeldMeta)
+    /// (manifest essentials + the current degradation state: `held_symbols`
+    /// vs `min_viable_symbols` ⇒ `recoverable`). Filtered to the manifest
+    /// signer (`content_manifest.pqc_key_id = publisher_key_id`); no symbol
+    /// bytes are read. Ordered by `admitted_at` descending. Empty when the
+    /// publisher holds nothing.
+    ///
+    /// Mirrors [`crate::store::Backend::list_held_fountain_content`].
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, Error>;
+
+    /// v10.0.0 (CIRISPersist#270) — evict a content unit's symbols down to
+    /// the per-tier keep-count, dropping by `retention_priority DESC` within
+    /// the `content_id`. The manifest is NEVER touched. Returns the number
+    /// of symbol rows evicted. No-op (`Ok(0)`) when the content_id is unknown
+    /// or already at/below the keep-count.
+    ///
+    /// Mirrors [`crate::store::Backend::evict_fountain_content_to_tier`].
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: crate::fountain::FountainTier,
+    ) -> Result<u64, Error>;
+
+    /// v10.0.0 (CIRISPersist#270) — **HardDelete** every symbol row for
+    /// `(content_id, corpus_kind)` unconditionally (the §8.1.11.3
+    /// deletion-SLA / revocation-dominates-rarity path), leaving the manifest
+    /// as the always-retained `EnvelopeOnly` provenance. Never consults
+    /// `retention_priority`. Returns the number of symbol rows dropped.
+    /// Unknown content ⇒ `Ok(0)` no-op.
+    ///
+    /// Mirrors [`crate::store::Backend::evict_fountain_content_hard_delete`].
+    async fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<u64, Error>;
 }
 
 /// Federation directory errors. Distinct from

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -6869,6 +6869,151 @@ impl PyEngine {
         })
     }
 
+    /// v9.1.0 (CC 1.13.3 / FSD §2.4, CIRISPersist#243; FFI #271) — admit
+    /// one caller-pre-encrypted (XChaCha20-Poly1305) RaptorQ symbol into
+    /// the scope-blob store, addressed by `(record_id, symbol_index)`.
+    ///
+    /// Persist NEVER encrypts/decrypts; it stores the opaque seal
+    /// components verbatim. Mirrors
+    /// [`BlobStorage::put_scope_blob`](crate::federation::BlobStorage::put_scope_blob)
+    /// — see that method for the first-write-wins idempotency contract
+    /// (re-put of an existing `(record_id, symbol_index)` is a no-op) and
+    /// the opaque-holder property (only the DEK *epoch* is persisted).
+    ///
+    /// Parameters (all byte params are `bytes`):
+    /// - `record_id` — the FSD §2.4 HMAC-SHA3-256 output (32 bytes).
+    /// - `symbol_index` — `0..N` symbol index within the record.
+    /// - `nonce` — XChaCha20-Poly1305 nonce (24 bytes).
+    /// - `ciphertext` — the pre-encrypted symbol bytes (opaque).
+    /// - `tag` — Poly1305 tag (16 bytes).
+    /// - `group_dek_ref_json` — JSON object
+    ///   `{"community_key_id": str, "epoch": int}` tying the symbol to the
+    ///   community DEK epoch it was sealed under (a
+    ///   [`GroupDekRef`](crate::federation::GroupDekRef)).
+    #[allow(clippy::too_many_arguments)]
+    fn put_scope_blob(
+        &self,
+        py: Python<'_>,
+        record_id: &Bound<'_, PyBytes>,
+        symbol_index: u16,
+        nonce: &Bound<'_, PyBytes>,
+        ciphertext: &Bound<'_, PyBytes>,
+        tag: &Bound<'_, PyBytes>,
+        group_dek_ref_json: &str,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let record_id = parse_fixed_bytes::<32>(record_id, "record_id")?;
+            let nonce = parse_fixed_bytes::<24>(nonce, "nonce")?;
+            let tag = parse_fixed_bytes::<16>(tag, "tag")?;
+            let ciphertext = ciphertext.as_bytes().to_vec();
+            let group_dek_ref: crate::federation::GroupDekRef =
+                serde_json::from_str(group_dek_ref_json).map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "group_dek_ref must be JSON {{\"community_key_id\": str, \
+                         \"epoch\": int}}: {e}"
+                    ))
+                })?;
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_scope_blob(
+                                record_id,
+                                symbol_index,
+                                nonce,
+                                ciphertext,
+                                tag,
+                                group_dek_ref,
+                            )
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .put_scope_blob(
+                                record_id,
+                                symbol_index,
+                                nonce,
+                                ciphertext,
+                                tag,
+                                group_dek_ref,
+                            )
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
+    /// v9.1.0 (FSD §2.4, CIRISPersist#243; FFI #271) — read one scope-blob
+    /// symbol back by `(record_id, symbol_index)`. Returns `None` if
+    /// absent; otherwise a `(nonce, ciphertext, tag)` tuple of `bytes`.
+    ///
+    /// Bumps the row's `last_accessed_at` (the LRU signal the capacity
+    /// sweeper consumes). The bytes round-trip exactly what
+    /// [`put_scope_blob`](Self::put_scope_blob) admitted — persist never
+    /// decrypts. Mirrors
+    /// [`BlobStorage::get_scope_blob`](crate::federation::BlobStorage::get_scope_blob).
+    fn get_scope_blob<'py>(
+        &self,
+        py: Python<'py>,
+        record_id: &Bound<'py, PyBytes>,
+        symbol_index: u16,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let record_id = parse_fixed_bytes::<32>(record_id, "record_id")?;
+            let sym_opt = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .get_scope_blob(record_id, symbol_index)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::BlobStorage;
+                        backend
+                            .get_scope_blob(record_id, symbol_index)
+                            .await
+                            .map_err(blob_err_to_py)
+                    })
+                }
+            })?;
+            match sym_opt {
+                None => Ok(None),
+                Some(sym) => {
+                    let tuple = pyo3::types::PyTuple::new(
+                        py,
+                        [
+                            PyBytes::new(py, &sym.nonce).into_any(),
+                            PyBytes::new(py, &sym.ciphertext).into_any(),
+                            PyBytes::new(py, &sym.tag).into_any(),
+                        ],
+                    )?;
+                    Ok(Some(tuple.into_any().unbind()))
+                }
+            }
+        })
+    }
+
     /// Federation blob storage: existence check by SHA-256 (hex).
     fn has_blob_json(&self, py: Python<'_>, sha256_hex: &str) -> PyResult<bool> {
         self.ensure_usable()?;
@@ -16095,6 +16240,74 @@ impl PyEngine {
         })
     }
 
+    /// v10.0.0 (CIRISPersist#272) — the refusal-reason companion of
+    /// [`reachable_under_scope`](Self::reachable_under_scope). Same
+    /// scope-bearing `delegates_to` walk, but returns a stable
+    /// snake_case verdict token instead of a bool so a Python consumer
+    /// can route a distinct audit entry per refusal reason. Tokens:
+    /// `"reachable"`, `"retracted_at_root"`, `"missing_scope"`,
+    /// `"signer_unreached"`, `"substrate_unavailable"`, `"no_trust_roots"`.
+    fn reachable_under_scope_with_reasons(
+        &self,
+        py: Python<'_>,
+        issuer_key_id: &str,
+        target_key_id: &str,
+        scope: &str,
+        max_depth: usize,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let issuer_key_id = issuer_key_id.to_owned();
+            let target_key_id = target_key_id.to_owned();
+            let scope = scope.to_owned();
+            let verdict = py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        crate::federation::admission::reachable_under_scope_with_reasons(
+                            &*backend,
+                            &issuer_key_id,
+                            &target_key_id,
+                            &scope,
+                            max_depth,
+                        )
+                        .await
+                        .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        crate::federation::admission::reachable_under_scope_with_reasons(
+                            &*backend,
+                            &issuer_key_id,
+                            &target_key_id,
+                            &scope,
+                            max_depth,
+                        )
+                        .await
+                        .map_err(federation_err_to_py)
+                    })
+                }
+            })?;
+            // Same-crate match on the `#[non_exhaustive]` enum is exhaustive
+            // (the attribute only forces a wildcard in downstream crates).
+            let token = match verdict {
+                crate::federation::ReachabilityVerdict::Reachable => "reachable",
+                crate::federation::ReachabilityVerdict::RetractedAtRoot => "retracted_at_root",
+                crate::federation::ReachabilityVerdict::MissingScope => "missing_scope",
+                crate::federation::ReachabilityVerdict::SignerUnreached => "signer_unreached",
+                crate::federation::ReachabilityVerdict::SubstrateUnavailable => {
+                    "substrate_unavailable"
+                }
+                crate::federation::ReachabilityVerdict::NoTrustRoots => "no_trust_roots",
+            };
+            Ok(token.to_owned())
+        })
+    }
+
     /// #249 Cut B — the inbound `delegates_to` edges naming `key_id` as
     /// recipient ("who delegated TO me?" — the reverse of
     /// `delegates_to_graph`). Returns a JSON array of
@@ -22917,6 +23130,23 @@ fn parse_sha256_hex(hex_str: &str) -> PyResult<[u8; 32]> {
     }
     let mut out = [0u8; 32];
     out.copy_from_slice(&v);
+    Ok(out)
+}
+
+/// v9.1.0 (CIRISPersist#271) — extract a Python `bytes` of an exact
+/// fixed length into `[u8; N]`, raising a typed `ValueError` on a
+/// length mismatch. Used by the scope-blob FFI (`record_id` = 32,
+/// `nonce` = 24, `tag` = 16).
+fn parse_fixed_bytes<const N: usize>(b: &Bound<'_, PyBytes>, field: &str) -> PyResult<[u8; N]> {
+    let v = b.as_bytes();
+    if v.len() != N {
+        return Err(PyValueError::new_err(format!(
+            "{field} must be exactly {N} bytes, got {}",
+            v.len()
+        )));
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(v);
     Ok(out)
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -101,10 +101,10 @@ pub use crate::signing::{LocalSigner, LocalSignerConfig, LocalSignerError};
 // Verify primitives. The full surface edge needs to compose a
 // verify pipeline against persist instead of rebuilding it.
 pub use crate::verify::{
-    body_sha256, canonical_payload_value, canonicalize_envelope_for_signing, verify_hybrid,
-    verify_hybrid_via_directory, verify_trace, verify_trace_via_directory, Canonicalizer,
-    HybridPolicy, HybridVerifyError, PublicKeyDirectory, PythonJsonDumpsCanonicalizer,
-    VerifyOutcome,
+    body_sha256, canonical_payload_value, canonicalize_envelope_for_signing,
+    ceg_produce_canonicalize, verify_hybrid, verify_hybrid_via_directory, verify_trace,
+    verify_trace_via_directory, Canonicalizer, HybridPolicy, HybridVerifyError, PublicKeyDirectory,
+    PythonJsonDumpsCanonicalizer, VerifyOutcome,
 };
 
 // Outbound queue types — federation peers building dispatcher

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -3209,6 +3209,51 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .filter(|r| r.removed_at.is_none())
             .cloned())
     }
+
+    // ─── v10.0.0 — fountain holdings/eviction surface (CIRISPersist#270) ──
+    // Delegate to the inherent `Backend` methods of the SAME NAME via
+    // fully-qualified syntax (a bare `self.<name>` would re-dispatch to
+    // this trait method ⇒ infinite recursion), then map `store::Error`
+    // onto `federation::Error::Backend`.
+
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, crate::federation::Error> {
+        <Self as crate::store::Backend>::list_held_fountain_content(self, publisher_key_id)
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: crate::fountain::FountainTier,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_to_tier(
+            self,
+            content_id,
+            corpus_kind,
+            tier,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_hard_delete(
+            self,
+            content_id,
+            corpus_kind,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
 }
 
 // ─── BlackholeRules impl (v3.2.0, CIRISPersist#120) ────────────────
@@ -8450,6 +8495,106 @@ mod tests {
         )
         .await
         .unwrap());
+    }
+
+    /// reachable_under_scope_with_reasons (#272): the refusal-reason
+    /// companion classifies each "no" — Reachable / MissingScope /
+    /// RetractedAtRoot / SignerUnreached / NoTrustRoots — and stays
+    /// byte-identical to the bool walk on the Reachable case. Distinct
+    /// key pairs isolate the scenarios in one backend.
+    #[tokio::test]
+    async fn reachable_under_scope_with_reasons_classifies_refusals() {
+        use crate::federation::admission::{
+            reachable_under_scope, reachable_under_scope_with_reasons, ReachabilityVerdict,
+            DELEGATION_SCOPE_MODERATE, DELEGATION_SCOPE_REVIEW, MAX_MODERATION_DELEGATION_DEPTH,
+        };
+        let backend = MemoryBackend::new();
+        for k in [
+            "ar-root", "ar-tgt", "br-root", "br-tgt", "cr-root", "cr-mid", "cr-tgt", "dr-iso",
+            "dr-tgt",
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fix_key(k, "primitive", k),
+                })
+                .await
+                .unwrap();
+        }
+        // A scope-bearing (`moderate`) delegation edge.
+        let delegate = |id: &str, granter: &str, grantee: &str| {
+            let mut d = fix_attestation(id, granter, grantee, granter);
+            d.attestation_type = crate::federation::types::attestation_type::DELEGATES_TO.into();
+            d.attestation_envelope = serde_json::json!({
+                "references_attestation_id": id,
+                "scope": [DELEGATION_SCOPE_MODERATE],
+                "sub_delegation": true,
+            });
+            resign_fix(&mut d);
+            d
+        };
+        // A `withdraws` keyed on the recipient (the scoped walk's edge-
+        // retraction model — `attested_key_id == recipient`).
+        let withdraw_edge = |id: &str, granter: &str, recipient: &str| {
+            let mut w = fix_attestation(id, granter, recipient, granter);
+            w.attestation_type = crate::federation::types::attestation_type::WITHDRAWS.into();
+            resign_fix(&mut w);
+            w
+        };
+        for a in [
+            delegate("ar-d", "ar-root", "ar-tgt"), // Reachable / MissingScope pair
+            delegate("br-d", "br-root", "br-tgt"), // RetractedAtRoot pair
+            withdraw_edge("br-w", "br-root", "br-tgt"), // … retracted
+            delegate("cr-d", "cr-root", "cr-mid"), // SignerUnreached: edge, but not to tgt
+        ] {
+            backend
+                .put_attestation(SignedAttestation { attestation: a })
+                .await
+                .unwrap();
+        }
+        let depth = MAX_MODERATION_DELEGATION_DEPTH;
+        let verdict = |issuer: &'static str, tgt: &'static str, scope: &'static str| {
+            let b = &backend;
+            async move {
+                reachable_under_scope_with_reasons(b, issuer, tgt, scope, depth)
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Reachable — and consistent with the bool walk.
+        assert_eq!(
+            verdict("ar-root", "ar-tgt", DELEGATION_SCOPE_MODERATE).await,
+            ReachabilityVerdict::Reachable
+        );
+        assert!(reachable_under_scope(
+            &backend,
+            "ar-root",
+            "ar-tgt",
+            DELEGATION_SCOPE_MODERATE,
+            depth
+        )
+        .await
+        .unwrap());
+        // MissingScope — edge to target exists but does not carry `review`.
+        assert_eq!(
+            verdict("ar-root", "ar-tgt", DELEGATION_SCOPE_REVIEW).await,
+            ReachabilityVerdict::MissingScope
+        );
+        // RetractedAtRoot — scope-bearing edge to target, but withdrawn.
+        assert_eq!(
+            verdict("br-root", "br-tgt", DELEGATION_SCOPE_MODERATE).await,
+            ReachabilityVerdict::RetractedAtRoot
+        );
+        // SignerUnreached — issuer delegates, but no path reaches the target.
+        assert_eq!(
+            verdict("cr-root", "cr-tgt", DELEGATION_SCOPE_MODERATE).await,
+            ReachabilityVerdict::SignerUnreached
+        );
+        // NoTrustRoots — issuer emitted no delegation edges at all.
+        assert_eq!(
+            verdict("dr-iso", "dr-tgt", DELEGATION_SCOPE_MODERATE).await,
+            ReachabilityVerdict::NoTrustRoots
+        );
     }
 
     /// delegations_to: K with 2 inbound `delegates_to` → returns both;

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -5854,6 +5854,51 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         meta.persist_row_hash = persist_row_hash;
         Ok(Some(meta))
     }
+
+    // ─── v10.0.0 — fountain holdings/eviction surface (CIRISPersist#270) ──
+    // Delegate to the inherent `Backend` methods of the SAME NAME via
+    // fully-qualified syntax (a bare `self.<name>` would re-dispatch to
+    // this trait method ⇒ infinite recursion), then map `store::Error`
+    // onto `federation::Error::Backend`.
+
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, crate::federation::Error> {
+        <Self as crate::store::Backend>::list_held_fountain_content(self, publisher_key_id)
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: crate::fountain::FountainTier,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_to_tier(
+            self,
+            content_id,
+            corpus_kind,
+            tier,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_hard_delete(
+            self,
+            content_id,
+            corpus_kind,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
 }
 
 // ─── Peer-metadata update helpers (v3.1.0, CIRISPersist#117) ───────

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -5465,6 +5465,51 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             Ok(Some(meta))
         })()
     }
+
+    // ─── v10.0.0 — fountain holdings/eviction surface (CIRISPersist#270) ──
+    // Delegate to the inherent `Backend` methods of the SAME NAME via
+    // fully-qualified syntax (a bare `self.<name>` would re-dispatch to
+    // this trait method ⇒ infinite recursion), then map `store::Error`
+    // onto `federation::Error::Backend`.
+
+    async fn list_held_fountain_content(
+        &self,
+        publisher_key_id: &str,
+    ) -> Result<Vec<crate::fountain::FountainHeldMeta>, crate::federation::Error> {
+        <Self as crate::store::Backend>::list_held_fountain_content(self, publisher_key_id)
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: crate::fountain::FountainTier,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_to_tier(
+            self,
+            content_id,
+            corpus_kind,
+            tier,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
+
+    async fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<u64, crate::federation::Error> {
+        <Self as crate::store::Backend>::evict_fountain_content_hard_delete(
+            self,
+            content_id,
+            corpus_kind,
+        )
+        .await
+        .map_err(|e| crate::federation::Error::Backend(e.to_string()))
+    }
 }
 
 // ─── Peer-metadata update helpers (v3.1.0, CIRISPersist#117) ───────

--- a/src/verify/mod.rs
+++ b/src/verify/mod.rs
@@ -16,7 +16,8 @@ pub mod ed25519;
 pub mod hybrid;
 
 pub use canonical::{
-    body_sha256, canonicalize_envelope_for_signing, Canonicalizer, PythonJsonDumpsCanonicalizer,
+    body_sha256, canonicalize_envelope_for_signing, ceg_produce_canonicalize, Canonicalizer,
+    PythonJsonDumpsCanonicalizer,
 };
 pub use canonical_validation::{
     validate_canonical_datetime, validate_canonical_hex, validate_envelope_canonical_form,


### PR DESCRIPTION
## Summary

The **public-surface-completion major**. Four downstream consumers were each reaching *around* the canonical persist interface — CIRISEdge's swarm runtime via adapter traits, its login path via a hand-rolled walk, CIRISConformance via raw-SQLite inspection, and edge's fixture-sigs via a `ciris_verify_core::jcs` layering inversion. This cut collapses all four onto persist's own surface. One BREAKING change (#270); the rest additive.

## #270 (BREAKING) — fountain methods → public `FederationDirectory` trait
`list_held_fountain_content` / `evict_fountain_content_to_tier` / `evict_fountain_content_hard_delete` are now **required methods** on `FederationDirectory` (were only on concrete `Engine` / the `Backend` trait). Lets CIRISEdge's `FountainSwarmRuntime` construct against `Arc<dyn FederationDirectory>` alone and drop its `FountainHoldingsSource`/`FountainTierEvict`/`FountainEvictHardDelete` adapter traits (CIRISEdge#143).
- **BREAKING**: external `impl FederationDirectory` must add the three. In-tree backends delegate to the `Backend` methods (`<Self as Backend>::…`, recursion-safe; `store::Error → federation::Error::Backend`). No feature gating needed.

## #271 — `put_scope_blob` / `get_scope_blob` Python FFI
PyO3 bindings for the v9.2.0 scope-blob surface (+ thin `Engine` wrappers via `BlobStorage`). Closes CIRISConformance's raw-SQLite reach-through (`test_410_scope_privacy_forensic.py`) and unblocks CIRISServer#38. `group_dek_ref` is a **JSON string** (`{community_key_id, epoch}`) per codebase convention (no `pythonize` dep); read returns `(nonce, ciphertext, tag)`.

## #272 — `reachable_under_scope_with_reasons` + `ReachabilityVerdict`
The refusal-reason companion of `reachable_under_scope`. Same §11.10 scope-bearing `delegates_to` walk, returns a typed verdict (`Reachable` | `RetractedAtRoot` | `MissingScope` | `SignerUnreached` | `SubstrateUnavailable` | `NoTrustRoots`) instead of `bool`. CIRISEdge's `verify_self_at_login_delegation` drops its hand-rolled scope-discriminating walk (the last graph-DX adoption gap, CIRISEdge#179).
- `Reachable` ⟺ the bool walk's `true` (byte-identical reachability decision). Substrate read failures classify as `SubstrateUnavailable` (not `Err`) so the consumer's `match` stays total — the one contract difference. `#[non_exhaustive]`.
- **Tested**: all five verdicts discriminated on a MemoryBackend fixture + bool-walk parity assertion.

## #273 — `ceg_produce_canonicalize` exported through `prelude`
Re-exported through `crate::verify` + `crate::prelude` so edge's fixture-sig helpers / CIRISConformance's `record_id` test canonicalize through the persist boundary, removing the verify-core layering inversion.

## Test
- **1584 passed / 0 failed** (`cargo nextest run --all-targets --test-threads=1`, plain postgres:16)
- clippy `-D warnings` across the CI feature set + 3 no-default-features combos; fmt clean
- Verify family stays pinned at v7.2.0

## Implementation note
#270 + #271 were implemented in parallel by isolated-worktree subagents (fountain-trait + scope-blob-FFI); #272 + #273 in the main pass. Integrated as patches into disjoint/adjacent regions, then gated as a whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)