### PR TITLE
v10.1.0 — federation signing-identity hardening (the #275 bug class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.1.0] — 2026-06-24
+
+### Hardened — federation signing-identity surface (the #275 bug class)
+
+A targeted hardening pass over the federation signing-identity surface, after
+#275 surfaced three times from one root (the engine's classical identity is
+Ed25519, but a key_id-deriving / scrub / write path could use or store a
+non-Ed25519 key). A 41-agent adversarial audit mapped the surface; the
+confirmed, actionable findings are fixed here. The substrate is otherwise
+heavily tested — this closes the specific gap that hid #275: no wheel-level
+construct→register→emit→**verify** round-trip, and no write-time pubkey-shape
+admission guard.
+
+- **Write-path admission backstop** — `federation::register::validate_registration_pubkey`
+  enforces that `pubkey_ed25519_base64` decodes to exactly **32 bytes** (a
+  valid Ed25519 key), and is called from **every** backend's `put_public_key`
+  (the one chokepoint all registration paths funnel through) AND from
+  `verify_key_registration` (fail-fast for the peer path). A wrong-curve /
+  malformed key (e.g. a 65-byte P-256 point) can no longer be admitted to
+  `federation_keys` regardless of how it was produced — caught at admission
+  with `federation_invalid_argument`, before INSERT, leaving no row.
+  Backend-symmetric (identical on Postgres + SQLite).
+- **Fixed a missed #247/#275 site** — `Engine::receive_and_persist_with` (the
+  ingest entry for `receive_and_persist` / `_pre_verified`) used the bare
+  keystore **alias** as the `signer_key_id` that the pipeline writes into each
+  row's `scrub_key_id` (which FKs to `federation_keys` post-#247). It now
+  derives the **registered** key_id via `local_derived_key_id()` (alias
+  fallback), matching the `sweep_evictions_once_inner` / `emit_withdraws`
+  floor — so trace/ingest scrub rows FK-resolve on a real node.
+- **Fail-loud at derivation** — `Engine::local_derived_key_id` now returns an
+  error when the composed signer's public key isn't 32 bytes (a non-Ed25519
+  signer), instead of silently deriving a key_id over a P-256 point and
+  storing an unverifiable identity.
+- **Tested**: a backend-free unit test for the validator (accepts 32-byte,
+  rejects 65-byte P-256 + non-base64); a wrong-curve `put_public_key`
+  rejection arm in the backend-agnostic register matrix (runs on Postgres +
+  SQLite, asserts no row is left); the Python wheel #275 regression asserts
+  the stored pubkey decodes to 32 bytes. Full gate green. Verify family
+  unchanged (v7.2.0).
+
 ## [10.0.2] — 2026-06-24
 
 ### Fixed — #275 (3rd surface): PyEngine federation signer must be Ed25519, not the P-256 keystore fallback

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.0.2"
+version = "10.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1596,6 +1596,26 @@ impl Engine {
                 "local_derived_key_id: hardware public_key read failed: {e}"
             )))
         })?;
+        // v10.1.0 (CIRISPersist#275 hardening) — fail LOUD, not silent: a
+        // federation key_id is `derive_key_id(<alias>, <32-byte Ed25519
+        // pubkey>)`. If the composed signer is NOT Ed25519 (e.g. a 65-byte
+        // P-256 `EcdsaP256` keystore fallback), deriving over its pubkey
+        // would mint a key_id that no valid Ed25519 federation row can match
+        // — and silently store an unverifiable key (the #275 3rd surface).
+        // Reject here so the misconfiguration surfaces at the source instead
+        // of as a downstream FK / invalid_length failure.
+        // An Ed25519 public key is exactly 32 bytes.
+        const ED25519_PUBLIC_KEY_LEN: usize = 32;
+        if pubkey.len() != ED25519_PUBLIC_KEY_LEN {
+            return Err(SignError::LocalSigner(
+                crate::signing::LocalSignerError::ClassicalSign(format!(
+                    "local_derived_key_id: signer public_key is {} bytes, not a 32-byte Ed25519 \
+                     key — the engine's federation signing identity must be Ed25519 (got a \
+                     non-Ed25519 signer; pass an Ed25519 local_key_id/local_key_path)",
+                    pubkey.len(),
+                )),
+            ));
+        }
         Ok(ciris_verify_core::fedcode::derive_key_id(
             self.signer.current_alias(),
             &pubkey,
@@ -2386,7 +2406,19 @@ impl Engine {
         scrubber: &dyn Scrubber,
         verify_mode: crate::ingest::VerifyMode,
     ) -> Result<crate::ingest::BatchSummary, crate::ingest::IngestError> {
-        let key_id = self.signer.current_alias().to_owned();
+        // v10.1.0 (CIRISPersist#275 hardening) — the ingest pipeline carries
+        // this into each scrubbed row's `scrub_key_id`, which FKs to
+        // `federation_keys(key_id)` (the #247 floor). A registered node emits
+        // under its DERIVED federation key_id (`<label>-<fp>`), NOT the bare
+        // keystore alias — so the lookup key must be the derived id (matching
+        // the `sweep_evictions_once_inner` / `emit_withdraws_attestation`
+        // floor; this was a missed site). Falls back to the alias only if the
+        // derived id can't be resolved (no signer pubkey), preserving prior
+        // behaviour for Ed25519-only / no-pubkey signers.
+        let key_id = self
+            .local_derived_key_id()
+            .await
+            .unwrap_or_else(|_| self.signer.current_alias().to_owned());
         match &self.backend {
             #[cfg(feature = "postgres")]
             BackendDispatch::Postgres(arc) => {

--- a/src/federation/register.rs
+++ b/src/federation/register.rs
@@ -94,6 +94,41 @@ use super::{Error, FederationDirectory};
 use crate::verify::canonical::ceg_produce_canonicalize;
 use crate::verify::{verify_hybrid, HybridPolicy, VerifyOutcome};
 
+/// v10.1.0 (CIRISPersist#275 hardening) — the **write-path admission
+/// invariant** for a `federation_keys` row's classical public key: it
+/// MUST base64-decode to exactly 32 bytes (a valid Ed25519 key).
+///
+/// This is the universal backstop the #275 saga proved was missing: a
+/// row whose `pubkey_ed25519_base64` was a 65-byte P-256 point was stored
+/// unchallenged and only failed (`invalid_length`) at a downstream
+/// `verify_hybrid_via_directory` read. Called by **every** backend's
+/// `put_public_key` (the one write chokepoint all registration paths —
+/// `register_self_federation_key`, `register_federation_key`, the FFI,
+/// direct callers — funnel through), so a wrong-curve / malformed key can
+/// never be admitted regardless of how it was produced. Backend-agnostic:
+/// the SAME check runs on Postgres and SQLite.
+pub fn validate_registration_pubkey(record: &KeyRecord) -> Result<(), Error> {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+    /// An Ed25519 public key is exactly 32 bytes.
+    const ED25519_PUBLIC_KEY_LEN: usize = 32;
+    let decoded = B64.decode(&record.pubkey_ed25519_base64).map_err(|e| {
+        Error::InvalidArgument(format!(
+            "pubkey_ed25519_base64 is not valid base64 (key_id {}): {e}",
+            record.key_id
+        ))
+    })?;
+    if decoded.len() != ED25519_PUBLIC_KEY_LEN {
+        return Err(Error::InvalidArgument(format!(
+            "pubkey_ed25519_base64 must decode to a 32-byte Ed25519 key, got {} bytes (key_id {}) \
+             — a non-Ed25519 key (e.g. a 65-byte P-256 point) cannot be admitted to \
+             federation_keys",
+            decoded.len(),
+            record.key_id
+        )));
+    }
+    Ok(())
+}
+
 /// Verify a [`KeyRecord`] registration against the §5.6.8.15 admission
 /// gate, BEFORE any store. Generic over [`FederationDirectory`] so it
 /// composes against any backend (postgres, sqlite, memory) — the
@@ -142,6 +177,10 @@ where
             "scrub_key_id must be non-empty for registration".to_string(),
         ));
     }
+    // #275 hardening — the classical pubkey must be a valid 32-byte Ed25519
+    // key (fail-fast before the PQC verify; `put_public_key` re-checks at the
+    // store chokepoint for paths that skip this gate).
+    validate_registration_pubkey(record)?;
 
     // Canonicalize the registration envelope through the CEG produce
     // gate — the same canonical form the producer signed. Cross-check
@@ -330,6 +369,35 @@ mod tests {
         record
     }
 
+    /// #275 hardening — `validate_registration_pubkey` enforces the
+    /// 32-byte Ed25519 invariant: accepts a real 32-byte key, rejects a
+    /// 65-byte P-256 point, rejects non-base64. Backend-free unit coverage
+    /// of the admission backstop (the matrix exercises it end-to-end on both
+    /// backends via put_public_key).
+    #[tokio::test]
+    async fn validate_registration_pubkey_enforces_32_byte_ed25519() {
+        let mut rec =
+            signed_self_record("vrp-key", identity_type::AGENT, None, false, false, false).await;
+        // Valid 32-byte Ed25519 (the builder uses a real key) — accepted.
+        validate_registration_pubkey(&rec).expect("32-byte Ed25519 key must be accepted");
+
+        // 65-byte uncompressed P-256 point — rejected, naming the invariant.
+        rec.pubkey_ed25519_base64 = B64.encode([0x04u8; 65]);
+        let err = validate_registration_pubkey(&rec).unwrap_err();
+        assert_eq!(err.kind(), "federation_invalid_argument");
+        assert!(
+            format!("{err}").contains("32-byte"),
+            "must name the invariant: {err}"
+        );
+
+        // Not valid base64 — rejected.
+        rec.pubkey_ed25519_base64 = "!!! not base64 !!!".into();
+        assert!(
+            validate_registration_pubkey(&rec).is_err(),
+            "non-base64 must be rejected"
+        );
+    }
+
     /// The full §5.6.8.15 admission-gate matrix, backend-agnostic.
     async fn run_register_matrix(engine: &Engine, run_tag: &str) {
         let directory = engine.federation_directory();
@@ -349,6 +417,42 @@ mod tests {
         assert!(
             read.is_some(),
             "(a) admitted key must be readable via lookup_public_key"
+        );
+
+        // (a') #275 hardening — a row whose pubkey_ed25519_base64 is NOT a
+        // 32-byte Ed25519 key (here a 65-byte P-256 point) is REJECTED at the
+        // put_public_key write chokepoint, on BOTH backends, before any
+        // INSERT. This is the admission backstop the #275 saga proved was
+        // missing (a wrong-curve key was stored unchallenged and only failed
+        // at read). Self-signed (scrub_key_id == key_id) so it reaches the
+        // store path directly.
+        let wrongcurve_id = format!("peer-wrongcurve-{run_tag}");
+        let mut wrongcurve = signed_self_record(
+            &wrongcurve_id,
+            identity_type::AGENT,
+            None,
+            false,
+            false,
+            false,
+        )
+        .await;
+        wrongcurve.pubkey_ed25519_base64 = B64.encode([0x04u8; 65]); // uncompressed P-256 point
+        let err = directory
+            .put_public_key(SignedKeyRecord { record: wrongcurve })
+            .await
+            .expect_err("(a') a non-32-byte pubkey must be rejected at put_public_key");
+        assert_eq!(err.kind(), "federation_invalid_argument");
+        assert!(
+            format!("{err}").contains("32-byte"),
+            "(a') rejection must name the 32-byte Ed25519 invariant: {err}"
+        );
+        assert!(
+            directory
+                .lookup_public_key(&wrongcurve_id)
+                .await
+                .expect("lookup")
+                .is_none(),
+            "(a') a rejected wrong-curve key must leave NO row"
         );
 
         // (b) bad/missing ML-DSA-65 (hybrid-pending under Strict) →

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2093,6 +2093,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = record.record;
 
+        // v10.1.0 (CIRISPersist#275 hardening) — universal write-path
+        // invariant: pubkey_ed25519_base64 MUST decode to a 32-byte Ed25519
+        // key. Rejects a wrong-curve / malformed key (e.g. a 65-byte P-256
+        // point) at admission for EVERY registration path — the backstop the
+        // #275 saga proved was missing. Backend-symmetric with SQLite. Runs
+        // first so a bad key leaves no trace.
+        crate::federation::register::validate_registration_pubkey(&row)?;
+
         // v2.5.0 (CIRISPersist#102 Ask 8) — hardware-attestation
         // admission gate for accord_holder rows. Runs BEFORE
         // persist_row_hash + INSERT so rejected rows leave no trace.

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1757,6 +1757,13 @@ impl crate::federation::FederationDirectory for SqliteBackend {
     ) -> Result<(), crate::federation::Error> {
         let mut row = record.record;
 
+        // v10.1.0 (CIRISPersist#275 hardening) — universal write-path
+        // invariant: pubkey_ed25519_base64 MUST decode to a 32-byte Ed25519
+        // key. Rejects a wrong-curve / malformed key (e.g. a 65-byte P-256
+        // point) at admission for EVERY registration path — the backstop the
+        // #275 saga proved was missing. Runs first so a bad key leaves no trace.
+        crate::federation::register::validate_registration_pubkey(&row)?;
+
         // v2.5.0 (CIRISPersist#102 Ask 8) — hardware-attestation
         // admission gate for accord_holder rows. Runs BEFORE
         // persist_row_hash + INSERT so rejected rows leave no trace.


### PR DESCRIPTION
## Summary

A targeted hardening pass over the federation signing-identity surface, after **#275** surfaced three times from one root (the engine's classical identity is Ed25519, but a key_id-deriving / scrub / write path could use or store a non-Ed25519 key). A **41-agent adversarial audit** mapped the surface; the confirmed, actionable findings are fixed here. The substrate is otherwise heavily tested — this closes the specific gap that hid #275: no wheel-level construct→register→emit→**verify** round-trip, and no write-time pubkey-shape admission guard.

## Changes

- **Write-path admission backstop** — `federation::register::validate_registration_pubkey` enforces `pubkey_ed25519_base64` decodes to exactly **32 bytes** (valid Ed25519), called from **every** backend's `put_public_key` (the one chokepoint all registration paths funnel through) AND from `verify_key_registration` (fail-fast for the peer path). A wrong-curve / malformed key (e.g. a 65-byte P-256 point) can no longer be admitted to `federation_keys` regardless of how it was produced — caught with `federation_invalid_argument`, before INSERT, leaving no row. Backend-symmetric (Postgres + SQLite).
- **Fixed a missed #247/#275 site** — `Engine::receive_and_persist_with` (ingest entry for `receive_and_persist` / `_pre_verified`) used the bare keystore **alias** as the `signer_key_id` the pipeline writes into each row's `scrub_key_id` (which FKs to `federation_keys` post-#247). Now derives the **registered** key_id via `local_derived_key_id()` (alias fallback), matching the `sweep_evictions_once_inner` / `emit_withdraws` floor.
- **Fail-loud at derivation** — `Engine::local_derived_key_id` errors when the composed signer's pubkey isn't 32 bytes (non-Ed25519), instead of silently deriving a key_id over a P-256 point.

## Test
- Backend-free validator unit test (accepts 32-byte, rejects 65-byte P-256 + non-base64); wrong-curve `put_public_key` rejection arm in the backend-agnostic register matrix (runs on **Postgres + SQLite**, asserts no row left); Python wheel #275 test asserts the stored pubkey decodes to 32 bytes.
- Full gate: **1586 passed / 0 failed** + Python suite (9 passed); clippy `-D` across CI + 3 no-default-features combos; fmt. Verify family unchanged (v7.2.0).

## Audit provenance
41 agents across 5 dimensions (registration paths, construction paths, key-id derivation, verify/read-back, pubkey-column invariant), each finding adversarially verified. Most findings were INFO ("correct, no fix"); the actionable ones are the three fixes above. Remaining lower-severity ideas (schema CHECK on pubkey length; `from_shared_with_local` cross-signer doc/validation) are noted for a future cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)