### PR TITLE
v10.1.1 — #275 (withdraws/eviction): register_self stores ML-DSA-65 pubkey + hybrid-signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.1.1] — 2026-06-24
+
+### Fixed — #275 (withdraws/eviction surface): `register_self_federation_key` now stores the ML-DSA-65 pubkey + hybrid-signs
+
+The eviction `withdraws` path (`evict_actor` → `withdraws_failed: N`) was the
+last live #275 surface. It is **not** an FK / key_id-divergence issue (those
+were fixed in 10.0.1–10.1.0): `register_self_federation_key` stored the row with
+`pubkey_ml_dsa_65_base64 = None` (deferred to a "cold-path fill" that never runs
+in a standalone / SQLite wheel). A registered key with **no ML-DSA pubkey** makes
+the federation-tier ingest gate reject *every* hybrid-signed emission verified
+against it — `verify_hybrid_pqc_fields_mismatch` ("PQC signature without pubkey").
+So a node that registered itself could hold blobs (classical/local-tier scrub)
+but could not emit the federation-tier `withdraws` that eviction requires.
+
+- **`Engine::register_self_federation_key`** now populates `pubkey_ml_dsa_65_base64`
+  from the engine's PQC signer and writes a complete hybrid scrub signature
+  (`sign_hybrid`) when a PQC identity is configured — the registered row is a
+  full Ed25519 + ML-DSA-65 hybrid key. A non-PQC (Ed25519-only) engine still
+  registers a classical-only row (federation-tier emits are gated off there by
+  design). The classical half of `sign_hybrid` is the engine's composed signer,
+  so the row stays internally consistent with `pubkey_ed25519_base64`.
+- **Tested**: a new end-to-end `evict_actor_after_register_self_emits_withdraws`
+  Rust test (`register_self → put_blob_signing → evict_actor`, asserts
+  `withdraws_failed == 0` / `withdraws_emitted == 1`) — the construct→register→
+  emit→withdraws lifecycle the prior tests didn't cover.
+
+### Note — `enqueue_outbound` is not a derived-key_id regression
+
+Investigated the reported `enqueue_outbound` "durable-send FK": the **sender**
+FK (the registered derived key_id) resolves correctly. The reproducible failures
+are (a) the **by-design** `destination_key_id` FK — `edge_outbound_queue`
+requires the destination to be a registered `federation_keys` row (schema V007),
+so a send to an unregistered peer fails (register the peer first), and (b) a
+`requires_ack=true` call without `ack_timeout_seconds` (input validation). No
+persist change here; flagged for the harness.
+
 ## [10.1.0] — 2026-06-24
 
 ### Hardened — federation signing-identity surface (the #275 bug class)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.1.0"
+version = "10.1.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1686,10 +1686,6 @@ impl Engine {
                 crate::federation::Error::Backend(format!("register_self canonicalize: {e}"))
             })?;
         let original_content_hash = hex::encode(Sha256::digest(&canonical));
-        let classical_sig = self.signer.sign(&canonical).await.map_err(|e| {
-            crate::federation::Error::Backend(format!("register_self classical sign: {e}"))
-        })?;
-        let scrub_signature_classical = B64.encode(&classical_sig);
 
         // Microsecond truncation (Postgres TIMESTAMPTZ precision) — inlined
         // to avoid a cirisaudit-feature dep on this path (mirrors the FFI).
@@ -1700,10 +1696,49 @@ impl Engine {
             dt.with_nanosecond(micros * 1000).unwrap_or(dt)
         };
 
+        // v10.1.0 (CIRISPersist#275 — withdraws/eviction surface) — populate
+        // the ML-DSA-65 PUBLIC KEY and a complete hybrid scrub signature when
+        // the engine has a PQC identity. Pre-#275 the row left
+        // `pubkey_ml_dsa_65_base64 = None` (deferred to a "cold-path fill"
+        // that never runs in a standalone / SQLite wheel). A registered key
+        // with NO ML-DSA pubkey makes the federation-tier ingest gate REJECT
+        // every hybrid-signed emission verified against it
+        // (`verify_hybrid_pqc_fields_mismatch`: "PQC signature without
+        // pubkey") — e.g. the eviction `withdraws` and any `emit_attestation`.
+        // So a node that registered itself could not emit. The classical half
+        // of `sign_hybrid` is the engine's composed signer (== the Ed25519
+        // identity in `pubkey_ed25519_base64`), so the row is internally
+        // consistent.
+        let pqc_pubkey_b64 = match self.local_signer.as_ref() {
+            Some(ls) => ls.pqc_public_key_b64().await.map_err(|e| {
+                crate::federation::Error::Backend(format!("register_self pqc public_key: {e}"))
+            })?,
+            None => None,
+        };
+        let (scrub_signature_classical, scrub_signature_pqc, pqc_completed_at) =
+            if pqc_pubkey_b64.is_some() {
+                let sig = self.sign_hybrid(&canonical).await.map_err(|e| {
+                    crate::federation::Error::Backend(format!("register_self hybrid sign: {e}"))
+                })?;
+                (
+                    B64.encode(&sig.classical.signature),
+                    Some(B64.encode(&sig.pqc.signature)),
+                    Some(now),
+                )
+            } else {
+                // Ed25519-only identity — classical-only self-signature. A
+                // non-PQC node cannot emit federation-tier rows (enforced at
+                // those emit sites); the row stays Ed25519-only.
+                let classical_sig = self.signer.sign(&canonical).await.map_err(|e| {
+                    crate::federation::Error::Backend(format!("register_self classical sign: {e}"))
+                })?;
+                (B64.encode(&classical_sig), None, None)
+            };
+
         let record = crate::federation::KeyRecord {
             key_id: key_id.clone(),
             pubkey_ed25519_base64,
-            pubkey_ml_dsa_65_base64: None,
+            pubkey_ml_dsa_65_base64: pqc_pubkey_b64,
             algorithm: crate::federation::types::algorithm::HYBRID.to_owned(),
             identity_type: identity_type.to_owned(),
             identity_ref: identity_ref.to_owned(),
@@ -1712,10 +1747,10 @@ impl Engine {
             registration_envelope,
             original_content_hash,
             scrub_signature_classical,
-            scrub_signature_pqc: None,
+            scrub_signature_pqc,
             scrub_key_id: key_id.clone(),
             scrub_timestamp: now,
-            pqc_completed_at: None,
+            pqc_completed_at,
             persist_row_hash: String::new(),
             roles,
             attestation_evidence: None,
@@ -6358,6 +6393,58 @@ mod tests {
             )
             .await
             .expect("put_blob_signing must resolve the scrub FK after register_self");
+    }
+
+    /// v10.1.0 (CIRISPersist#275 — withdraws/eviction surface) — the
+    /// canonical "register self → hold a blob → evict the actor" lifecycle
+    /// end to end: the eviction `withdraws` attestation must FK-resolve
+    /// against the row `register_self_federation_key` wrote. Reproduces the
+    /// conformance harness's `withdraws_failed` report.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn evict_actor_after_register_self_emits_withdraws_275() {
+        use crate::federation::BlobBody;
+
+        let signer = test_signer(); // PQC-configured (hybrid withdraws need it)
+        let engine = Engine::with_signer(signer.clone(), "sqlite::memory:")
+            .await
+            .expect("construct engine");
+        let kid = engine
+            .register_self_federation_key("agent", "ref", None, serde_json::json!({}), vec![])
+            .await
+            .expect("register_self_federation_key");
+
+        // Hold a blob under the registered (derived) id.
+        let bytes = b"evict-275".to_vec();
+        let sha = sha256_of_bytes(&bytes);
+        engine
+            .put_blob_signing(
+                &sha,
+                BlobBody::Inline(bytes),
+                Some("application/octet-stream"),
+                &kid,
+                chrono::Utc::now(),
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .expect("put_blob_signing");
+
+        // Evict the actor → emits a federation-tier withdraws whose
+        // attesting/attested/scrub key_id must FK-resolve against the
+        // register_self row.
+        let report = engine
+            .evict_actor(&kid, chrono::Utc::now())
+            .await
+            .expect("evict_actor");
+        assert_eq!(report.blobs_evicted, 1, "the held blob is evicted");
+        assert_eq!(
+            report.withdraws_failed, 0,
+            "the withdraws must NOT FK-fail after register_self: {report:?}"
+        );
+        assert_eq!(
+            report.withdraws_emitted, 1,
+            "one withdraws emitted: {report:?}"
+        );
     }
 
     #[cfg(feature = "sqlite")]


### PR DESCRIPTION
## Summary

Fixes the **last live #275 surface** — the eviction `withdraws` path (`evict_actor` → `withdraws_failed: N`).

**It is not an FK / key_id-divergence issue** (those were 10.0.1–10.1.0). Root cause: `register_self_federation_key` stored the row with `pubkey_ml_dsa_65_base64 = None` (deferred to a "cold-path fill" that never runs in a standalone / SQLite wheel). A registered key with **no ML-DSA pubkey** makes the federation-tier ingest gate reject *every* hybrid-signed emission verified against it:

```
verify_hybrid_pqc_fields_mismatch — PQC signature without pubkey (or vice versa) — both required
```

So a self-registered node could hold blobs (classical/local-tier scrub) but could not emit the federation-tier `withdraws` that eviction requires. (Captured by calling the withdraws helper directly — the error was swallowed into `withdraws_failed`.)

## Fix
`Engine::register_self_federation_key` now populates `pubkey_ml_dsa_65_base64` from the engine's PQC signer and writes a complete hybrid scrub signature (`sign_hybrid`) when a PQC identity is configured — the registered row is a full Ed25519 + ML-DSA-65 hybrid key. A non-PQC (Ed25519-only) engine still registers a classical-only row (federation-tier emits are gated off there by design). The classical half of `sign_hybrid` is the engine's composed signer, so the row stays consistent with `pubkey_ed25519_base64`.

## Test
New end-to-end `evict_actor_after_register_self_emits_withdraws` (`register_self → put_blob_signing → evict_actor`, asserts `withdraws_failed == 0` / `withdraws_emitted == 1`) — the construct→register→emit→withdraws lifecycle the earlier tests didn't cover. Full gate: **1587 passed / 0 failed** + Python suite (9 passed); clippy `-D` across CI + 3 no-default-features combos; fmt. Verify family unchanged (v7.2.0).

## `enqueue_outbound` — investigated, not a derived-key_id regression
The **sender** FK (the registered derived key_id) resolves correctly. The reproducible failures are (a) the **by-design** `destination_key_id` FK — `edge_outbound_queue` (schema V007) requires the destination to be a registered `federation_keys` row, so a send to an unregistered peer fails (register the peer first); and (b) a `requires_ack=true` call without `ack_timeout_seconds` (input validation). No persist change here — flagged for the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)