### PR TITLE
v10.0.2 — #275 (3rd surface): PyEngine federation signer must be Ed25519, not the P-256 keystore fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.0.2] — 2026-06-24
+
+### Fixed — #275 (3rd surface): PyEngine federation signer must be Ed25519, not the P-256 keystore fallback
+
+v10.0.1 fixed the FK divergence by registering `self.signer`'s derived
+identity — but on the **PyEngine** construction path `self.signer` is the
+**P-256** signer `get_platform_signer` returns when no Ed25519 keyring
+identity is present (its `public_key()` is a 65-byte uncompressed EC point).
+So `register_self_federation_key` stored a 65-byte P-256 key under
+`pubkey_ed25519_base64`, and any read-back verify (`verify_hybrid_via_directory`)
+failed `invalid_length`. (The v10.0.1 Rust regression passed only because
+`Engine::with_signer` — the *Rust* path — already makes `self.signer` the
+Ed25519 `LocalSignerHardwareAdapter`; the PyEngine path diverged.)
+
+Root cause: the engine's classical signing identity is Ed25519 (`sign_hybrid`
+signs via the Ed25519 `local_signer`), but `PyEngine::new` left `self.signer`
+as the non-Ed25519 platform fallback — desyncing every key_id-deriving / scrub
+path (`local_derived_key_id`, `put_blob_signing`, `register_self`) from
+`sign_hybrid`.
+
+- **`PyEngine::new`** now mirrors `Engine::with_signer`: when the platform
+  signer is **not** an Ed25519 key (`algorithm() != Ed25519` — e.g. the
+  `EcdsaP256` software/TPM fallback) **and** an Ed25519 `local_signer` is
+  configured, the engine's signer becomes that local Ed25519 key (wrapped in
+  `LocalSignerHardwareAdapter`). A genuine Ed25519 platform/hardware signer is
+  left untouched. This unifies the construction paths: `self.signer` is now
+  the Ed25519 federation identity, so the stored pubkey is a valid 32-byte
+  Ed25519 key and every emit/scrub/derive path agrees with `sign_hybrid`.
+- **Tested**: the Python wheel regression now asserts the stored
+  `pubkey_ed25519_base64` decodes to 32 bytes (catches the P-256 leak this
+  surface was) in addition to the FK + return-id checks.
+
 ## [10.0.1] — 2026-06-24
 
 ### Fixed — #275: `register_self_federation_key` registered the wrong identity → `put_blob_signing` FK-failed on every persist ≥ 9.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.0.1"
+version = "10.0.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1371,6 +1371,36 @@ impl PyEngine {
                 }
             };
 
+        // v10.0.2 (CIRISPersist#275, 3rd surface) — the federation classical
+        // identity is Ed25519. `get_platform_signer`'s SOFTWARE fallback is a
+        // P-256 signer (its `public_key()` is a 65-byte uncompressed EC point,
+        // NOT a 32-byte Ed25519 key), so using it as `self.signer` desynced
+        // every key_id-deriving / scrub path (`local_derived_key_id`,
+        // `put_blob_signing`'s holds_bytes scrub, `register_self_federation_key`)
+        // from `sign_hybrid` (which signs classical via the Ed25519
+        // `local_signer`) — and stored an unverifiable P-256 key under
+        // `pubkey_ed25519_base64`. When a software-tier platform signer is
+        // paired with an Ed25519 `local_signer`, make the engine's signer that
+        // local Ed25519 key — wrapped exactly as [`crate::Engine::with_signer`]
+        // does (`LocalSignerHardwareAdapter`), the canonical Rust path. Real
+        // hardware signers (non-`SoftwareOnly`) are left untouched.
+        let signer: Arc<dyn HardwareSigner> = match local_signer.as_ref() {
+            // The platform signer is NOT an Ed25519 key (e.g. the
+            // P-256/`EcdsaP256` software/TPM fallback `get_platform_signer`
+            // returns when no Ed25519 keyring identity is present) but an
+            // Ed25519 `local_signer` IS configured — so the platform signer
+            // cannot serve as the federation classical identity (its
+            // `public_key()` is a 65-byte EC point, not a 32-byte Ed25519
+            // key). Use the local Ed25519 key as the engine's signer,
+            // wrapped exactly as `Engine::with_signer` does. A genuine
+            // Ed25519 platform/hardware signer (`algorithm() == Ed25519`)
+            // is left as-is.
+            Some(ls) if signer.algorithm() != ciris_keyring::ClassicalAlgorithm::Ed25519 => {
+                Arc::new(crate::signing::LocalSignerHardwareAdapter::new(ls.clone()))
+            }
+            _ => signer,
+        };
+
         // v0.3.2 (CIRISPersist#11) — Auto-sweep on init when a local
         // PQC key is configured. Drains hybrid-pending rows authored
         // before the per-write cold-path was wired (or rows where the

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -305,6 +305,7 @@ def test_register_self_then_put_blob_signing_275() -> None:
     id. Skips on a non-sqlite wheel."""
     import base64
     import hashlib
+    import json
     import os
     import secrets
     import tempfile
@@ -331,6 +332,14 @@ def test_register_self_then_put_blob_signing_275() -> None:
         # bare alias — this is the heart of the #275 fix.
         assert kid != alias, "register_self must register the derived id, not the alias"
         assert kid.startswith(alias + "-"), f"derived id shape <label>-<fp>: {kid!r}"
+
+        # #275 3rd surface — the stored pubkey_ed25519_base64 must be a valid
+        # 32-byte Ed25519 key (not the 65-byte P-256 point the keystore
+        # software/TPM fallback would yield), or any read-back verify
+        # (verify_hybrid_via_directory) fails invalid_length.
+        row = json.loads(eng.lookup_keys_for_identity("ref"))[0]
+        pubkey = base64.b64decode(row["pubkey_ed25519_base64"])
+        assert len(pubkey) == 32, f"stored pubkey must be 32-byte Ed25519, got {len(pubkey)}"
 
         # The canonical self-holds-bytes ingest must NOT FK-fail now.
         body = b"hello-275"


### PR DESCRIPTION
## Summary

Completes the **#275** fix. v10.0.1 resolved the FK divergence by registering `self.signer`'s derived identity — but on the **PyEngine** path `self.signer` is the **P-256** signer `get_platform_signer` returns when no Ed25519 keyring identity is present (`public_key()` = 65-byte uncompressed EC point). So `register_self_federation_key` stored a 65-byte P-256 key under `pubkey_ed25519_base64`, and any read-back verify (`verify_hybrid_via_directory`) failed `invalid_length`.

The v10.0.1 Rust regression passed only because `Engine::with_signer` (the **Rust** path) already makes `self.signer` the Ed25519 `LocalSignerHardwareAdapter` — the PyEngine path diverged. This is the gap the hardening pass (below) closes.

## Root cause
The engine's classical signing identity is Ed25519 (`sign_hybrid` signs via the Ed25519 `local_signer`), but `PyEngine::new` left `self.signer` as the non-Ed25519 platform fallback — desyncing every key_id-deriving / scrub path (`local_derived_key_id`, `put_blob_signing`, `register_self`) from `sign_hybrid`.

## Fix
`PyEngine::new` now mirrors `Engine::with_signer`: when the platform signer is **not** Ed25519 (`algorithm() != Ed25519` — e.g. the `EcdsaP256` software/TPM fallback) **and** an Ed25519 `local_signer` is configured, the engine's signer becomes that local Ed25519 key (`LocalSignerHardwareAdapter`). A genuine Ed25519 platform/hardware signer is left untouched. `self.signer` is now the Ed25519 federation identity, so the stored pubkey is a valid 32-byte Ed25519 key and every emit/scrub/derive path agrees with `sign_hybrid`.

## Test
- Python wheel regression now asserts the stored `pubkey_ed25519_base64` decodes to **32 bytes** (catches the P-256 leak) in addition to the FK + return-id checks.
- Full gate: **1585 passed / 0 failed** + Python suite (9 passed); clippy `-D` across CI + 3 no-default-features combos; fmt. Verify family unchanged (v7.2.0).

## Follow-up
A targeted federation-identity hardening pass follows (end-to-end wheel lifecycle + verify round-trip; sweep of all key-id-derivation + key-registration paths for wrong-curve pubkeys) — the wheel-level lifecycle gap this bug lived in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)