### PR TITLE
v10.4.0 — #290: put_community_json PyO3 binding (resolves #289 too)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.4.0] — 2026-06-25
+
+### Added — #290: `put_community_json` PyO3 binding (closes the put_family/put_community FFI asymmetry; also resolves #289)
+
+`put_family_json` was on the PyO3 `Engine` but **`put_community_json` was not**,
+even though the `put_community` backend trait method + both stores have always
+implemented it. So from Python there was no way to bring a community into
+existence (`add_community_member` hard-requires the community to already exist) —
+which left the §11.10 moderation-authority walk's authority set always empty, so
+`is_named_moderator` / `moderators_of` could never resolve, and the positive
+moderation path (appoint → recognize → `file_moderation`) was undrivable. Found
+by the CIRISConformance harness (`test_270`).
+
+- New **`Engine.put_community_json(payload_json)`**, symmetric to
+  `put_family_json`: a **flat** `Community` object (`persist_row_hash`
+  backend-computed — pass `""`; `community_key_id` + each member `key_id` FK
+  `federation_keys`; the CC 3.2 owner-binding `UnownedCommunityMember` gate
+  applies to agent/node members). Pure FFI exposure — no backend change.
+- **Resolves #289 too**: the *family* half of that seam was already drivable
+  (`put_family_json` + the `cohort_*` member ops, `test_260` green); the
+  community half was the only gap, and creating a community from Python also
+  makes the membership-**quorum** gate (`cohort_verify_membership_quorum`)
+  drivable end-to-end (create group → add members → change envelope →
+  sub-majority sigs → assert refusal).
+- **Tested**: a Python wheel round-trip (`put_community_json` →
+  `lookup_community_json`). Verify family unchanged (v7.5.0).
+
 ## [10.3.0] — 2026-06-25
 
 ### Fixed — #288: enforce reserved-prefix admission on the `attestation_type` namespace (CC 3.4.1 / 3.4.3 / 3.4.5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.3.0"
+version = "10.4.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -6126,6 +6126,50 @@ impl PyEngine {
         })
     }
 
+    /// v10.4.0 (CIRISPersist#290) — admit a `Community` row, symmetric to
+    /// [`Self::put_family_json`]. The `put_community` backend trait method
+    /// has always existed; only the PyO3 exposure was missing — so from
+    /// Python there was no way to bring a community into existence, which
+    /// left the §11.10 moderation-authority walk's authority set always
+    /// empty (`is_named_moderator` / `moderators_of` could never resolve).
+    ///
+    /// `payload_json` is a **flat** `Community` object (not wrapped); like
+    /// the family path, `persist_row_hash` is backend-computed (pass `""`),
+    /// and `community_key_id` + each member `key_id` must FK a registered
+    /// `federation_keys` row.
+    fn put_community_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let community: crate::federation::Community = serde_json::from_str(payload_json)
+                .map_err(|e| PyValueError::new_err(format!("community decode: {e}")))?;
+            let signed = crate::federation::SignedCommunity { community };
+            py.detach(move || match &self.backend {
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::FederationDirectory;
+                        backend
+                            .put_community(signed)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        use crate::federation::FederationDirectory;
+                        backend
+                            .put_community(signed)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
     /// v3.12.0 — fetch a single family by `family_key_id`. Returns
     /// JSON `Family` object or `None` (null).
     fn lookup_family_json(&self, py: Python<'_>, family_key_id: &str) -> PyResult<Option<String>> {

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -356,3 +356,61 @@ def test_register_self_then_put_blob_signing_275() -> None:
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()
+
+
+def test_put_community_json_round_trip_290() -> None:
+    """v10.4.0 (CIRISPersist#290) — `put_community_json` brings a community
+    into existence over the wheel (symmetric with `put_family_json`). Before
+    this, the only community surfaces were add/lookup/active — none could
+    CREATE one — so the §11.10 moderation-authority walk's authority set was
+    always empty. Round-trips create → lookup. Skips on a non-sqlite wheel."""
+    import json
+    import os
+    import secrets
+    import tempfile
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    seed = os.path.join(tempfile.mkdtemp(), "seed")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "node-" + secrets.token_hex(8)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:", alias, local_key_id=alias, local_key_path=seed
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        # The community_key_id + each member must FK a registered
+        # federation_keys row. Register as `primitive` — the put_community
+        # owner-binding gate (CC 3.2 UnownedCommunityMember) is exempt for
+        # primitive identities; agent/node members would need an owner-
+        # binding chain (which the conformance harness supplies in the real
+        # moderation flow, but isn't needed to prove the FFI admits a row).
+        kid = eng.register_self_federation_key("primitive", "ref", None, None, None)
+        now = "2026-06-25T00:00:00.000Z"
+        eng.put_community_json(
+            json.dumps(
+                {
+                    "community_key_id": kid,
+                    "community_name": "T",
+                    "members": [{"key_id": kid, "joined_at": now, "role": "founder"}],
+                    "founded_at": now,
+                    "consensus_protocol": "majority",
+                    "policy_blob": None,
+                    "persist_row_hash": "",
+                }
+            )
+        )
+        # The community now exists + is readable (the authority root the
+        # §11.10 moderation walk needs).
+        got = json.loads(eng.lookup_community_json(kid))
+        assert got["community_key_id"] == kid
+        assert any(m["key_id"] == kid for m in got["members"]), got
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()


### PR DESCRIPTION
Fixes **#290** (and resolves **#289**) — exposes `Engine.put_community_json(payload_json)` on the PyO3 surface, symmetric to `put_family_json`.

`put_community` has always existed on the backend trait + both stores; only the FFI exposure was missing — so from Python there was **no way to create a community** (`add_community_member` requires it to exist first). That left the §11.10 moderation-authority walk's authority set always empty, so `is_named_moderator` / `moderators_of` could never resolve and the positive moderation path was undrivable (CIRISConformance `test_270`).

Flat `Community` object; `persist_row_hash` backend-computed (pass `""`); `community_key_id` + each member `key_id` FK `federation_keys` (the CC 3.2 owner-binding `UnownedCommunityMember` gate applies to agent/node members). Pure FFI exposure — no backend change.

**Resolves #289**: the *family* half of that seam was already drivable (`put_family_json` + the `cohort_*` member ops, `test_260` green); the community half was the only gap, and creating a community from Python also makes the membership-quorum gate drivable end-to-end.

Test: Python wheel round-trip (`put_community_json` → `lookup_community_json`). Gate: 1587 tests + python suite (10); clippy `-D` CI + 3 no-default; fmt. Verify family unchanged (v7.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)