### PR TITLE
v10.6.0 — #295: expose local_derived_key_id() on pyo3 Engine + re-pin CIRISVerify v7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.6.0] — 2026-06-26
+
+### Added — #295: expose `local_derived_key_id()` on the pyo3 `Engine` (kills a recurring seal↔verify footgun)
+
+The pyo3 `Engine` exposed `local_key_id()` (the **bare keystore alias**) but not
+`local_derived_key_id()` — yet the federation floor (#247/#275) registers and
+verifies every self key under its **derived** id
+(`derive_key_id(<alias>, <ed25519 pubkey>)` = `"<label>-<fingerprint>"`). So any
+Python/cohabitation consumer that stamped `engine.local_key_id()` onto something
+the substrate later verifies got `verify_unknown_key`. This was the **third**
+instance of the same class (CIRISEdge#203 stamped the bare alias; CIRISServer#93
+audit actor_id; CIRISServer#118 lens seal-sign), each having to re-implement
+`derive_key_id` to recover the id persist already computes internally.
+
+`Engine.local_derived_key_id()` is now bound to Python, driving the existing
+`Engine::local_derived_key_id` Rust method (single source of truth, including the
+#275 32-byte-Ed25519 fail-loud guard) — software and hardware-hybrid engines
+behave identically. Consumers now call one method and get the registered/verified
+id with **zero re-derivation**; CIRISServer's lens-core interim re-derive helper
+(#118) collapses to a single call. `local_key_id()`'s doc now loudly flags it as
+the bare alias and points at `local_derived_key_id()` for anything verified.
+Raises `ValueError` if no signing identity is configured or the composed signer
+is not 32-byte Ed25519 (a non-Ed25519 fallback would mint an unverifiable id).
+
+### Changed — re-pin CIRISVerify v7.5.0 → v7.6.0 (wheel concurrence)
+
+All six verify crate pins (`ciris-keyring` ×4 incl. tpm/ios/android targets,
+`ciris-verify-core`, `ciris-crypto`) flip to `v7.6.0` — the TPM runtime-plugin
+line (dlopen client + plugin-backed secure blob storage + the wheel-shipped
+plugin, CIRISVerify #130 / v7.5.1 + v7.6.0). Minor bump, no MAJOR; the wheel
+`Requires-Dist ciris-verify>=7,<8` is unchanged.
+
 ## [10.5.0] — 2026-06-25
 
 ### Fixed — #293: `emit_attestation`/`emit_attestation_self` admitted non-lowercase-hex `subject_key_ids[]` (CC 2.6.3 / §0.6) — residual of #288

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.5.0"
+version = "10.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -751,10 +751,10 @@ tokio-stream = "0.1"
 # master key). Placed AFTER every platform-independent dep — see the
 # v0.9.0 bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +765,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2503,6 +2503,15 @@ impl PyEngine {
     /// role-tag conceptual leak. The old name is fully removed —
     /// callers must update to `local_key_id`.
     ///
+    /// ⚠️ **This is the BARE keystore alias — NOT the federation key_id.**
+    /// The federation floor (#247/#275) registers and verifies every self
+    /// key under its DERIVED id (`derive_key_id(<alias>, <ed25519 pubkey>)`
+    /// = `"<label>-<fingerprint>"`). Anything the substrate later verifies
+    /// (seal/scrub/emit `key_id`s, audit actor refs) MUST use
+    /// [`Self::local_derived_key_id`] — stamping this bare alias gets
+    /// rejected with `verify_unknown_key` (the recurring footgun behind
+    /// CIRISEdge#203 / CIRISServer#93 / CIRISServer#118 / CIRISPersist#295).
+    ///
     /// Raises `ValueError` if no local signing identity is configured.
     fn local_key_id(&self, _py: Python<'_>) -> PyResult<String> {
         self.ensure_usable()?;
@@ -2517,6 +2526,52 @@ impl PyEngine {
                      to the Engine constructor)",
                     )
                 })
+        })
+    }
+
+    /// v10.6.0 (CIRISPersist#295) — Return this Engine's **registered
+    /// (derived) federation key_id**: `derive_key_id(<keystore alias>,
+    /// <ed25519 pubkey>)` = `"<label>-<fingerprint>"`. This is the value
+    /// that FKs to `federation_keys(key_id)` after CIRISVerify FSD-003, and
+    /// the id the substrate verifies against — distinct from
+    /// [`Self::local_key_id`] (the bare keystore alias, the `derive_key_id`
+    /// *input*).
+    ///
+    /// **Use this for anything the substrate later verifies** — seal/scrub
+    /// `key_id`s, `emit_*` attester ids, audit actor refs. It removes the
+    /// recurring "stamp the bare alias → `verify_unknown_key`" footgun
+    /// (CIRISEdge#203 / CIRISServer#93 / CIRISServer#118): every consumer was
+    /// re-implementing `derive_key_id` (decode the b64 pubkey, call
+    /// `ciris_verify_core::fedcode::derive_key_id`) to recover the id persist
+    /// already computes internally. Now it's one call, zero re-derivation.
+    ///
+    /// Drives the same `Engine::local_derived_key_id` the Rust surface uses
+    /// (single source of truth, incl. the #275 32-byte-Ed25519 fail-loud
+    /// guard), so software and hardware-hybrid engines behave identically.
+    ///
+    /// Raises `ValueError` if no signing identity is configured or the
+    /// composed signer is not a 32-byte Ed25519 key (a non-Ed25519 fallback
+    /// would mint an unverifiable id — #275).
+    fn local_derived_key_id(&self, py: Python<'_>) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let backend = match &self.backend {
+                BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
+            };
+            let signer = self.signer.clone();
+            let local_signer = self.local_signer.clone();
+            py.detach(move || {
+                let engine = crate::Engine::from_shared_with_local(backend, signer, local_signer);
+                runtime.block_on(async move {
+                    engine
+                        .local_derived_key_id()
+                        .await
+                        .map_err(|e| PyValueError::new_err(format!("{e}")))
+                })
+            })
         })
     }
 

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -353,6 +353,51 @@ def test_register_self_then_put_blob_signing_275() -> None:
             "2026-05-28T13:45:09.000Z",
             str(uuid.uuid4()),
         )
+
+        # #295 — local_derived_key_id() returns the SAME registered/verified
+        # derived id (the footgun-free one), distinct from the bare alias.
+        assert eng.local_derived_key_id() == kid
+        assert eng.local_derived_key_id() != eng.local_key_id()
+        assert eng.local_key_id() == alias
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()
+
+
+def test_local_derived_key_id_pyo3_295():
+    """#295 — the pyo3 Engine exposes local_derived_key_id(): the DERIVED
+    federation key_id (`<label>-<fp>`) the substrate registers + verifies,
+    so consumers stop re-implementing derive_key_id. Distinct from the bare
+    local_key_id() alias. Skips on a non-sqlite wheel."""
+    import os
+    import secrets
+    import tempfile
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    seed = os.path.join(tempfile.mkdtemp(), "seed")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "node-" + secrets.token_hex(8)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:", alias, local_key_id=alias, local_key_path=seed
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        derived = eng.local_derived_key_id()
+        # Shape: <alias>-<fingerprint>, NOT the bare alias.
+        assert derived != alias
+        assert derived.startswith(alias + "-"), f"derived shape <label>-<fp>: {derived!r}"
+        assert eng.local_key_id() == alias
+        # Stable across calls (pure derivation over the composed signer).
+        assert eng.local_derived_key_id() == derived
+        # It is exactly the id register_self registers + returns (the FK target).
+        assert eng.register_self_federation_key("agent", "ref", None, None, None) == derived
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()


### PR DESCRIPTION
Closes #295 + pulls in the latest CIRISVerify.

## #295 — `local_derived_key_id()` on the pyo3 `Engine`
The pyo3 `Engine` exposed `local_key_id()` (the **bare keystore alias**) but not `local_derived_key_id()` — yet the federation floor (#247/#275) registers + verifies every self key under its **derived** id (`derive_key_id(<alias>, <ed25519 pubkey>)` = `<label>-<fingerprint>`). Consumers stamping the bare alias got `verify_unknown_key` — the **3rd** recurrence of the class (CIRISEdge#203 / CIRISServer#93 / CIRISServer#118), each re-implementing `derive_key_id`.

Now bound to Python, driving the existing `Engine::local_derived_key_id` Rust method (single source of truth, incl. the #275 32-byte-Ed25519 fail-loud guard) — software + hardware-hybrid identical. One call, zero re-derivation; CIRISServer's lens-core interim (#118) collapses to a single `engine.local_derived_key_id()`. `local_key_id()`'s doc now loudly flags it as the bare alias and points at the derived getter.

## Re-pin CIRISVerify v7.5.0 → v7.6.0
All six pins (`ciris-keyring` ×4 incl. tpm/ios/android targets, `ciris-verify-core`, `ciris-crypto`) → `v7.6.0` (TPM runtime-plugin line, CIRISVerify #130 / v7.5.1 + v7.6.0). Minor, no MAJOR; `Requires-Dist ciris-verify>=7,<8` unchanged.

## Tests
- Rust: `local_derived` getter + 175 verify-touching sqlite tests (hybrid/sign/verify/emit/register/blob_signing) green on 7.6.0.
- Python: `test_local_derived_key_id_pyo3_295` (derived ≠ bare alias, `<label>-<fp>` shape, == register_self's returned id) + the #275 round-trip extended to assert `local_derived_key_id() == kid`.
- Full clippy (`-D warnings`) + fmt + the `--features server` (no-backend) leg all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ