### PR TITLE
v10.2.2 — re-pin CIRISVerify v7.4.0 → v7.5.0 (wheel concurrence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.2.2] — 2026-06-25
+
+### Changed — re-pin CIRISVerify v7.4.0 → v7.5.0 (wheel concurrence)
+
+- All six git-tag verify crates flipped in lockstep; family floor `version = "7"` unchanged; wheel `Requires-Dist` floor stays `ciris-verify>=7.0.0,<8`. v7.5.0 is a `ciris-keyring` build-portability fix — keyring builds on **musl** (CIRISVerify#127) + the wheel loads on **bare hosts** (CIRISVerify#125), plus verify's own CIRISCache CI adoption. No change to persist's consumed Rust APIs (`verify_hybrid` / `canonical` / `jcs` / `threshold` / `transparency` / `xchacha` / `hkdf` / `hmac` / `fedcode` / `accord_genesis`) — confirmed by a clean compile + full gate. Family-floor / wheel-concurrence re-pin only; no persist code change.
+
 ## [10.2.1] — 2026-06-25
 
 ### Fixed — #283: postgres `audit_log.action_type` CHECK rejected `consent_event` + `wisdom_based_deferral` (pg/sqlite parity)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.2.1"
+version = "10.2.2"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the


### PR DESCRIPTION
All six git-tag verify crates flipped to v7.5.0 in lockstep; family floor `version = "7"` unchanged; wheel `Requires-Dist` stays `ciris-verify>=7.0.0,<8`.

v7.5.0 is a `ciris-keyring` build-portability fix — keyring builds on **musl** (CIRISVerify#127) + the wheel loads on **bare hosts** (CIRISVerify#125), plus verify's own CIRISCache CI adoption. **No change to persist's consumed Rust APIs** — confirmed by a clean compile + full gate. Family-floor / wheel-concurrence re-pin only; no persist code change.

Gate: **1590 passed / 0 failed**; clippy `-D` across CI + 3 no-default combos; fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)