### PR TITLE
v10.7.0 — re-pin CIRISVerify v7.6.0 → v8.0.0 (verify MAJOR: tss-esapi deleted from keyring)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -92,12 +92,8 @@ jobs:
           restore-keys: |
             bench-${{ runner.os }}-
 
-      - name: Install libtss2-dev (TPM build dep for ciris-keyring `tpm`)
-        # v1.10.0 (CIRISPersist#87) — the Linux `tpm` keyring feature
-        # builds `tss-esapi`, which needs the libtss2 headers +
-        # pkg-config files at build time, not just the runtime .so
-        # (libtss2-dev pulls the runtime libs as dependencies).
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
+      # v10.7.0 (CIRISVerify v8.0.0, #141) — no libtss2-dev: ciris-keyring
+      # deleted the link-time tss-esapi backend; nothing to apt-install.
 
       - name: System info
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,9 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v6
-      # v1.10.0 (CIRISPersist#87) — ciris-keyring's `tpm` feature
-      # (auto-enabled for Linux targets, see Cargo.toml) builds
-      # `tss-esapi`, which links libtss2 at build time.
-      - name: install libtss2-dev (TPM build dep)
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
+      # v10.7.0 (CIRISVerify v8.0.0) — no libtss2-dev: ciris-keyring deleted
+      # the link-time tss-esapi backend (#141); the TPM plugin is dlopen'd at
+      # runtime and the keyring link-binds no libtss2 on any target.
       - uses: dtolnay/rust-toolchain@stable
       # CIRISCache (CIRISPersist#285) — GHCR-backed cross-repo Rust cache,
       # replacing Swatinem/rust-cache (unlimited GHCR storage, survives the
@@ -748,10 +746,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # v1.10.0 (CIRISPersist#87) — libtss2 for the `tpm` keyring
-      # feature (clippy compiles the full graph).
-      - name: install libtss2-dev (TPM build dep)
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
+      # v10.7.0 (CIRISVerify v8.0.0, #141) — no libtss2-dev; clippy compiles
+      # the full graph but ciris-keyring no longer link-binds tss-esapi.
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -843,10 +839,6 @@ jobs:
       NIGHTLY_PIN: nightly-2026-06-12
     steps:
       - uses: actions/checkout@v6
-      # v1.10.0 (CIRISPersist#87) — libtss2 for the `tpm` keyring
-      # feature on the Linux wheel builds. macOS wheels build the
-      # base keyring (no tss-esapi), so this step is Linux-only.
-      #
       # v3.5.3 (CIRISPersist#133) — libsqlite3-dev for the dynamic
       # libsqlite3 link. v3.5.2 narrowed the `bundled` rusqlite feature
       # to Android-only, but the Linux wheel-build runner had no
@@ -855,9 +847,13 @@ jobs:
       # That defeated #132's cross-cdylib SIGSEGV fix at the wheel tier
       # (CIRISEdge#50 still SEGV against the v3.5.2 wheel). The
       # post-build `readelf` gate below catches any future regression.
-      - name: install libtss2-dev + libsqlite3-dev (TPM + SQLite build deps)
+      #
+      # v10.7.0 (CIRISVerify v8.0.0, #141) — the former libtss2-dev half is
+      # dropped: ciris-keyring no longer link-binds tss-esapi (the TPM plugin
+      # is dlopen'd at runtime), so only libsqlite3-dev remains.
+      - name: install libsqlite3-dev (SQLite build dep)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       # v5.5.4 (CIRISPersist#205) — Windows openssl-sys link. The `pyo3`
       # feature force-includes `postgres` → `dep:openssl` → openssl-sys;
       # Linux/macOS have a system OpenSSL, Windows does not. vcpkg's
@@ -1345,10 +1341,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v6
-      # v1.10.0 (CIRISPersist#87) — libtss2 for the `tpm` keyring
-      # feature; the emit_persist_extras step compiles the crate.
-      - name: install libtss2-dev (TPM build dep)
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
+      # v10.7.0 (CIRISVerify v8.0.0, #141) — no libtss2-dev; this step
+      # compiles the crate but ciris-keyring no longer link-binds tss-esapi.
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [10.7.0] — 2026-06-26
+
+### Changed — re-pin CIRISVerify v7.6.0 → v8.0.0 (verify MAJOR; tss-esapi deleted from the keyring)
+
+CIRISVerify v8.0.0 is a MAJOR: **#141 deletes the link-time `tss-esapi` TPM backend
+from `ciris-keyring`**. The keyring's only TPM backend is now the runtime `dlopen`
+plugin (`PluginTpmSigner` / `PluginTpmSecureBlobStorage`), and the keyring
+link-binds **no** libtss2 on any target. Persist consumes the keyring abstractly
+(the `HardwareSigner` trait + `create_platform_storage` runtime-detect/fallback),
+so there are **no persist code changes** — but two build-surface knobs had to move:
+
+- **`tpm` keyring feature removed.** `--features tpm` no longer exists; the
+  TPM-plugin path is a **default** keyring feature. The Linux
+  `[target.'cfg(target_os = "linux")']` pin drops `"tpm"` from its feature list
+  (keeping `"pqc-ml-dsa"`) — leaving it in would fail to compile against v8.0.0.
+  iOS/android features are unchanged (only `tpm` was deleted).
+- **`libtss2-dev` build dependency removed from CI.** The keyring is now
+  libtss2-free (verified: the built wheel `.so` has **0 libtss2 `DT_NEEDED`**), so
+  the four `ci.yml` apt-install steps + the `bench.yml` step are deleted; the
+  combined wheel-build step keeps only `libsqlite3-dev`. Hardware TPM needs only
+  the runtime `libciris_tpm_plugin.so`, dlopen'd if present (none in CI → software
+  fallback, as before).
+
+All six verify pins (`ciris-keyring` ×4 incl. ios/android targets,
+`ciris-verify-core`, `ciris-crypto`) flip to `v8.0.0` with `version = "8"`, and the
+wheel `Requires-Dist` floor moves to `ciris-verify>=8.0.0,<9` in lockstep (the
+verify-MAJOR cohab-firewall knob — same class as the v2.0.1 / v4.10.0 / v9.0.3
+metadata bumps). The `TpmDiscrete` custody-attestation evidence shapes persist
+admits are `ciris-verify-core` data types, untouched by the keyring deletion. 188
+verify/tpm/custody-touching sqlite tests + the Rust/Python regression suite green
+on v8.0.0; full clippy (`-D warnings`) + fmt + the `--features server` no-backend
+leg clean. Legacy-key rotation (when federation turns on) rides persist's existing
+`supersede` surface — nothing to re-sign today.
+
 ## [10.6.0] — 2026-06-26
 
 ### Added — #295: expose `local_derived_key_id()` on the pyo3 `Engine` (kills a recurring seal↔verify footgun)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.6.0"
+version = "10.7.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -735,9 +735,13 @@ tokio-stream = "0.1"
 # features from `[dependencies]` (`pqc-ml-dsa`) with any matching
 # `[target.*]` table, so each build target picks up the right backend
 # automatically with no per-target maturin config:
-#   - Linux   → `tpm`     (TPM 2.0 via tss-esapi — needs libtss2 at
-#                          BUILD time; the CI Linux jobs apt-install
-#                          `libtss2-dev`)
+#   - Linux   → base set  (TPM 2.0 via the runtime `dlopen` plugin, which
+#                          is a DEFAULT ciris-keyring feature as of verify
+#                          v8.0.0 — CIRISVerify #141 deleted the link-time
+#                          `tss-esapi` backend. The keyring link-binds NO
+#                          libtss2 on any target, so there is no longer a
+#                          BUILD dep; hardware TPM needs only the runtime
+#                          `libciris_tpm_plugin.so`, dlopen'd if present.)
 #   - iOS     → `ios`     (Secure Enclave / Keychain — pulls no extra
 #                          crates; `ios` is a cfg-only keyring feature)
 #   - Android → `android` (Keystore / StrongBox)
@@ -745,16 +749,16 @@ tokio-stream = "0.1"
 # ciris-keyring exposes no hardware backend for them.
 #
 # `create_platform_storage` runtime-detects the hardware and falls
-# back to software storage where there is none, so a `tpm`-built
-# binary still runs on a no-TPM host (`migrate_to_hardware_key` then
-# returns `HardwareKeyUnavailable` and the caller keeps the software
-# master key). Placed AFTER every platform-independent dep — see the
-# v0.9.0 bug note on the rusqlite target table above.
+# back to software storage where there is none, so the binary still
+# runs on a no-TPM host (`migrate_to_hardware_key` then returns
+# `HardwareKeyUnavailable` and the caller keeps the software master
+# key). Placed AFTER every platform-independent dep — see the v0.9.0
+# bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "tpm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -765,7 +769,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,15 @@ classifiers = [
 # (`pip install ciris-persist==9.0.2 ciris-verify==6.2.0`) hit a hard
 # pip resolution conflict. Floor is v6.0.0 to track the v6 family floor,
 # coherent with the Rust pin.
+# v10.7.0 (CIRISVerify v8.0.0 re-pin) — verify MAJOR 7→8 (tss-esapi deleted
+# from ciris-keyring; the runtime dlopen TPM plugin is the sole backend,
+# CIRISVerify #141). Floor moves to v8.0.0 (`<9`) in lockstep with the six
+# Rust pins, or the published wheel declares `ciris-verify<8` while its Cargo
+# deps pin v8.0.0 → the recurring cohab-conflict class
+# (`pip install ciris-persist ciris-verify==8.0.0`). Same drift firewall as
+# the v2.0.1 / v4.10.0 / v9.0.3 entries above.
 dependencies = [
-    "ciris-verify>=7.0.0,<8",
+    "ciris-verify>=8.0.0,<9",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Brings in **CIRISVerify v8.0.0** (just released — Android re-run + publish chain complete, plugin bundled in the wheel).

## Why MAJOR
v8.0.0 #141 **deletes the link-time `tss-esapi` TPM backend from `ciris-keyring`**. The keyring's only TPM backend is now the runtime `dlopen` plugin (`PluginTpmSigner` / `PluginTpmSecureBlobStorage`); it link-binds **no** libtss2 on any target.

## Persist impact — no code, two build-surface knobs
Persist consumes the keyring abstractly (`HardwareSigner` + `create_platform_storage` runtime-detect/fallback), so **no persist code changes**. But:
- **Dropped the removed `tpm` keyring feature** from the Linux `[target.cfg(linux)]` pin (kept `pqc-ml-dsa`). `--features tpm` no longer exists — leaving it in fails to compile on v8.0.0. The plugin path is a *default* keyring feature now. iOS/android features unchanged.
- **Removed `libtss2-dev` from CI** (4 `ci.yml` steps + 1 `bench.yml` step; the combined wheel step keeps `libsqlite3-dev`). The keyring is libtss2-free — verified: the built wheel `.so` has **0 libtss2 `DT_NEEDED`**. Hardware TPM needs only the runtime `libciris_tpm_plugin.so`, dlopen'd if present (none in CI → software fallback, as before).

## Lockstep pins
All 6 verify pins (`ciris-keyring` ×4 incl. ios/android, `ciris-verify-core`, `ciris-crypto`) → `v8.0.0` / `version = "8"`; wheel `Requires-Dist` floor → `ciris-verify>=8.0.0,<9` (verify-MAJOR cohab firewall — same class as v2.0.1 / v4.10.0 / v9.0.3). The `TpmDiscrete` custody-attestation evidence shapes persist admits are `ciris-verify-core` data types, untouched by the keyring deletion.

## Validation
- 188 verify/tpm/custody-touching sqlite tests + Rust/Python regression (#295/#275/#293/community) green on v8.0.0.
- Full clippy (`-D warnings`) + fmt + the `--features server` (no-backend) leg + the CI `secrets` feature set all clean.
- Built wheel `.so`: 0 libtss2 `DT_NEEDED`.

Legacy-key rotation (when federation turns on) rides persist's existing `supersede` surface — nothing to re-sign today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ