### PR TITLE
v10.3.0 — #288: enforce reserved-prefix admission on attestation_type (CC 3.4.1/3.4.3/3.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.3.0] — 2026-06-25
+
+### Fixed — #288: enforce reserved-prefix admission on the `attestation_type` namespace (CC 3.4.1 / 3.4.3 / 3.4.5)
+
+`emit_attestation_self` / `emit_attestation` / `put_attestation` admitted
+attestation **types** the Constitution reserves to specific `identity_type`s —
+the substrate accepted attestations it MUST reject. The pre-existing
+`DimensionAdmissionPolicy::check` only gated the **`dimension`** field of
+`scores` rows, so an attestation whose **type** is `accord:invoke:*` /
+`system:audit_chain:*` / `capacity:*` slipped through (any `identity_type` could
+emit it). Found by the CIRISConformance harness (`test_240`).
+
+- New **`admission::check_reserved_prefix_admission`**, wired into
+  `put_attestation` on **all three backends** (the chokepoint — covers
+  `emit_attestation_self` / `emit_attestation` / direct writes / replicated rows
+  alike, keyed on the *attesting* key's `identity_type` so it's node-independent):
+  - `accord:*` → `accord_holder` only (CC 3.4.1 — the one constitutional asymmetry)
+  - `system:*` / `audit_chain:*` / `corpus_health:*` / … → per the reserved-prefix
+    rule table (CC 3.4.3 — substrate-self-report)
+  - `hard_case:*` → `substrate_persist` only (substrate-emitted)
+  - `capacity:*` → MUST NOT be self-emitted (`attesting_key_id == attested_key_id`)
+    — CC 3.4.5's "Critical enforcement" anti-Goodhart rule (an attester==attested
+    check, independent of identity_type)
+- New typed error **`Error::CapacitySelfEmissionRejected`** (kind
+  `federation_capacity_self_emission_rejected`); the prefix/identity rejections
+  reuse `AccordDimensionRequiresAccordHolder` / `ReservedPrefixEmitterMismatch`.
+  All surface as `ValueError` over the FFI (caller-fault admission rejection).
+- Structural primitives (`scores` / `delegates_to` / …) and non-reserved types
+  fast-exit with no directory lookup. persist emits none of these prefixes
+  itself, so no self-breakage.
+- **Tested**: the issue's three repro cases reject + the authorized contrasts
+  pass (accord_holder emits `accord:*`, substrate_persist emits `system:*` /
+  `hard_case:*`, non-self `capacity:*`), backend-agnostic. Verify family
+  unchanged (v7.5.0).
+
 ## [10.2.2] — 2026-06-25
 
 ### Changed — re-pin CIRISVerify v7.4.0 → v7.5.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.2.2"
+version = "10.3.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -336,15 +336,14 @@ impl Default for DimensionAdmissionPolicy {
 ///   layer (see [`DimensionAdmissionPolicy::check`] Layer 1) so its
 ///   typed error variant stays distinct
 ///   ([`super::Error::AccordDimensionRequiresAccordHolder`]).
-/// - `capacity:*` self-emission rejection (CEG §7.5) is NOT in this
-///   table — it's an attester==attested check, not an identity-type
-///   check, and lives at the consumer composition layer per §7.5's
-///   anti-Goodhart commentary. The substrate's reserved-prefix gate
-///   doesn't enforce it because the substrate doesn't see the
-///   attester==attested distinction except at the row level (the
-///   `Attestation` row carries `attesting_key_id` + `attested_key_id`;
-///   the admission gate only knows the attester's identity-type, not
-///   whether the two keys are the same row).
+/// - `capacity:*` self-emission rejection (CEG §7.5 / CC 3.4.5) is NOT in
+///   this *dimension* table — it's an attester==attested check, not an
+///   identity-type check. As of v10.3.0 (CIRISPersist#288) it IS
+///   substrate-enforced, on the `attestation_type` namespace at the
+///   `put_attestation` chokepoint by
+///   [`check_reserved_prefix_admission`] (which sees the row-level
+///   `attesting_key_id` == `attested_key_id` distinction the
+///   identity-type-only `DimensionAdmissionPolicy::check` cannot).
 /// - `licensure:*` (CEG §7.3) is co-owned — the admission gate
 ///   doesn't reject single-source emissions; per §7.3, consumers
 ///   mark them `confidence ≤ 0.5` until the second co-owner attests.
@@ -2941,6 +2940,95 @@ pub async fn check_node_agency_admission(
         attested_key_id: row.attested_key_id.clone(),
         offending_scopes,
     })
+}
+
+/// v10.3.0 (CIRISPersist#288, CC 3.4.1 / 3.4.3 / 3.4.5) — reserved-prefix
+/// admission on the **`attestation_type`** namespace, keyed on the attesting
+/// key's `identity_type`.
+///
+/// The Constitution reserves whole `attestation_type` prefixes to specific
+/// emitter classes. The pre-existing [`DimensionAdmissionPolicy::check`] only
+/// gates the **`dimension`** field of `scores` rows — so an attestation whose
+/// **type** is `accord:invoke:*` / `system:audit_chain:*` / `capacity:*`
+/// slipped through unchecked (any `identity_type` could emit it). This gate
+/// closes that, at the `put_attestation` chokepoint (so it covers
+/// `emit_attestation` / `emit_attestation_self` / direct writes / replicated
+/// rows alike — keyed on the *attesting* key's identity_type, which is
+/// node-independent):
+///
+/// - `accord:*` → `accord_holder` only (CC 3.4.1 — the one constitutional
+///   asymmetry).
+/// - `system:*` / `audit_chain:*` / `corpus_health:*` / … → per the
+///   [`default_reserved_prefix_rules`] table (CC 3.4.3 — substrate-self-report).
+/// - `hard_case:*` → `substrate_persist` only (substrate-emitted).
+/// - `capacity:*` → MUST NOT be self-emitted (`attesting_key_id ==
+///   attested_key_id`) — CC 3.4.5's "Critical enforcement" anti-Goodhart rule
+///   (an `identity_type`-independent attester==attested check).
+///
+/// Structural primitives (`scores` / `delegates_to` / `supersedes` /
+/// `withdraws` / `recants`) and any non-reserved type fast-exit with no
+/// directory lookup.
+pub async fn check_reserved_prefix_admission(
+    directory: &dyn super::FederationDirectory,
+    row: &super::Attestation,
+) -> Result<(), Error> {
+    use super::types::identity_type;
+    let at = row.attestation_type.as_str();
+
+    // CC 3.4.5 — capacity:* self-emission. Cheapest check (no lookup); an
+    // attester==attested rule independent of identity_type.
+    if at.starts_with("capacity:") && row.attesting_key_id == row.attested_key_id {
+        return Err(Error::CapacitySelfEmissionRejected {
+            key_id: row.attesting_key_id.clone(),
+            attestation_type: at.to_owned(),
+        });
+    }
+
+    // Which (if any) identity-gated reserved prefix does the TYPE carry?
+    let is_accord = at.starts_with("accord:");
+    let is_hard_case = at.starts_with("hard_case:");
+    let matched_rule = default_reserved_prefix_rules()
+        .into_iter()
+        .find(|r| at.starts_with(r.pattern_prefix.as_str()));
+    if !is_accord && !is_hard_case && matched_rule.is_none() {
+        return Ok(()); // not a reserved type — no lookup needed.
+    }
+
+    // Resolve the attester's identity_type (an unregistered/unknown attester
+    // resolves to "" — fail-secure: it satisfies no reserved-prefix rule).
+    let got = directory
+        .lookup_public_key(&row.attesting_key_id)
+        .await?
+        .map(|k| k.identity_type)
+        .unwrap_or_default();
+
+    if is_accord && got != identity_type::ACCORD_HOLDER {
+        return Err(Error::AccordDimensionRequiresAccordHolder {
+            dimension: at.to_owned(),
+            identity_type: got,
+        });
+    }
+    if is_hard_case && got != identity_type::SUBSTRATE_PERSIST {
+        return Err(Error::ReservedPrefixEmitterMismatch {
+            dimension: at.to_owned(),
+            prefix: "hard_case:".to_owned(),
+            required: vec![identity_type::SUBSTRATE_PERSIST.to_owned()],
+            got_identity_type: got,
+        });
+    }
+    if let Some(rule) = matched_rule {
+        if !rule.required_identity_types.contains(&got) {
+            let mut required = rule.required_identity_types.clone();
+            required.sort();
+            return Err(Error::ReservedPrefixEmitterMismatch {
+                dimension: at.to_owned(),
+                prefix: rule.pattern_prefix.clone(),
+                required,
+                got_identity_type: got,
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -2919,6 +2919,24 @@ pub enum Error {
         got_identity_type: String,
     },
 
+    /// v10.3.0 (CIRISPersist#288, CC 3.4.5). A `capacity:*` attestation
+    /// was self-emitted (`attesting_key_id == attested_key_id`). The
+    /// Constitution's "Critical enforcement" rule: a `capacity:*` score
+    /// MUST NOT be self-emitted — the agent's own capacity score is never
+    /// fed back into the agent's own context (anti-Goodhart). Rejected at
+    /// admission; the row is not stored. Unlike the identity-type prefix
+    /// rules, this is an attester==attested check, not an identity check.
+    #[error(
+        "capacity:* self-emission rejected: attesting_key_id == attested_key_id ({key_id:?}) — \
+         a capacity score must not be self-emitted (CC 3.4.5; attestation_type={attestation_type:?})"
+    )]
+    CapacitySelfEmissionRejected {
+        /// The key that attempted to self-emit a `capacity:*` attestation.
+        key_id: String,
+        /// The `attestation_type` that triggered the rejection.
+        attestation_type: String,
+    },
+
     /// v2.5.0 (CIRISPersist#102 Ask 4). The submitted `scores`
     /// attestation's `attestation_envelope` failed JSON Schema
     /// validation against the per-axis schema registered for the
@@ -3449,6 +3467,9 @@ impl Error {
                 "federation_accord_dimension_requires_accord_holder"
             }
             Error::DimensionRejected { .. } => "federation_dimension_rejected",
+            Error::CapacitySelfEmissionRejected { .. } => {
+                "federation_capacity_self_emission_rejected"
+            }
             Error::ReservedPrefixEmitterMismatch { .. } => {
                 "federation_reserved_prefix_emitter_mismatch"
             }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -22812,7 +22812,10 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // v3.0.0 (CIRISPersist#116, CEG 0.2 §7.0) — reserved-prefix
         // emitter mismatch is caller-fault malformed-content; same
         // shape as the other admission-gate rejections.
-        crate::federation::Error::ReservedPrefixEmitterMismatch { .. } => {
+        // v10.3.0 (#288, CC 3.4.5) — capacity:* self-emission is the same
+        // admission-gate-rejection shape (caller-fault, ValueError).
+        crate::federation::Error::ReservedPrefixEmitterMismatch { .. }
+        | crate::federation::Error::CapacitySelfEmissionRejected { .. } => {
             PyValueError::new_err(kind)
         }
         // v3.9.1 (CIRISPersist#150 Ask 3) — cohort_scope admission

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1289,6 +1289,11 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // emission leaves no trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
+        // admission on the attestation_TYPE namespace, keyed on the attesting
+        // key's identity_type. Backend-symmetric with SQLite + Postgres.
+        crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate (parity with the postgres + sqlite backends). A
@@ -8638,5 +8643,114 @@ mod tests {
         assert!(inbound.iter().all(
             |a| a.attestation_type == crate::federation::types::attestation_type::DELEGATES_TO
         ));
+    }
+
+    /// #288 (CC 3.4.1/3.4.3/3.4.5) — reserved-prefix admission on the
+    /// attestation_TYPE, keyed on the attesting key's identity_type:
+    /// `accord:*`→accord_holder, `system:*`→substrate_persist,
+    /// `hard_case:*`→substrate_persist, `capacity:*`→no self-emission.
+    /// Reproduces the issue's three repro cases + the authorized contrast.
+    #[tokio::test]
+    async fn check_reserved_prefix_admission_enforces_cc_3_4_x_288() {
+        use crate::federation::admission::check_reserved_prefix_admission;
+        let backend = MemoryBackend::new();
+        for (k, it) in [
+            ("rp-agent", "agent"),
+            ("rp-accord", "accord_holder"),
+            ("rp-substrate", "substrate_persist"),
+        ] {
+            let mut rec = fix_key(k, "ref", k);
+            rec.identity_type = it.to_owned();
+            backend
+                .put_public_key(SignedKeyRecord { record: rec })
+                .await
+                .unwrap();
+        }
+        // Build a minimal row with a given type + attesting/attested keys.
+        // (The gate reads only attestation_type + attesting/attested key_id.)
+        let row = |attn: &str, attesting: &str, attested: &str| {
+            let mut a = fix_attestation("rp-att", attesting, attested, attesting);
+            a.attestation_type = attn.to_owned();
+            a
+        };
+
+        // accord:* — agent REJECTED (CC 3.4.1), accord_holder OK.
+        let e = check_reserved_prefix_admission(
+            &backend,
+            &row("accord:invoke:notify:x", "rp-agent", "rp-agent"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            e.kind(),
+            "federation_accord_dimension_requires_accord_holder"
+        );
+        check_reserved_prefix_admission(
+            &backend,
+            &row("accord:invoke:notify:x", "rp-accord", "rp-accord"),
+        )
+        .await
+        .expect("accord_holder may emit accord:*");
+
+        // capacity:* — self-emission REJECTED (CC 3.4.5); non-self OK (any id).
+        let e = check_reserved_prefix_admission(
+            &backend,
+            &row("capacity:composite", "rp-agent", "rp-agent"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(e.kind(), "federation_capacity_self_emission_rejected");
+        check_reserved_prefix_admission(
+            &backend,
+            &row("capacity:composite", "rp-agent", "rp-accord"),
+        )
+        .await
+        .expect("non-self capacity:* is allowed");
+
+        // system:* — agent REJECTED (CC 3.4.3), substrate_persist OK.
+        let e = check_reserved_prefix_admission(
+            &backend,
+            &row("system:audit_chain:hash_continuity", "rp-agent", "rp-agent"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(e.kind(), "federation_reserved_prefix_emitter_mismatch");
+        check_reserved_prefix_admission(
+            &backend,
+            &row(
+                "system:audit_chain:hash_continuity",
+                "rp-substrate",
+                "rp-substrate",
+            ),
+        )
+        .await
+        .expect("substrate_persist may emit system:*");
+
+        // hard_case:* — agent REJECTED, substrate_persist OK.
+        let e = check_reserved_prefix_admission(
+            &backend,
+            &row("hard_case:promotion_overdue", "rp-agent", "rp-agent"),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(e.kind(), "federation_reserved_prefix_emitter_mismatch");
+        check_reserved_prefix_admission(
+            &backend,
+            &row(
+                "hard_case:promotion_overdue",
+                "rp-substrate",
+                "rp-substrate",
+            ),
+        )
+        .await
+        .expect("substrate_persist may emit hard_case:*");
+
+        // Non-reserved types fast-exit OK regardless of identity_type.
+        check_reserved_prefix_admission(&backend, &row("scores", "rp-agent", "rp-agent"))
+            .await
+            .expect("scores is not a reserved type");
+        check_reserved_prefix_admission(&backend, &row("delegates_to", "rp-agent", "rp-accord"))
+            .await
+            .expect("delegates_to is not a reserved type");
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2479,6 +2479,13 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         // no trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
+        // admission on the attestation_TYPE namespace (accord:* → accord_holder;
+        // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →
+        // substrate_persist; capacity:* → no self-emission), keyed on the
+        // attesting key's identity_type. Backend-symmetric with SQLite + memory.
+        crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate. A no-op for local-tier rows (CC 5.3.2.2 deferred

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2166,6 +2166,14 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
+        // admission on the attestation_TYPE namespace (accord:* → accord_holder;
+        // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →
+        // substrate_persist; capacity:* → no self-emission), keyed on the
+        // attesting key's identity_type. Runs BEFORE persist_row_hash + INSERT
+        // so a rejected emission leaves no trace.
+        crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate (parity with the postgres + memory backends). A


### PR DESCRIPTION
## Summary

Fixes **#288** — a substrate **constitutional-enforcement gap**. `emit_attestation_self` / `emit_attestation` / `put_attestation` admitted attestation **types** the Constitution reserves to specific `identity_type`s.

The pre-existing `DimensionAdmissionPolicy::check` only gates the **`dimension`** field of `scores` rows — so an attestation whose **type** is `accord:invoke:*` / `system:audit_chain:*` / `capacity:*` slipped through (any `identity_type` could emit it). Found by the CIRISConformance harness (`test_240`).

## Fix
New **`admission::check_reserved_prefix_admission`**, wired into `put_attestation` on **all three backends** (the chokepoint — covers `emit_attestation_self`/`emit_attestation`/direct writes/replicated rows, keyed on the **attesting** key's `identity_type` so it's node-independent):
- `accord:*` → `accord_holder` only (CC 3.4.1 — the one constitutional asymmetry)
- `system:*` / `audit_chain:*` / `corpus_health:*` / … → per the reserved-prefix rule table (CC 3.4.3 — substrate-self-report)
- `hard_case:*` → `substrate_persist` only (substrate-emitted)
- `capacity:*` → MUST NOT be self-emitted (`attesting_key_id == attested_key_id`) — CC 3.4.5's "Critical enforcement" anti-Goodhart rule (an attester==attested check, independent of identity_type)

New typed `Error::CapacitySelfEmissionRejected` (`federation_capacity_self_emission_rejected`); the prefix/identity rejections reuse `AccordDimensionRequiresAccordHolder` / `ReservedPrefixEmitterMismatch`. All map to `ValueError` over the FFI. Structural primitives + non-reserved types fast-exit with no directory lookup; persist emits none of these prefixes itself, so no self-breakage.

## Test
The issue's three repro cases reject + the authorized contrasts pass (accord_holder emits `accord:*`, substrate_persist emits `system:*`/`hard_case:*`, non-self `capacity:*`), backend-agnostic. Full gate: **1591 passed / 0 failed**; clippy `-D` across CI + 3 no-default combos; fmt. Verify family unchanged (v7.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)