### PR TITLE
v10.2.1 — #283: postgres audit_log action_type CHECK admits consent_event + wisdom_based_deferral (pg/sqlite parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.2.1] — 2026-06-25
+
+### Fixed — #283: postgres `audit_log.action_type` CHECK rejected `consent_event` + `wisdom_based_deferral` (pg/sqlite parity)
+
+`audit_record_entry` rejected two valid `LensAudit` action types on **postgres**
+that **sqlite accepts** — a backend-parity gap (the same API call works on the
+mobile/embedded sqlite backend, silently breaks on the server postgres backend).
+CIRISServer's `LensAudit` emits `consent_event` (`log_consent_event`) and
+`wisdom_based_deferral` (`log_wbd`); the postgres `audit_log.action_type` CHECK
+(V018/V020) enumerates a closed vocabulary that was missing both. Surfaced by
+the CIRISConformance harness (`test_320`, runs every scenario against both
+backends) once CIRISServer#93 seeded the chain so writes reached the CHECK.
+
+- **Migration V090** extends the postgres CHECK to admit `consent_event` +
+  `wisdom_based_deferral`, following the established additive-evolution pattern
+  (drop + re-add the extended CHECK, `NOT VALID` for legacy rows; CIRISAgent#756
+  Q2's closed-vocab accountability control). **Postgres-only**: sqlite's
+  `audit_log.action_type` is `TEXT NOT NULL` with no CHECK by design (sqlite
+  can't `ADD CONSTRAINT … NOT VALID`, and a table rebuild would re-validate
+  legacy rows), so the closed vocabulary is enforced postgres-side; after V090
+  both backends accept every action type `LensAudit` emits. sqlite/lens/V090 is
+  a documented parity no-op (keeps the version sequence in lockstep).
+- **Tested**: `audit_admits_lensaudit_consent_and_wbd_283` (postgres — exercises
+  the V090 CHECK against live PG) + `…_sqlite` (parity). Verify family unchanged
+  (v7.4.0).
+
 ## [10.2.0] — 2026-06-25
 
 ### Added — #281: `audit_next_chain_position` PyO3 binding (audit chain head)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.2.0"
+version = "10.2.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V090__audit_action_type_lensaudit.sql
+++ b/migrations/postgres/lens/V090__audit_action_type_lensaudit.sql
@@ -1,0 +1,71 @@
+-- V090 — extend cirislens.audit_log.action_type CHECK to admit the
+-- LensAudit consent + wisdom-based-deferral vocabulary (CIRISPersist#283).
+--
+-- CIRISServer's `LensAudit` emits `consent_event` (`log_consent_event`) and
+-- `wisdom_based_deferral` (`log_wbd`). Both are accepted on SQLite (whose
+-- `audit_log.action_type` is `TEXT NOT NULL` with no CHECK — see below) but
+-- were REJECTED by the postgres CHECK, a backend-parity gap that surfaced as
+-- a postgres-only failure in the CIRISConformance audit-accountability test
+-- (`test_320`) once CIRISServer#93 seeded the chain so the writes reached the
+-- CHECK.
+--
+-- Additive-only evolution, per the V018/V020 pattern (CIRISAgent#756 Q2):
+-- DROP the existing constraint + ADD the extended one; `NOT VALID` lets any
+-- legacy rows skip validation (the followup VALIDATE pass can run after a
+-- backfill). The audit hash-chain + per-entry signature remain the real
+-- integrity gate; this allowlist is the agent-team's closed-vocab
+-- accountability control.
+--
+-- Why postgres-only: SQLite's `audit_log` deliberately carries NO action_type
+-- CHECK (V014). SQLite cannot `ADD CONSTRAINT ... NOT VALID`, and a 12-step
+-- table rebuild would re-validate EVERY existing row against the new CHECK on
+-- the `INSERT ... SELECT` copy — which would fail on any legacy out-of-vocab
+-- row. So the closed vocabulary is enforced postgres-side only; SQLite treats
+-- `action_type` as an opaque producer string. After this migration both
+-- backends accept every action type `LensAudit` emits (behavioural parity for
+-- all legitimate calls). See sqlite/lens/V090 (parity note).
+--
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+ALTER TABLE cirislens.audit_log
+    DROP CONSTRAINT IF EXISTS audit_log_action_type_check;
+
+ALTER TABLE cirislens.audit_log
+    ADD CONSTRAINT audit_log_action_type_check
+    CHECK (action_type IN (
+        -- Handler actions (V018)
+        'handler_action_speak',
+        'handler_action_memorize',
+        'handler_action_recall',
+        'handler_action_forget',
+        'handler_action_tool',
+        'handler_action_defer',
+        'handler_action_reject',
+        'handler_action_ponder',
+        'handler_action_observe',
+        'handler_action_task_complete',
+
+        -- System events (V018)
+        'system_event',
+        'security_event',
+        'config_change',
+        'service_lifecycle',
+        'error_event',
+
+        -- Wallet events (V018)
+        'wallet_funds_received',
+        'wallet_funds_sent',
+        'wallet_transfer_failed',
+        'wallet_swap_completed',
+        'wallet_swap_failed',
+        'wallet_security_event',
+
+        -- Trust hierarchy state transitions (V020 — CIRISPersist#47)
+        'trust_granted',
+        'trust_revoked',
+
+        -- LensAudit consent + wisdom-based deferral (V090 — CIRISPersist#283)
+        'consent_event',
+        'wisdom_based_deferral'
+    ))
+    NOT VALID;

--- a/migrations/sqlite/lens/V090__audit_action_type_lensaudit.sql
+++ b/migrations/sqlite/lens/V090__audit_action_type_lensaudit.sql
@@ -1,0 +1,19 @@
+-- V090 — parity note for postgres/lens/V090 (CIRISPersist#283). NO-OP.
+--
+-- Postgres V090 extends the `audit_log.action_type` CHECK to admit the
+-- LensAudit `consent_event` + `wisdom_based_deferral` vocabulary. SQLite has
+-- NOTHING to do here: `cirislens_audit_log.action_type` is `TEXT NOT NULL`
+-- with NO CHECK (V014) — it already accepts every action type. The closed
+-- vocabulary is enforced postgres-side only, because SQLite cannot
+-- `ADD CONSTRAINT ... NOT VALID` and a table rebuild would re-validate legacy
+-- rows against the new CHECK. So `action_type` is an opaque producer string
+-- on SQLite by design; the audit hash-chain + signature are the integrity
+-- gate. After postgres V090 both backends accept the same vocabulary
+-- (behavioural parity for every LensAudit call).
+--
+-- This migration only re-asserts the existing (V014) action_type index
+-- `IF NOT EXISTS` so the version sequence stays in lockstep with postgres.
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+CREATE INDEX IF NOT EXISTS audit_log_action_type
+    ON cirislens_audit_log (action_type);

--- a/src/audit/postgres.rs
+++ b/src/audit/postgres.rs
@@ -1592,6 +1592,49 @@ mod tests {
         entry
     }
 
+    /// v10.2.1 (CIRISPersist#283) — the postgres `audit_log.action_type`
+    /// CHECK admits the LensAudit `consent_event` (`log_consent_event`) +
+    /// `wisdom_based_deferral` (`log_wbd`) vocabulary (V090). These record
+    /// fine on SQLite (no CHECK) but were CHECK-rejected on postgres — the
+    /// backend-parity gap CIRISConformance `test_320` surfaced.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn audit_admits_lensaudit_consent_and_wbd_283() {
+        use crate::store::backend::Backend;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let key = SigningKey::from_bytes(&[0xC3; 32]);
+        let tenant = format!("audit-283-{}", Uuid::new_v4().simple());
+
+        let e1 = build_and_sign(
+            &key,
+            &tenant,
+            1,
+            GENESIS_PREV_HASH.to_vec(),
+            "consent_event",
+        );
+        backend
+            .record_entry(e1.clone())
+            .await
+            .expect("consent_event must be admitted by the V090 CHECK");
+        let e2 = build_and_sign(
+            &key,
+            &tenant,
+            2,
+            e1.entry_hash.clone(),
+            "wisdom_based_deferral",
+        );
+        backend
+            .record_entry(e2)
+            .await
+            .expect("wisdom_based_deferral must be admitted by the V090 CHECK");
+    }
+
     /// v0.8.1 (CIRISPersist#35) — end-to-end audit log lifecycle:
     /// genesis insert, chain extend, verify_chain Ok, replay
     /// rejection, chain-fork rejection, tenant isolation, verify

--- a/src/audit/sqlite.rs
+++ b/src/audit/sqlite.rs
@@ -1694,6 +1694,35 @@ mod tests {
         );
     }
 
+    /// v10.2.1 (CIRISPersist#283) — SQLite parity: the LensAudit
+    /// `consent_event` + `wisdom_based_deferral` action types record fine
+    /// (SQLite's `action_type` is unconstrained — the postgres CHECK is what
+    /// V090 extends to match). The postgres counterpart
+    /// (`audit_admits_lensaudit_consent_and_wbd_283`) exercises the CHECK.
+    #[tokio::test]
+    async fn audit_admits_lensaudit_consent_and_wbd_283_sqlite() {
+        let (_b, audit) = fresh_backend().await;
+        let key = SigningKey::from_bytes(&[0xC3; 32]);
+        let tenant = format!("audit-283-{}", Uuid::new_v4().simple());
+
+        let e1 = build_and_sign(
+            &key,
+            &tenant,
+            1,
+            GENESIS_PREV_HASH.to_vec(),
+            "consent_event",
+        );
+        audit.record_entry(e1.clone()).await.expect("consent_event");
+        let e2 = build_and_sign(
+            &key,
+            &tenant,
+            2,
+            e1.entry_hash.clone(),
+            "wisdom_based_deferral",
+        );
+        audit.record_entry(e2).await.expect("wisdom_based_deferral");
+    }
+
     /// v0.8.5 SQLite parity: same lifecycle as the v0.8.1 Postgres
     /// audit test, run against in-memory SQLite.
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes **#283** — a pg/sqlite **parity** bug. `audit_record_entry` rejected two valid `LensAudit` action types on **postgres** that **sqlite accepts**: the same API call works on the mobile/embedded sqlite backend but silently broke on the server postgres backend.

CIRISServer's `LensAudit` emits `consent_event` (`log_consent_event`) and `wisdom_based_deferral` (`log_wbd`); the postgres `audit_log.action_type` CHECK (V018/V020 — a deliberate closed vocabulary, CIRISAgent#756 Q2) enumerated neither. Found by the CIRISConformance harness (`test_320`, every scenario against both backends) once CIRISServer#93 seeded the chain so writes reached the CHECK.

## Fix
**Migration V090** extends the postgres CHECK to admit `consent_event` + `wisdom_based_deferral`, following the established additive pattern (drop + re-add the extended CHECK, `NOT VALID` for legacy rows).

**Postgres-only by design:** sqlite's `audit_log.action_type` is `TEXT NOT NULL` with no CHECK — sqlite can't `ADD CONSTRAINT … NOT VALID`, and a table rebuild would re-validate legacy rows against the new CHECK. So the closed vocabulary is enforced postgres-side; after V090 both backends accept every action type `LensAudit` emits (behavioural parity for all legitimate calls). `sqlite/lens/V090` is a documented parity no-op (keeps the version sequence in lockstep).

## Test
`audit_admits_lensaudit_consent_and_wbd_283` (postgres — exercises the V090 CHECK against live PG) + `…_sqlite` (parity). Full gate: **1590 passed / 0 failed**; clippy `-D` across CI + 3 no-default combos; fmt. Verify family unchanged (v7.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)