### PR TITLE
v10.2.0 — #281: audit_next_chain_position PyO3 binding (audit chain head)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.2.0] — 2026-06-25
+
+### Added — #281: `audit_next_chain_position` PyO3 binding (audit chain head)
+
+`audit_record_entry` requires the client to supply a fully-formed chained
+entry (`sequence_number == tail_seq + 1`, `prev_hash == previous entry_hash`,
+GENESIS = 32 zero bytes for the first). persist computes this internally
+(`AuditService::next_chain_position`) but it was **not on the PyO3 surface**,
+so CIRISServer's cohabitation `LensAudit.log_*` could not assemble a valid
+entry over the wheel (it sent `sequence_number = 0` / empty `prev_hash`, which
+`audit_record_entry` rejects) — leaving the **D02/D23 audit-chain controls
+with no working wheel implementation** (CIRISServer#93, found by the
+CIRISConformance harness).
+
+- New **`Engine.audit_next_chain_position(tenant_id) -> str`** (JSON
+  `{"next_sequence_number": <u64>, "prev_hash": "<64 hex chars>"}`),
+  `#[cfg(feature = "cirisaudit")]`, dispatching to the existing
+  `AuditService::next_chain_position` (Postgres backend / `sqlite_audit`).
+  A fresh tenant chain returns `next_sequence_number = 1` and the GENESIS
+  `prev_hash` (32 zero bytes → 64 hex zeros). The LensAudit flow is then:
+  `pos = audit_next_chain_position(tenant)` → set `sequence_number` /
+  `prev_hash` → canonicalize → sign → `audit_record_entry`; first entry lands
+  at sequence 1 and `audit_verify_chain` verifies. Additive — no change to the
+  existing audit surface.
+- **Tested**: `next_chain_position_genesis_then_increment` (genesis `(1, zeros)`
+  → record → head advances to `(2, tail.entry_hash)`).
+
 ## [10.1.2] — 2026-06-24
 
 ### Changed — re-pin CIRISVerify v7.2.0 → v7.4.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.1.2"
+version = "10.2.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/audit/sqlite.rs
+++ b/src/audit/sqlite.rs
@@ -1654,6 +1654,46 @@ mod tests {
         entry
     }
 
+    /// v10.2.0 (CIRISPersist#281) — `next_chain_position` exposes the
+    /// chain HEAD a client stamps onto the next entry (the value the
+    /// `audit_next_chain_position` PyO3 binding returns): GENESIS
+    /// `(1, zeros)` for a fresh tenant, then `(tail_seq + 1, tail.entry_hash)`
+    /// after a record. This is the exact pair LensAudit needs to build a
+    /// valid entry (CIRISServer#93).
+    #[tokio::test]
+    async fn next_chain_position_genesis_then_increment() {
+        let (_b, audit) = fresh_backend().await;
+        let key = SigningKey::from_bytes(&[0xC2; 32]);
+        let tenant = format!("ncp-{}", Uuid::new_v4().simple());
+
+        // Fresh chain → (1, GENESIS_PREV_HASH).
+        let g = audit.next_chain_position(&tenant).await.unwrap();
+        assert_eq!(g.next_sequence_number, 1, "fresh chain starts at seq 1");
+        assert_eq!(
+            g.prev_hash, GENESIS_PREV_HASH,
+            "fresh chain prev_hash is genesis"
+        );
+
+        // Record entry 1 AT the genesis position the reader handed back.
+        let e1 = build_and_sign(
+            &key,
+            &tenant,
+            g.next_sequence_number,
+            g.prev_hash.to_vec(),
+            "config_change",
+        );
+        audit.record_entry(e1.clone()).await.unwrap();
+
+        // Head advances to (2, e1.entry_hash).
+        let p = audit.next_chain_position(&tenant).await.unwrap();
+        assert_eq!(p.next_sequence_number, 2, "head advances to tail_seq + 1");
+        assert_eq!(
+            p.prev_hash.to_vec(),
+            e1.entry_hash,
+            "head prev_hash is tail.entry_hash"
+        );
+    }
+
     /// v0.8.5 SQLite parity: same lifecycle as the v0.8.1 Postgres
     /// audit test, run against in-memory SQLite.
     #[tokio::test]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -16819,6 +16819,66 @@ impl PyEngine {
         })
     }
 
+    /// v10.2.0 (CIRISPersist#281) — the audit chain HEAD for `tenant_id`:
+    /// the `(next_sequence_number, prev_hash)` a client must stamp onto the
+    /// next chained `AuditEntry` before [`Self::audit_record_entry`].
+    /// Returns JSON `{"next_sequence_number": <u64>, "prev_hash": "<64 hex
+    /// chars>"}`. A brand-new tenant chain returns `next_sequence_number = 1`
+    /// and the GENESIS `prev_hash` (32 zero bytes → 64 hex zeros).
+    ///
+    /// Exposes the internal `AuditService::next_chain_position` so a
+    /// cohabitation client (`LensAudit`, CIRISServer#93) can assemble a
+    /// valid entry over the wheel: `pos = audit_next_chain_position(tenant)`
+    /// → set `sequence_number = pos.next_sequence_number` / `prev_hash =
+    /// pos.prev_hash` → canonicalize → sign → `audit_record_entry`. Cleaner
+    /// (and pre-signable) than reconstructing it from `current_sth` (which
+    /// returns the Merkle tree head, NOT the per-entry `prev_hash`) plus a
+    /// tail `audit_list_entries`.
+    #[cfg(feature = "cirisaudit")]
+    fn audit_next_chain_position(&self, py: Python<'_>, tenant_id: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let tenant_id = tenant_id.to_owned();
+            py.detach(move || {
+                let pos = match &self.backend {
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            use crate::audit::AuditService;
+                            backend
+                                .next_chain_position(&tenant_id)
+                                .await
+                                .map_err(audit_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(_) => {
+                        let audit = self
+                            .sqlite_audit
+                            .as_ref()
+                            .expect(
+                                "v1.5.0 Phase H: sqlite_audit must be Some when backend is Sqlite",
+                            )
+                            .clone();
+                        runtime.block_on(async move {
+                            use crate::audit::AuditService;
+                            audit
+                                .next_chain_position(&tenant_id)
+                                .await
+                                .map_err(audit_err_to_py)
+                        })?
+                    }
+                };
+                Ok(serde_json::json!({
+                    "next_sequence_number": pos.next_sequence_number,
+                    "prev_hash": hex::encode(pos.prev_hash),
+                })
+                .to_string())
+            })
+        })
+    }
+
     /// v1.5.0 Phase H — Generate the full inclusion-proof bundle for
     /// a trust grant. Returns a JSON-serialized
     /// [`crate::federation::read::TrustGrantInclusionProof`] (sth +


### PR DESCRIPTION
## Summary

Fixes **#281** — exposes the audit chain head over the wheel so CIRISServer's `LensAudit` can build a valid chained `AuditEntry` (the **D02/D23 audit-chain controls**, CIRISServer#93, found by the CIRISConformance harness).

`audit_record_entry` requires a fully-formed chained entry (`sequence_number == tail_seq + 1`, `prev_hash == previous entry_hash`, GENESIS = 32 zero bytes for the first). persist computes this internally via `AuditService::next_chain_position`, but it wasn't on the PyO3 surface — so `LensAudit.log_*` sent `sequence_number=0` / empty `prev_hash` and `audit_record_entry` rejected it.

## Change
New **`Engine.audit_next_chain_position(tenant_id) -> str`** (JSON `{"next_sequence_number": <u64>, "prev_hash": "<64 hex chars>"}`), `#[cfg(feature = "cirisaudit")]`, dispatching to the existing `next_chain_position` (Postgres backend / `sqlite_audit`). A fresh tenant chain returns `next_sequence_number = 1` + the GENESIS `prev_hash` (64 hex zeros). LensAudit flow: `pos = audit_next_chain_position(tenant)` → set `sequence_number`/`prev_hash` → canonicalize → sign → `audit_record_entry`. Additive — no change to the existing audit surface.

## Test
`next_chain_position_genesis_then_increment` (genesis `(1, zeros)` → record → head advances to `(2, tail.entry_hash)`). Full gate: **1588 passed / 0 failed**; clippy `-D` across CI + 3 no-default combos; fmt. Verify family unchanged (v7.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)