### PR TITLE
v10.0.1 — #275: register_self_federation_key registers the composed-signer derived identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.0.1] — 2026-06-24
+
+### Fixed — #275: `register_self_federation_key` registered the wrong identity → `put_blob_signing` FK-failed on every persist ≥ 9.3.0
+
+The canonical "register my self key, then store a blob I hold" flow
+(`register_self_federation_key` → `put_blob_signing`) raised
+`ValueError: blob_attestation_emission_failed` on every persist **≥ 9.3.0**
+(through 10.0.0); it worked on ≤ 9.2.2. Found by the CIRISConformance
+cross-wheel harness bumping its matrix to the 9.11/10.0 floor.
+
+Root cause: the #247 floor (v9.3.0) made every federation-tier emit's
+`scrub_key_id` the **derived** wire key_id (`derive_key_id(<alias>, <ed25519
+pubkey>)` = `<label>-<fp>`), and `put_blob_signing`'s holds_bytes scrub FKs
+to it. But `register_self_federation_key` registered the **`LocalSigner`
+seed's** identity (and historically the bare keystore alias) — a *different*
+key from the engine's composed `self.signer`, the one every emit/scrub path
+actually derives its key_id from. On a real node (composed signer ≠ local
+seed ⇒ different Ed25519 pubkeys ⇒ different derived ids) the registered row
+and the scrub FK target diverged, so the holds_bytes insert FK-failed. Pre-
+9.3.0 both paths used the bare alias, which matched — the #247 floor exposed
+the latent two-identity split.
+
+- **`Engine::register_self_federation_key`** (new crate-level method) now
+  registers the engine's **composed-signer** federation identity: keyed by
+  the derived id ([`Engine::local_derived_key_id`]), carrying `self.signer`'s
+  Ed25519 pubkey + a classical self-signature, and **returns the derived id**
+  so the caller threads it back as `attesting_key_id`. The PyO3
+  `register_self_federation_key` delegates to it (the `attestation_promote` /
+  `emit_attestation` cohabitation pattern). Same fix covers the eviction
+  `withdraws` emission path (Ask #2) — it derives from the same signer, so the
+  now-registered derived row resolves its FK too.
+- **Error surfacing** (Ask #3): `blob_err_to_py` now appends the inner detail
+  to `AttestationEmissionFailed` (e.g. `blob_attestation_emission_failed: FK
+  violation on holds_bytes attestation: FOREIGN KEY constraint failed`),
+  keeping the stable kind token as a prefix — previously the underlying cause
+  was swallowed to a bare token.
+- **Tested**: a Rust regression (`register_self_federation_key` →
+  `put_blob_signing` resolves the scrub FK; returned id is the derived id, not
+  the alias) and the exact issue repro as a Python wheel test
+  (`tests/python/test_sqlite_engine.py`, runs in CI).
+
+**Behavior change**: `register_self_federation_key` now returns the derived
+federation key_id (`<label>-<fp>`), not the bare alias — this is the value
+that FKs across the federation surface, and the value callers must use as
+`attesting_key_id`. Verify family unchanged (v7.2.0).
+
 ## [10.0.0] — 2026-06-23
 
 The **public-surface-completion** major: four downstream consumers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1602,6 +1602,121 @@ impl Engine {
         ))
     }
 
+    /// v10.0.1 (CIRISPersist#275) — register THIS engine's **own
+    /// federation identity** — the composed `self.signer`, the key every
+    /// emit/scrub path derives its key_id from — as a self-signed
+    /// `federation_keys` row of `identity_type`.
+    ///
+    /// The row is keyed by the **derived** federation key_id
+    /// ([`Self::local_derived_key_id`] = `derive_key_id(<alias>, <ed25519
+    /// pubkey>)` = `<label>-<fp>`), carries `self.signer`'s Ed25519 pubkey,
+    /// and a classical self-signature over the canonical
+    /// `registration_envelope`. This is the row the holds_bytes / withdraws
+    /// / emit `scrub_key_id` FK resolves against (the #247 floor).
+    ///
+    /// # Why `self.signer`, not a `LocalSigner`
+    ///
+    /// Pre-#275 the FFI bootstrap registered the **`LocalSigner`** seed's
+    /// identity (and historically the bare keystore alias). But every
+    /// federation-tier emit — [`Self::put_blob_signing`]'s holds_bytes
+    /// scrub, [`Self::emit_attestation_self`], [`Self::attestation_promote`],
+    /// the eviction `withdraws` — derives its key_id from `self.signer`
+    /// ([`Self::local_derived_key_id`]). When the composed signer and the
+    /// local seed are distinct identities (different Ed25519 pubkeys ⇒
+    /// different derived ids — the real-node shape), the registered row and
+    /// the scrub FK target diverged, so `put_blob_signing` FK-failed on the
+    /// canonical "register self, then hold bytes" flow for every persist
+    /// ≥ 9.3.0. Registering `self.signer`'s identity (and returning its
+    /// derived id, which the caller threads back as `attesting_key_id`)
+    /// closes that gap structurally.
+    ///
+    /// The ML-DSA half is left to the cold-path PQC fill (matches the
+    /// pre-#275 shape). Returns the registered (derived) key_id.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn register_self_federation_key(
+        &self,
+        identity_type: &str,
+        identity_ref: &str,
+        valid_until: Option<chrono::DateTime<chrono::Utc>>,
+        registration_envelope: serde_json::Value,
+        roles: Vec<String>,
+    ) -> Result<String, crate::federation::Error> {
+        use crate::federation::FederationDirectory;
+        use crate::verify::canonical::{Canonicalizer, PythonJsonDumpsCanonicalizer};
+        use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+        use sha2::{Digest, Sha256};
+
+        // The federation identity is the engine's composed signer — the
+        // SAME key every emit/scrub path derives its key_id from (#247/#275).
+        let key_id = self.local_derived_key_id().await.map_err(|e| {
+            crate::federation::Error::Backend(format!("register_self derive key_id: {e}"))
+        })?;
+        let pubkey = self.signer.public_key().await.map_err(|e| {
+            crate::federation::Error::Backend(format!("register_self signer public_key: {e}"))
+        })?;
+        let pubkey_ed25519_base64 = B64.encode(&pubkey);
+
+        // Canonicalize the registration envelope with the production
+        // Python-dumps canonicalizer (the rule the manual/FFI workflow
+        // signs over), SHA-256 it, and classically self-sign with the
+        // composed signer.
+        let canonical = PythonJsonDumpsCanonicalizer
+            .canonicalize_value(&registration_envelope)
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("register_self canonicalize: {e}"))
+            })?;
+        let original_content_hash = hex::encode(Sha256::digest(&canonical));
+        let classical_sig = self.signer.sign(&canonical).await.map_err(|e| {
+            crate::federation::Error::Backend(format!("register_self classical sign: {e}"))
+        })?;
+        let scrub_signature_classical = B64.encode(&classical_sig);
+
+        // Microsecond truncation (Postgres TIMESTAMPTZ precision) — inlined
+        // to avoid a cirisaudit-feature dep on this path (mirrors the FFI).
+        let now = {
+            use chrono::Timelike as _;
+            let dt = chrono::Utc::now();
+            let micros = dt.nanosecond() / 1000;
+            dt.with_nanosecond(micros * 1000).unwrap_or(dt)
+        };
+
+        let record = crate::federation::KeyRecord {
+            key_id: key_id.clone(),
+            pubkey_ed25519_base64,
+            pubkey_ml_dsa_65_base64: None,
+            algorithm: crate::federation::types::algorithm::HYBRID.to_owned(),
+            identity_type: identity_type.to_owned(),
+            identity_ref: identity_ref.to_owned(),
+            valid_from: now,
+            valid_until,
+            registration_envelope,
+            original_content_hash,
+            scrub_signature_classical,
+            scrub_signature_pqc: None,
+            scrub_key_id: key_id.clone(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles,
+            attestation_evidence: None,
+        };
+        let signed = crate::federation::SignedKeyRecord { record };
+
+        // Self-bootstrap write — the same path the FFI `put_public_key`
+        // takes (NO `verify_key_registration`: that hybrid-mandatory
+        // §5.6.8.15 gate is for PEER registration via
+        // [`Self::register_federation_key`], not a node minting its own
+        // bootstrap row; the PQC half is filled by the cold path). The
+        // `put_public_key` writer is idempotent on the `key_id` PK.
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.put_public_key(signed).await?,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.put_public_key(signed).await?,
+        }
+        Ok(key_id)
+    }
+
     /// v4.6 (CIRISPersist#171 phase 2, CEG §10.1.3/§10.1.5) — promote a
     /// **local**-tier self-attestation to **federation**: canonicalize the
     /// row's envelope through the produce-side gate (JCS post-cut, §0.9),
@@ -6163,6 +6278,54 @@ mod tests {
         // list_holders sees the writer.
         let holders = sq.list_holders(&sha).await.expect("list_holders");
         assert_eq!(holders, vec![signer_alias]);
+    }
+
+    /// v10.0.1 (CIRISPersist#275) — regression: `register_self_federation_key`
+    /// must register the engine's COMPOSED-signer derived id (the same id
+    /// `put_blob_signing`'s holds_bytes `scrub_key_id` derives), so the
+    /// canonical "register self, then hold bytes" flow does NOT FK-fail. The
+    /// #247 floor (v9.3.0) made the scrub FK target the derived id while the
+    /// bootstrap registered the alias / a different signer's id, breaking
+    /// this on every persist >= 9.3.0.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn register_self_then_put_blob_signing_resolves_scrub_fk_275() {
+        use crate::federation::BlobBody;
+
+        let signer = test_signer();
+        let engine = Engine::with_signer(signer.clone(), "sqlite::memory:")
+            .await
+            .expect("construct engine");
+
+        // register_self registers the engine's federation identity, keyed
+        // by the DERIVED id — not the bare alias.
+        let kid = engine
+            .register_self_federation_key("agent", "ref", None, serde_json::json!({}), vec![])
+            .await
+            .expect("register_self_federation_key");
+        let derived = engine.local_derived_key_id().await.expect("derived id");
+        assert_eq!(kid, derived, "must register (and return) the derived id");
+        assert_ne!(
+            kid,
+            signer.key_id(),
+            "derived id is NOT the bare keystore alias"
+        );
+
+        // The canonical self-holds-bytes ingest must resolve the holds_bytes
+        // scrub_key_id FK against the row register_self just wrote.
+        let bytes = b"register-self-275".to_vec();
+        let sha = sha256_of_bytes(&bytes);
+        engine
+            .put_blob_signing(
+                &sha,
+                BlobBody::Inline(bytes),
+                Some("application/octet-stream"),
+                &kid,
+                chrono::Utc::now(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .expect("put_blob_signing must resolve the scrub FK after register_self");
     }
 
     #[cfg(feature = "sqlite")]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3340,8 +3340,12 @@ impl PyEngine {
     ///    asynchronously if the engine was constructed with PQC keys.
     /// 7. Calls `put_public_key` with the assembled `SignedKeyRecord`.
     ///
-    /// Returns the registered `key_id` (which equals
-    /// `engine.local_key_id()`).
+    /// Returns the registered `key_id` — the **derived** federation
+    /// key_id `derive_key_id(<alias>, <pubkey>)` (= `engine.local_derived_key_id()`),
+    /// NOT the bare keystore alias. Thread this returned value back as the
+    /// `attesting_key_id` to `put_blob_signing` / the emit helpers so the
+    /// holds_bytes / withdraws `scrub_key_id` FK resolves (CIRISPersist#275;
+    /// the #247 floor).
     ///
     /// Idempotent on `(key_id)` PRIMARY KEY of `federation_keys` — the
     /// underlying `put_public_key` writer rejects on key_id conflict
@@ -3365,17 +3369,6 @@ impl PyEngine {
     ) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
-            use base64::engine::general_purpose::STANDARD as B64;
-            use base64::Engine as _;
-            use sha2::{Digest, Sha256};
-
-            let signer = self.local_signer.clone().ok_or_else(|| {
-                PyValueError::new_err(
-                    "no local signing key configured (pass local_key_id + local_key_path \
-                     to the Engine constructor)",
-                )
-            })?;
-
             // Parse valid_until.
             let valid_until_dt: Option<chrono::DateTime<chrono::Utc>> = match valid_until {
                 None => None,
@@ -3391,79 +3384,45 @@ impl PyEngine {
                     PyValueError::new_err(format!("registration_envelope JSON decode: {e}"))
                 })?,
             };
+            let roles = roles.unwrap_or_default();
 
-            // Canonicalize envelope — same shape as canonicalize_envelope
-            // PyO3 surface, which the documented manual workflow uses.
-            let canonical_bytes = <PythonJsonDumpsCanonicalizer as crate::verify::canonical::Canonicalizer>::canonicalize_value(
-                &PythonJsonDumpsCanonicalizer,
-                &envelope,
-            )
-            .map_err(|e| PyRuntimeError::new_err(format!("canonicalize: {e}")))?;
-
-            // SHA-256 hex of the canonical bytes.
-            let mut hasher = Sha256::new();
-            hasher.update(&canonical_bytes);
-            let original_content_hash = format!("{:x}", hasher.finalize());
-
-            // Classical Ed25519 sig over canonical_bytes — base64.
-            let classical_sig_bytes = signer
-                .sign_ed25519(&canonical_bytes)
-                .map_err(|e| PyRuntimeError::new_err(format!("local_sign: {e}")))?;
-            let classical_sig_b64 = B64.encode(classical_sig_bytes);
-
-            // Build KeyRecord. PQC half + persist_row_hash + pqc_completed_at
-            // left to the existing put_public_key cold-path + server-compute.
-            let key_id = signer.key_id().to_owned();
-            let pubkey_ed25519_b64 = signer.public_key_b64();
-            // Truncate to microsecond precision — Postgres TIMESTAMPTZ is
-            // microsecond-precision, so the post-storage round-trip would
-            // otherwise differ from the pre-storage canonical bytes. Mirrors
-            // crate::audit::verify::truncate_to_micros (inlined to avoid a
-            // cirisaudit-feature dependency on this path).
-            let now = {
-                use chrono::Timelike as _;
-                let dt = chrono::Utc::now();
-                let micros = dt.nanosecond() / 1000;
-                dt.with_nanosecond(micros * 1000).unwrap_or(dt)
+            // v10.0.1 (CIRISPersist#275) — delegate to the crate-level
+            // `Engine::register_self_federation_key`, which registers the
+            // engine's **composed-signer** federation identity (the key
+            // every emit/scrub path derives its key_id from), keyed by the
+            // DERIVED federation key_id. Pre-#275 this FFI registered the
+            // `LocalSigner` seed's identity (or, earlier, the bare alias) —
+            // a row the holds_bytes / withdraws scrub FK could never resolve
+            // against when the composed signer and the local seed are
+            // distinct identities, so `put_blob_signing` FK-failed on every
+            // persist ≥ 9.3.0. Reconstruct the hybrid-capable engine over
+            // the shared backend + signer (the `attestation_promote` /
+            // `emit_attestation` cohabitation pattern) and call it.
+            let backend = match &self.backend {
+                BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
             };
-
-            let record = crate::federation::KeyRecord {
-                key_id: key_id.clone(),
-                pubkey_ed25519_base64: pubkey_ed25519_b64,
-                pubkey_ml_dsa_65_base64: None,
-                algorithm: crate::federation::types::algorithm::HYBRID.to_owned(),
-                identity_type: identity_type.to_owned(),
-                identity_ref: identity_ref.to_owned(),
-                valid_from: now,
-                valid_until: valid_until_dt,
-                registration_envelope: envelope,
-                original_content_hash,
-                scrub_signature_classical: classical_sig_b64,
-                scrub_signature_pqc: None,
-                scrub_key_id: key_id.clone(),
-                scrub_timestamp: now,
-                pqc_completed_at: None,
-                persist_row_hash: String::new(),
-                roles: roles.unwrap_or_default(),
-                // v2.5.0 (CIRISPersist#102 Ask 8) — the PyO3
-                // self-signing path is used by lens/agent bootstrap
-                // for steward / primitive / agent identities; it
-                // does NOT mint accord-holder keys (those go through
-                // a separate hardware-attestation bootstrap that
-                // populates `attestation_evidence` directly via
-                // `put_public_key` with a fully-formed
-                // SignedKeyRecord). Default to None here.
-                attestation_evidence: None,
-            };
-            let signed = crate::federation::SignedKeyRecord { record };
-            let signed_json = serde_json::to_string(&signed).map_err(|e| {
-                PyRuntimeError::new_err(format!("SignedKeyRecord JSON encode: {e}"))
-            })?;
-
-            // Delegate to put_public_key — handles backend dispatch +
-            // cold-path PQC fill automatically.
-            self.put_public_key(py, &signed_json)?;
-            Ok(key_id)
+            let signer = self.signer.clone();
+            let local_signer = self.local_signer.clone();
+            let runtime = self.runtime.clone();
+            let identity_type = identity_type.to_owned();
+            let identity_ref = identity_ref.to_owned();
+            py.detach(move || {
+                let engine = crate::Engine::from_shared_with_local(backend, signer, local_signer);
+                runtime.block_on(async move {
+                    engine
+                        .register_self_federation_key(
+                            &identity_type,
+                            &identity_ref,
+                            valid_until_dt,
+                            envelope,
+                            roles,
+                        )
+                        .await
+                        .map_err(federation_err_to_py)
+                })
+            })
         })
     }
 
@@ -22889,10 +22848,17 @@ fn blob_err_to_py(e: crate::federation::BlobError) -> PyErr {
     let kind = e.kind();
     tracing::warn!(error = %e, kind = kind, "blob storage error");
     match e {
+        // v10.0.1 (CIRISPersist#275) — keep the stable `kind` token as a
+        // prefix (callers branching on `str(e).startswith(...)` / `in`
+        // still match) but append the inner detail, which carries the
+        // underlying cause (e.g. the holds_bytes/withdraws scrub_key_id FK
+        // violation) — previously swallowed to a bare token.
+        crate::federation::BlobError::AttestationEmissionFailed(ref detail) => {
+            PyValueError::new_err(format!("{kind}: {detail}"))
+        }
         crate::federation::BlobError::HashMismatch { .. }
         | crate::federation::BlobError::InlineSizeExceeded { .. }
-        | crate::federation::BlobError::InvalidArgument(_)
-        | crate::federation::BlobError::AttestationEmissionFailed(_) => PyValueError::new_err(kind),
+        | crate::federation::BlobError::InvalidArgument(_) => PyValueError::new_err(kind),
         // v3.4.0 (CIRISPersist#123) — trust gate rejection.
         crate::federation::BlobError::TrustBelowThreshold { .. } => PyValueError::new_err(kind),
         // v3.6.0 (CIRISPersist#134) — perceptual-hash matcher hit.

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -289,3 +289,61 @@ def test_retention_ffi_round_trip_large_bytes() -> None:
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()
+
+
+def test_register_self_then_put_blob_signing_275() -> None:
+    """v10.0.1 (CIRISPersist#275) — regression for the canonical
+    "register my self key, then store a blob I hold" flow.
+
+    The #247 floor (v9.3.0) made every federation-tier emit's
+    `scrub_key_id` the DERIVED federation key_id
+    (`derive_key_id(<alias>, <pubkey>)` = `<label>-<fp>`), but
+    `register_self_federation_key` kept registering the bare keystore
+    ALIAS — so `put_blob_signing`'s holds_bytes scrub FK pointed at a row
+    that never existed and FK-failed (`blob_attestation_emission_failed`)
+    on every persist >= 9.3.0. The fix registers (and returns) the derived
+    id. Skips on a non-sqlite wheel."""
+    import base64
+    import hashlib
+    import os
+    import secrets
+    import tempfile
+    import uuid
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    seed = os.path.join(tempfile.mkdtemp(), "seed")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "node-" + secrets.token_hex(8)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:", alias, local_key_id=alias, local_key_path=seed
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        kid = eng.register_self_federation_key("agent", "ref", None, None, None)
+        # The registered + returned key_id is the DERIVED wire id, NOT the
+        # bare alias — this is the heart of the #275 fix.
+        assert kid != alias, "register_self must register the derived id, not the alias"
+        assert kid.startswith(alias + "-"), f"derived id shape <label>-<fp>: {kid!r}"
+
+        # The canonical self-holds-bytes ingest must NOT FK-fail now.
+        body = b"hello-275"
+        sha = hashlib.sha256(body).hexdigest()
+        eng.put_blob_signing(
+            sha,
+            base64.b64encode(body).decode(),
+            None,
+            None,
+            kid,
+            "2026-05-28T13:45:09.000Z",
+            str(uuid.uuid4()),
+        )
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()


### PR DESCRIPTION
## Summary

Fixes **#275** — `register_self_federation_key` → `put_blob_signing` (the canonical "register my self key, then store a blob I hold" flow) raised `ValueError: blob_attestation_emission_failed` on every persist **≥ 9.3.0** (through 10.0.0); worked on ≤ 9.2.2. Surfaced by the CIRISConformance cross-wheel harness bumping its matrix to the 9.11/10.0 floor.

## Root cause

The #247 floor (v9.3.0) made every federation-tier emit's `scrub_key_id` the **derived** wire key_id (`derive_key_id(<alias>, <ed25519 pubkey>)` = `<label>-<fp>`), and `put_blob_signing`'s holds_bytes scrub FKs to it. But `register_self_federation_key` registered the **`LocalSigner` seed's** identity (and, historically, the bare keystore alias) — a *different* key from the engine's composed `self.signer`, the one every emit/scrub path actually derives its key_id from. On a real node (composed signer ≠ local seed ⇒ different Ed25519 pubkeys ⇒ different derived ids), the registered row and the scrub FK target diverged → the holds_bytes insert FK-failed. Pre-9.3.0 both paths used the bare alias and matched; the #247 floor exposed the latent two-identity split.

## Fix

- **`Engine::register_self_federation_key`** (new crate-level method) registers the engine's **composed-signer** identity — keyed by the derived id (`local_derived_key_id()`), carrying `self.signer`'s Ed25519 pubkey + a classical self-signature — and **returns the derived id** so the caller threads it back as `attesting_key_id`. The PyO3 method delegates to it (the `attestation_promote`/`emit_attestation` cohabitation pattern). Same fix covers the eviction `withdraws` path (Ask #2): it derives from the same signer, so the now-registered derived row resolves its FK too.
- **Error surfacing** (Ask #3): `blob_err_to_py` appends the inner detail to `AttestationEmissionFailed` (the FK cause is no longer swallowed), keeping the stable kind token as a prefix.

## Test
- Rust regression: `register_self_federation_key` → `put_blob_signing` resolves the scrub FK; returned id is the derived id, not the alias.
- The exact issue repro as a Python wheel test (`tests/python/test_sqlite_engine.py`, runs in CI).
- Full gate: **1585 passed / 0 failed** (`cargo nextest --all-targets --test-threads=1`, plain postgres:16) + Python suite (9 passed); clippy `-D` across CI + 3 no-default-features combos; fmt.

## Behavior change
`register_self_federation_key` now returns the **derived** federation key_id (`<label>-<fp>`), not the bare alias — the value that FKs across the federation surface and that callers must pass as `attesting_key_id`. The prior return led to FK failure, so no working consumer depended on it. Verify family unchanged (v7.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)