### PR TITLE
v10.5.0 — #293: reject non-lowercase-hex subject_key_ids[] at emit admission (CC 2.6.3 / §0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.5.0] — 2026-06-25
+
+### Fixed — #293: `emit_attestation`/`emit_attestation_self` admitted non-lowercase-hex `subject_key_ids[]` (CC 2.6.3 / §0.6) — residual of #288
+
+The reserved-prefix half of #288 (`accord:*` / `capacity:*`-self / `system:*`)
+shipped in 10.4.0, but the **subject-key canonical-form half stayed open**: the
+emit path admitted a `subject_key_ids[]` element that was not canonical
+lowercase (e.g. an uppercase-hex subject id), which CC 2.6.3 / CEG §0.6 forbid
+because a wrong-case subject id breaks byte-identical canonicalization for
+downstream verifiers — two encodings of the same subject would both admit.
+
+The §0.6/§0.8 lowercase-canonical rejection was already enforced on adjacent
+fields (`location.rs` `cell_id`, `media_sharing.rs` content hashes); the gap was
+that the **emit path's `subject_key_ids` was never run through it**. Fixed by
+`federation::validate_subject_key_ids`, called in the shared
+`emit_attestation_assemble` body — so **both** `emit_attestation(&signer, …)`
+and `emit_attestation_self(…)` enforce it identically, on sqlite and postgres
+alike (engine-level, no backend asymmetry). A subject id is a federation
+key_id — on real nodes the derived `"<label>-<fingerprint>"` shape, all
+lowercase by construction — so the rule rejects any ASCII-uppercase (or empty)
+element rather than a strict `0-9a-f` charset (which would wrongly reject the
+legitimate `-`-bearing label). The canonical lowercase form of the same id is
+admitted: the rule rejects the *encoding*, not the subject. Closes the
+CIRISConformance `test_240::test_subject_key_ids_must_be_lowercase_hex`
+`xfail(strict=True)` (XPASSes the moment the rule lands).
+
 ## [10.4.0] — 2026-06-25
 
 ### Added — #290: `put_community_json` PyO3 binding (closes the put_family/put_community FFI asymmetry; also resolves #289)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.4.0"
+version = "10.5.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1998,6 +1998,13 @@ impl Engine {
         use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
         use sha2::{Digest, Sha256};
 
+        // CIRISPersist#293 (CC 2.6.3 / §0.6) — refuse a non-canonical
+        // (uppercase / empty) subject id at admission, before the row is
+        // assembled. Covers BOTH emit entry points (this is their shared
+        // body), so `emit_attestation` and `emit_attestation_self` enforce
+        // it identically on either backend.
+        crate::federation::validate_subject_key_ids(&input.subject_key_ids)?;
+
         let original_content_hash = hex::encode(Sha256::digest(canonical));
         let now = chrono::Utc::now();
 
@@ -7924,6 +7931,61 @@ mod tests {
             .is_some_and(|s| !s.is_empty()));
         assert_eq!(row.original_content_hash.len(), 64);
         assert_eq!(row.weight, None, "no weight set ⇒ default None");
+    }
+
+    /// CIRISPersist#293 (CC 2.6.3 / §0.6) — `emit_attestation_self` REFUSES a
+    /// `subject_key_ids[]` element that is not canonical lowercase (the
+    /// uppercase-hex case from the issue repro). The check lives in the
+    /// shared assemble body, so `emit_attestation` enforces it identically.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn emit_attestation_self_rejects_uppercase_subject_key_id_293() {
+        use crate::federation::types::attestation_type::SCORES;
+        use crate::federation::FederationDirectory;
+
+        let signer = crate::federation::tier_ingest::test_support::local_signer("ciris-self");
+        let derived = signer.derived_key_id();
+        let engine = Engine::with_signer(signer.clone(), "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        sq.put_public_key(sweeper_test_key_derived_for(&derived, "ciris-self"))
+            .await
+            .expect("seed key");
+
+        // Uppercase-hex subject id (the issue repro) — must be refused.
+        let upper = "FF7C5632DAE6EF3AE7F6283BD35268BC7910332414AA8A1C35A1645CA0295F61";
+        let mut bad = crate::federation::EmitAttestationInput::with_envelope(
+            SCORES,
+            serde_json::json!({
+                "id": "emit-self-293", "dimension": "identity_binding:v1",
+                "score": 1.0, "confidence": 0.9,
+            }),
+        );
+        bad.subject_key_ids = vec![upper.to_owned()];
+        let err = engine
+            .emit_attestation_self(bad)
+            .await
+            .expect_err("uppercase subject_key_id must be refused (#293)");
+        assert!(
+            matches!(err, crate::federation::Error::InvalidArgument(_)),
+            "expected InvalidArgument, got {err:?}"
+        );
+
+        // The canonical lowercase form of the SAME id is admitted — the rule
+        // rejects the encoding, not the subject.
+        let mut ok = crate::federation::EmitAttestationInput::with_envelope(
+            SCORES,
+            serde_json::json!({
+                "id": "emit-self-293-ok", "dimension": "identity_binding:v1",
+                "score": 1.0, "confidence": 0.9,
+            }),
+        );
+        ok.subject_key_ids = vec![upper.to_lowercase()];
+        engine
+            .emit_attestation_self(ok)
+            .await
+            .expect("lowercase subject_key_id is admitted");
     }
 
     /// #253 PG twin — `emit_attestation_self` over the composed signer on a

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -289,6 +289,12 @@ fn assert_change_envelope_matches(
 /// `0-9a-f` charset because a derived key_id legitimately carries a `-` and a
 /// lowercase alphabetic label — the operative canonical invariant is "no
 /// uppercase", matching the precedent validators.
+///
+/// Gated to the backends that have an emit path: the sole caller
+/// (`Engine::emit_attestation_assemble`) is
+/// `#[cfg(any(feature = "postgres", feature = "sqlite"))]`, so without a
+/// backend feature this function would be dead code (the crate denies it).
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
 pub(crate) fn validate_subject_key_ids(subject_key_ids: &[String]) -> Result<(), Error> {
     for sid in subject_key_ids {
         if sid.is_empty() || sid.bytes().any(|b| b.is_ascii_uppercase()) {

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -277,6 +277,30 @@ fn assert_change_envelope_matches(
     Ok(())
 }
 
+/// CIRISPersist#293 (CC 2.6.3 / CEG §0.6) — reject any `subject_key_ids[]`
+/// element that is not in canonical (all-lowercase) form. A subject id is a
+/// federation key_id — on real nodes the derived `"<label>-<fingerprint>"`
+/// shape, which is all-lowercase by construction — so the rule is exactly
+/// the §0.6/§0.8 lowercase-canonical rejection already enforced on adjacent
+/// fields (`location.rs` `cell_id`, `media_sharing.rs` hashes): an uppercase
+/// or otherwise non-canonical subject id breaks byte-identical
+/// canonicalization for downstream verifiers (two encodings of the same
+/// subject would both admit). We reject ASCII-uppercase rather than a strict
+/// `0-9a-f` charset because a derived key_id legitimately carries a `-` and a
+/// lowercase alphabetic label — the operative canonical invariant is "no
+/// uppercase", matching the precedent validators.
+pub(crate) fn validate_subject_key_ids(subject_key_ids: &[String]) -> Result<(), Error> {
+    for sid in subject_key_ids {
+        if sid.is_empty() || sid.bytes().any(|b| b.is_ascii_uppercase()) {
+            return Err(Error::InvalidArgument(format!(
+                "subject_key_ids element must be a canonical lowercase key_id \
+                 (CC 2.6.3 / §0.6); got {sid:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Federation directory trait — the registry/lens/agent's read+write
 /// surface over persist's three federation tables.
 ///

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -414,3 +414,78 @@ def test_put_community_json_round_trip_290() -> None:
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()
+
+
+def test_emit_attestation_self_rejects_uppercase_subject_key_id_293():
+    """#293 (CC 2.6.3 / §0.6) — emit_attestation_self must REFUSE a
+    non-lowercase subject_key_ids[] element (uppercase-hex from the issue
+    repro), while the canonical lowercase form of the same id is admitted.
+    The rule rejects the encoding, not the subject."""
+    import json
+    import os
+    import secrets
+    import tempfile
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    d = tempfile.mkdtemp()
+    seed = os.path.join(d, "s")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    pqc = os.path.join(d, "p")
+    with open(pqc, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "n" + secrets.token_hex(6)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:",
+            alias,
+            local_key_id=alias,
+            local_key_path=seed,
+            local_pqc_key_id=alias + "-pqc",
+            local_pqc_key_path=pqc,
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        eng.register_self_federation_key("agent", "ref", None, None, None)
+        upper = "FF7C5632DAE6EF3AE7F6283BD35268BC7910332414AA8A1C35A1645CA0295F61"
+
+        # Uppercase-hex subject id — must be refused (was admitted on 10.4.0).
+        with pytest.raises(ValueError):
+            eng.emit_attestation_self(
+                json.dumps(
+                    {
+                        "attestation_type": "scores:x",
+                        "subject_key_ids": [upper],
+                        "attestation_envelope": {
+                            "id": "e293",
+                            "dimension": "identity_binding:v1",
+                            "score": 1.0,
+                            "confidence": 0.9,
+                        },
+                    }
+                )
+            )
+
+        # The canonical lowercase form of the SAME id is admitted.
+        eng.emit_attestation_self(
+            json.dumps(
+                {
+                    "attestation_type": "scores:x",
+                    "subject_key_ids": [upper.lower()],
+                    "attestation_envelope": {
+                        "id": "e293ok",
+                        "dimension": "identity_binding:v1",
+                        "score": 1.0,
+                        "confidence": 0.9,
+                    },
+                }
+            )
+        )
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()


### PR DESCRIPTION
Closes #293 — the subject-key canonical-form residual of #288.

## What
`emit_attestation` / `emit_attestation_self` admitted a `subject_key_ids[]` element that was not canonical lowercase (e.g. the uppercase-hex repro in #293), which CC 2.6.3 / CEG §0.6 forbid — a wrong-case subject id breaks byte-identical canonicalization for downstream verifiers (two encodings of the same subject would both admit). The reserved-prefix half of #288 shipped in 10.4.0; this is the remaining subject-key half.

## Fix
`federation::validate_subject_key_ids`, called in the shared `emit_attestation_assemble` body — so **both** emit entry points enforce it identically, **sqlite + postgres alike** (engine-level, no backend asymmetry). A subject id is a federation key_id — on real nodes the derived `<label>-<fingerprint>` shape, all-lowercase by construction — so the rule rejects any ASCII-uppercase (or empty) element rather than a strict `0-9a-f` charset (which would wrongly reject the legitimate `-`-bearing label). The canonical lowercase form of the same id is admitted: the rule rejects the *encoding*, not the subject. Mirrors the existing §0.6/§0.8 lowercase rejection on `location.rs` `cell_id` and `media_sharing.rs` hashes.

## Tests
- Rust: `emit_attestation_self_rejects_uppercase_subject_key_id_293` (uppercase refused → `InvalidArgument`; lowercase admitted). All 5 emit + 70 withdraws/takedown/delegation/owner_bind tests green (no legitimate derived-key_id path regresses).
- Python: `test_emit_attestation_self_rejects_uppercase_subject_key_id_293` mirrors the issue repro exactly.
- Closes CIRISConformance `test_240::test_subject_key_ids_must_be_lowercase_hex` `xfail(strict=True)` (XPASSes the moment the rule lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ