### PR TITLE
#297: cargo network-resilience env for crates.io registry flakes (CI-only)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,6 +43,14 @@ permissions:
   # PR comment for regression alerts.
   pull-requests: write
 
+# CIRISPersist#297 — same crates.io registry-flake resilience as ci.yml so the
+# bench suite's `cargo metadata` doesn't fail fast on a sparse-index / HTTP2
+# download hiccup. See ci.yml's env block for the rationale.
+env:
+  CARGO_NET_RETRY: '10'                 # retry registry/network requests (default 3)
+  CARGO_HTTP_MULTIPLEXING: 'false'      # HTTP/1.1 — sidesteps the HTTP/2 framing flake
+  CARGO_NET_GIT_FETCH_WITH_CLI: 'true'  # git CLI for the 6 CIRISVerify git-dep pins
+
 jobs:
   bench:
     name: Criterion bench suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,15 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # CIRISPersist#297 — network resilience for recurring crates.io registry
+  # flakes during `cargo metadata` (start of nextest/clippy + install-action),
+  # which fail fast before compilation. Two observed signatures, same class:
+  # "no matching package named X" (sparse-index hiccup) and "[16] Error in the
+  # HTTP2 framing layer" / "unable to update registry" (download flake).
+  # Prevention to complement auto-retry.yml's reaction (saves a rerun cycle).
+  CARGO_NET_RETRY: '10'                 # retry registry/network requests (default 3)
+  CARGO_HTTP_MULTIPLEXING: 'false'      # HTTP/1.1 — sidesteps the HTTP/2 framing flake
+  CARGO_NET_GIT_FETCH_WITH_CLI: 'true'  # git CLI for the 6 CIRISVerify git-dep pins
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #297. CI-only hardening — no version bump, no release.

Recurring `cargo metadata` transients (fail fast before compilation): `no matching package named memchr` (sparse-index, clippy + cirisaudit legs) and `unable to update registry … [16] Error in the HTTP2 framing layer` (pkg-config download, secrets leg). `auto-retry.yml` already *reacts* but each costs a full rerun.

Add cargo's own *prevention* knobs at workflow-level env (every job/step inherits):
- `CARGO_NET_RETRY=10` — retry registry/network requests (default 3).
- `CARGO_HTTP_MULTIPLEXING=false` — HTTP/1.1, sidesteps the HTTP/2 framing flake.
- `CARGO_NET_GIT_FETCH_WITH_CLI=true` — git CLI for the 6 CIRISVerify git-dep pins.

Applied to `ci.yml` (existing top-level env) + `bench.yml` (new top-level env). YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ