### PR TITLE
v11.0.0 — BREAKING: owner → steward rename (CC 0.5.1 §3.2) + #299 nodes_stewarded_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.0.0] — 2026-06-26
+
+### BREAKING — owner → steward rename across the steward-binding surface (CC 0.5.1 §3.2 alignment)
+
+CIRIS Constitution 0.5.1 §3.2 makes "owner" the **wrong word** for node/agent
+stewardship: *"Steward-binding is **responsibility, not property** — a steward is
+responsible for a ward, never a holder of one … You never steward a node, an
+agent, or a person as a possession"* (the **structural no-slavery guarantee**).
+The constitution names the predicate **`is_steward_bound(K)`** and the concept
+**steward-binding**; persist's `owner_*` naming was the property framing the
+constitution rejects. This renames the whole surface — **clean break, no aliases**.
+
+**Renamed public API (downstream MUST update — CIRISServer / Agent):**
+
+| Was | Now |
+|---|---|
+| `Engine::owner_bind` / pyo3 `owner_bind` | `steward_bind` |
+| `Engine::owner_bindings_of` + `admission::owner_bindings_of` + pyo3 `owner_bindings_of_json` | `steward_bindings_of` / `steward_bindings_of_json` |
+| `Engine::owner_binding_chain` + `admission::owner_binding_chain` + pyo3 `owner_binding_chain_json` | `steward_binding_chain` / `steward_binding_chain_json` |
+| `admission::is_owner_bound` + pyo3 `is_owner_bound_json` | `is_steward_bound` / `is_steward_bound_json` |
+| `Error::UnownedCommunityMember` (kind `federation_unowned_community_member`) | `UnstewardedCommunityMember` (kind `federation_unstewarded_community_member`) |
+
+Consumers matching the `federation_unowned_community_member` error kind (e.g.
+CIRISConformance) must update to `federation_unstewarded_community_member`. The
+gate function `check_community_membership_steward_binding` was already
+steward-named — only its error lagged. Doc/threat-model prose updated in lockstep.
+
+**Preserved (genuinely different "owner" concepts, NOT renamed):** the
+`SharedInstanceLease` leader-election owner (`owner_pid` / `owner_hostname` —
+real lease ownership, CIRISEdge#100); the `EngineCell` lifecycle owner; the
+cohabitation consumer-ownership declarations; the at-rest-cascade
+`owner_or_family_key_id` (data recipient, not stewardship).
+
+### Added — #299: `Engine::nodes_stewarded_by` (the outbound steward-binding reader)
+
+Folded into this cut (so it ships steward-named, never `owner`). The exact
+inverse of `steward_bindings_of` (`n ∈ nodes_stewarded_by(U)` ⟺
+`U ∈ steward_bindings_of(n)`): "list the nodes I steward" is now one substrate
+call instead of CIRISServer's hand-rolled scan-then-confirm. Enumerates candidate
+nodes (U's outgoing `delegates_to` + occurrences + self) and **confirms each via
+`steward_bindings_of`** — so the liveness/`withdraws`-`recants`-retraction/
+live-`user`-role-anchor logic is inherited verbatim (never re-derived) and
+read-after-write correctness lives in the substrate. Exposed on the Rust `Engine`
+and pyo3 (`nodes_stewarded_by_json`). Rust (memory + sqlite, both directions) +
+Python regression tests; 78 community/steward/node-agency tests green.
+
 ## [10.7.0] — 2026-06-26
 
 ### Changed — re-pin CIRISVerify v7.6.0 → v8.0.0 (verify MAJOR; tss-esapi deleted from the keyring)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "10.7.0"
+version = "11.0.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -18,7 +18,7 @@ v0.2.0–v0.3.6 attack surface in §3.7..§3.10 (AV-28..AV-39);
 holonomic surface in §3.14 (AV-59..AV-66);
 constitution-alignment surface in §3.15 (AV-67..AV-72) — PQC-mandatory
 federation-tier per-trace ingest (CC 5.3.2.4.3.1), the node/agency
-delegation split (CC 4.4.3.4.3 / CC 1.13.5), owner-binding community
+delegation split (CC 4.4.3.4.3 / CC 1.13.5), steward-binding community
 membership (CC 3.2), the community-DEK rotation cascade (CC 4.4.3.2.2),
 and the four adversarial-review bypasses those gates initially carried.
 **RC17 compliance:** persist is COMPLIANT and rolls no §19 crypto —
@@ -246,7 +246,7 @@ divergence-router / anti-rollback / WW-2 leaf filter, aggregation-meta
 and member-commitment integrity, rarity-vs-revocation). AV-67..AV-72
 (§3.15) cover the v9.0.0 CIRIS Constitution 0.1.5 alignment surface
 (PQC-mandatory federation-tier per-trace ingest, the node/agency
-delegation split, owner-binding community membership, community-DEK
+delegation split, steward-binding community membership, community-DEK
 rotation, and the four adversarial-review bypasses those gates carried).
 Each AV lists the attack, the primary mitigation, the secondary
 mitigation, and the residual risk.
@@ -2091,32 +2091,32 @@ invariant is "a node-only key's delegation literally cannot carry agency,"
 which is the structural property CC 1.13.5 names. **Closed v9.0.0; see
 AV-71 for the duplicate-token bypass closed in the same cut.**
 
-#### AV-69: Unowned node/agent admitted to a non-infra community (CC 3.2 / CC 3.4.7.1)
+#### AV-69: Unstewarded node/agent admitted to a non-infra community (CC 3.2 / CC 3.4.7.1)
 
 **Attack**: an adversary writes a `put_community` whose roster includes a
-`node`- or `agent`-role key with **no owner-binding to an accountable
-human** — granting a bare, unowned node standing to speak AS the group.
+`node`- or `agent`-role key with **no steward-binding to an accountable
+human** — granting a bare, unstewarded node standing to speak AS the group.
 Per CC 3.2, non-infra community membership is an **authority act** and
 CC 1.13.2 requires authority to root in a `user`-role human; pre-v9.0.0
 `put_community` ran only `check_consensus_protocol_form` + the geographic
-gate and admitted the unowned member.
+gate and admitted the unstewarded member.
 
 **Mitigation v9.0.0 (#235, CC 3.2 / CC 3.4.7.1)**:
-`federation::admission::check_community_membership_owner_binding`, wired
+`federation::admission::check_community_membership_steward_binding`, wired
 into `put_community` on all three backends after the geographic gate and
 before the write lock / `persist_row_hash` / INSERT (verify-before-mutation,
-AV-9). It reuses the `is_owner_bound(K)` predicate (CC 3.4.7.1 — a live,
+AV-9). It reuses the `is_steward_bound(K)` predicate (CC 3.4.7.1 — a live,
 unrevoked path from `K` to a `user`-role identity); **only members
 resolving to `node` or `agent`** are constrained — the first such member
-lacking a live owner-binding REJECTS the whole write with typed
-`Error::UnownedCommunityMember` (token
-`federation_unowned_community_member`), not stored. A `user`-role member
-is trivially owner-bound.
+lacking a live steward-binding REJECTS the whole write with typed
+`Error::UnstewardedCommunityMember` (token
+`federation_unstewarded_community_member`), not stored. A `user`-role member
+is trivially steward-bound.
 
 **Secondary**: the **infrastructure carve-out** (CC 3.2 "Trust ≠
 membership") — a community whose `policy_blob.cohort_subkind ==
 "infrastructure"` is exempt (a node MAY trust + serve an infra community
-with no owner). The gate is a **precondition**, NOT a substitute for the
+with no steward). The gate is a **precondition**, NOT a substitute for the
 community's own `consensus_protocol` vote.
 
 **Residual**: an unresolved or non-node/agent member is out of scope (no
@@ -2186,7 +2186,7 @@ match the CC 3.4.7.1 `identity_type`-is-a-set definition.
 **Attack (four sub-vectors, all closed v9.0.0 by the adversarial review)**:
 
 - **F2 — self-labeled `cohort_subkind: infrastructure`.** Any caller could
-  self-label a community `infrastructure` to skip the AV-69 owner-binding
+  self-label a community `infrastructure` to skip the AV-69 steward-binding
   precondition AND force its content to Commons-plaintext (no DEK,
   AV-70) — both gates honored the label with **no authority check**.
   **Mitigation**: `is_authorized_infrastructure_community` honors the
@@ -2194,16 +2194,16 @@ match the CC 3.4.7.1 `identity_type`-is-a-set definition.
   `lookup_public_key`) has an `identity_type` set containing
   **`substrate_persist`** (the reserved governance/substrate authority).
   Used in BOTH gates; **fail-secure** — an unauthorized infra-labeled
-  community falls through to the STRICTER non-infra path (owner-binding
+  community falls through to the STRICTER non-infra path (steward-binding
   REQUIRED + DEK cascade APPLIES).
-- **F3 — `is_owner_bound` honored revoked/expired delegations.** Clause 3
+- **F3 — `is_steward_bound` honored revoked/expired delegations.** Clause 3
   ("∃ a live `delegates_to(U → k)` from a `user`-role granter") accepted
   ANY `delegates_to` — a `withdraws`/`recants`-retracted or lapsed
-  delegation still conferred owner-binding (AV-69 bypass). **Mitigation**:
+  delegation still conferred steward-binding (AV-69 bypass). **Mitigation**:
   an edge is now skipped if the granter has a `withdraws`/`recants`
   against `k` (the §11.10 edge-retraction model, recipient named as
   `attested_key_id`) or if `expires_at <= now`; only a genuinely live edge
-  confers owner-binding.
+  confers steward-binding.
 - **F4 — rotation forward-secrecy hole for future-dated `effective_at`.**
   `put_community_membership_revocation` bumped the epoch at write time, but
   `resolve_community_members` only dropped a member once `effective_at <=
@@ -2303,10 +2303,10 @@ the same reserved governance role that already owns `system:` /
 | AV-66 | Rarity-driven retention resurrecting revoked content (N5) | v8.1.0/v8.2.0 `evict_fountain_content_hard_delete` is a SEPARATE path that NEVER consults `retention_priority` — drops all symbols, manifest stays `EnvelopeOnly`; `resolve_retention_action` drives `retention_decision`/`ejection_verdict` (Withdrawn → `EjectHardDelete` regardless of `is_rare`). Revocation overrides rarity by construction, not by comparison. | N6 `holding_claim_counts` gates rarity on possession-proven claims (unverified claim can't lower another peer's priority). | **✓ Mitigated v8.1.0/v8.2.0** | CIRISPersist#228 |
 | AV-67 | Federation-tier forge-later via unverified per-trace ingest (CC 5.3.2.4.3.1 — the CC 5.3.2.4.3 `tier=federation ⟹ hybrid present` invariant enforced at the bulk testimony corpus; same forge-later class as AV-59 at the trace-store path, previously unmodeled at the per-trace `put_attestation` grain) | v9.0.0 `verify_federation_tier_ingest` (`ceg_produce_canonicalize` JCS → `SHA-256 == original_content_hash` → `lookup_public_key` REGISTERED pubkeys → `verify_hybrid`(`Strict`), BOTH halves REQUIRED) wired into `put_attestation` on all three backends BEFORE `persist_row_hash`+INSERT (verify-before-mutation, AV-9); rejected ⇒ zero rows, typed `FederationTierUnverified`. Composed with — not replacing — `check_federation`. | **Local-tier EXEMPT** (CC 5.3.2.2 deferred sig; matrix arm (e) proves no over-reject). Exposed + fixed the classical-only `withdraws` emitter gap (evict/sweeper/takedown now hybrid-sign via `LocalSigner`; non-PQC engine fails honest, no silent skip). | **✓ Mitigated v9.0.0** (BREAKING — classical-only fed rows non-conformant; non-PQC producers local-tier-only) | CIRISPersist#237 |
 | AV-68 | Node-only key receiving agency via `delegates_to` (CC 4.4.3.4.3 "Partnership WITHOUT agency" / CC 1.13.5 "infrastructure must not have agency") | v9.0.0 `check_node_agency_admission` wired into `put_attestation` (3 backends, verify-before-mutation): a `delegates_to` to a `node`-ONLY recipient (resolved via `lookup_public_key`, CC 3.4.7.1) MUST be `scopes_are_infra_only` (non-empty, every token `infra:`), else REJECTED `NodeAgencyForbidden` + not stored. Published `identity_type::NODE` + `delegation_scope` (`infra:*`/`agency:*` + `LEGACY_AGENCY_KINDS`). | No over-reject: `agent`/brain key MAY carry `agency:*`; `{node,agent}` hybrid not constrained; unresolved recipient FK-rejected by `put_attestation` anyway. CIRISServer `ownership.rs` becomes a thin wrapper. | **✓ Mitigated v9.0.0** (see AV-71 for the dup-token bypass) | CIRISPersist#235/#236 |
-| AV-69 | Unowned node/agent admitted to a non-infra community (CC 3.2 owner-binding gate / CC 3.4.7.1; authority must root in a human, CC 1.13.2) | v9.0.0 `check_community_membership_owner_binding` wired into `put_community` (3 backends) after the geographic gate, before write lock/INSERT (verify-before-mutation): a `node`/`agent` roster member lacking a live `is_owner_bound(K)` path to a `user`-role identity REJECTS the write `UnownedCommunityMember` + not stored. Precondition, NOT a substitute for the `consensus_protocol` vote. | Infra carve-out (CC 3.2 "Trust ≠ membership"): `cohort_subkind: infrastructure` community admits an unowned node. `user` member trivially owner-bound; unresolved/non-node-agent out of scope (no over-reject). | **✓ Mitigated v9.0.0** (see AV-72/F2 self-label, AV-72/F3 revoked-delegation bypasses) | CIRISPersist#235 |
+| AV-69 | Unstewarded node/agent admitted to a non-infra community (CC 3.2 steward-binding gate / CC 3.4.7.1; authority must root in a human, CC 1.13.2) | v9.0.0 `check_community_membership_steward_binding` wired into `put_community` (3 backends) after the geographic gate, before write lock/INSERT (verify-before-mutation): a `node`/`agent` roster member lacking a live `is_steward_bound(K)` path to a `user`-role identity REJECTS the write `UnstewardedCommunityMember` + not stored. Precondition, NOT a substitute for the `consensus_protocol` vote. | Infra carve-out (CC 3.2 "Trust ≠ membership"): `cohort_subkind: infrastructure` community admits an unstewarded node. `user` member trivially steward-bound; unresolved/non-node-agent out of scope (no over-reject). | **✓ Mitigated v9.0.0** (see AV-72/F2 self-label, AV-72/F3 revoked-delegation bypasses) | CIRISPersist#235 |
 | AV-70 | Community-DEK not rotated on member removal — removed member decrypts NEW community content (CC 4.4.3.2.2 forward secrecy; community-DEK is content's SOLE confidentiality boundary, CC 4.4.3.2.1) | v9.0.0 `put_community_membership_revocation` bumps the community DEK epoch (`community_dek_bump_epoch`, 3 backends) as part of the revocation write; next emission mints a FRESH DEK wrapped only to remaining members (active roster = `lookup_community` ∖ effective revocations); removed member can't unwrap. **Exposure window = zero.** All wraps `wrap_algorithm: v2` (FIPS-203 hybrid) — NEVER v1 (CC 4.4.3.4.1 / CC 5.2 HNDL); keyless member fail-secure EXCLUDED + `hard_case:recipient_excluded` (V087 CHECK makes v1 unrepresentable). | Forward-only (old-epoch blobs keep grants); flat per-member re-wrap, deliberately NOT MLS TreeKEM (CC 5.1, RET-layer OQ). Infra communities opt OUT (Commons plaintext, no DEK — trust root publicly auditable). | **✓ Mitigated v9.0.0** (see AV-72/F4 future-dated `effective_at`, AV-72/F5 atomicity) | CIRISPersist (CC 4.4.3.2.2) |
 | AV-71 | Node-agency gate (AV-68) bypass via duplicate `identity_type` token `"node,node"` (CC 1.13.5 / CC 4.4.3.4.3) | v9.0.0 (adversarial review F1) the gate now tests the identity_type **set** via `HashSet<&str>` (`len()==1 && contains(NODE)`), robust to duplicate/whitespace/order — `"node,node"` no longer evades node-only detection. | `node,agent` hybrid still ADMITTED (no over-reject); regression-tested on 3 backends (`"node,node"`/`"node, node"` + `agency:*` → REJECTED + not stored). | **✓ Mitigated v9.0.0** | CIRISPersist#237 (F1) |
-| AV-72 | Authority/forward-secrecy bypasses in the new v9.0.0 community gates (CC 3.2 / CC 4.4.3.2.1 / CC 3.4.7.1 / CC 4.4.3.2.2) | v9.0.0 (adversarial review F2–F5): **F2** self-labeled `cohort_subkind: infrastructure` skipped owner-binding + forced plaintext → `is_authorized_infrastructure_community` honors the carve-out ONLY if `community_key_id` is `substrate_persist`-roled (fail-secure to the stricter path). **F3** `is_owner_bound` honored revoked/expired delegations → edge skipped on `withdraws`/`recants` against `k` (§11.10) or `expires_at <= now`. **F4** future-dated `effective_at` kept wrapping a "removed" member → community revocation now immediate (future-dated beyond 60s skew REJECTED before write). **F5** non-atomic revoke+hard_case+bump → ONE transaction per backend. | Each fix has a fails-without/passes-with test on all backends where the path runs; no new substrate authority (`substrate_persist` is the existing reserved governance role, §3.7). | **✓ Mitigated v9.0.0** | CIRISPersist#237 (F2–F5) |
+| AV-72 | Authority/forward-secrecy bypasses in the new v9.0.0 community gates (CC 3.2 / CC 4.4.3.2.1 / CC 3.4.7.1 / CC 4.4.3.2.2) | v9.0.0 (adversarial review F2–F5): **F2** self-labeled `cohort_subkind: infrastructure` skipped steward-binding + forced plaintext → `is_authorized_infrastructure_community` honors the carve-out ONLY if `community_key_id` is `substrate_persist`-roled (fail-secure to the stricter path). **F3** `is_steward_bound` honored revoked/expired delegations → edge skipped on `withdraws`/`recants` against `k` (§11.10) or `expires_at <= now`. **F4** future-dated `effective_at` kept wrapping a "removed" member → community revocation now immediate (future-dated beyond 60s skew REJECTED before write). **F5** non-atomic revoke+hard_case+bump → ONE transaction per backend. | Each fix has a fails-without/passes-with test on all backends where the path runs; no new substrate authority (`substrate_persist` is the existing reserved governance role, §3.7). | **✓ Mitigated v9.0.0** | CIRISPersist#237 (F2–F5) |
 
 ---
 

--- a/src/cirisnode/mod.rs
+++ b/src/cirisnode/mod.rs
@@ -158,7 +158,7 @@ pub enum Error {
     /// (`ModerationEvent` / `takedown_notice`) emission was refused: the
     /// signer neither holds the duty as-self (it is NOT a subject of the
     /// target content nor a named moderator of the target community) NOR is
-    /// reached by an owner-bound duty-holder via a live `delegates_to`
+    /// reached by an steward-bound duty-holder via a live `delegates_to`
     /// chain bearing the governing scope (`moderate` / `takedown`). The row
     /// is not stored. This is the cirisnode-surface
     /// image of [`crate::federation::Error::DelegatedScopeUnauthorized`] —
@@ -233,11 +233,11 @@ impl Error {
 /// `community_id` is the producer-declared target community (whose named
 /// moderators hold the duty). `duty` is `moderate` / `takedown` / `review`.
 /// `target_descriptor` is an audit string naming the target. Admit IFF the
-/// signer is a duty-holder (as-self) or an owner-bound holder reaches the
+/// signer is a duty-holder (as-self) or an steward-bound holder reaches the
 /// signer via a live `duty`-scoped chain; the v8.7.0 absent-⇒-admit bypass
 /// is GONE (no duty-holder ⇒ REJECT). Delegates to
 /// [`crate::federation::admission::check_moderation_admission`] so the
-/// scope-isolation + attenuation + sub_delegation + depth-cap + owner-bound
+/// scope-isolation + attenuation + sub_delegation + depth-cap + steward-bound
 /// properties are identical to the report-`scores` path.
 ///
 /// A federation [`Backend`](crate::federation::Error::Backend) error from
@@ -285,7 +285,7 @@ pub async fn check_moderation_or_reject(
             scope,
         }) => Err(Error::DelegatedScopeUnauthorized(format!(
             "signer {signer} holds neither the {scope} duty as-self over {target} nor a live \
-             {scope}-scoped delegates_to chain from an owner-bound duty-holder (CEG §11.10)"
+             {scope}-scoped delegates_to chain from an steward-bound duty-holder (CEG §11.10)"
         ))),
         Err(crate::federation::Error::Backend(e)) => Err(Error::Backend(e)),
         Err(e) => Err(Error::Internal(format!(

--- a/src/cirisnode/postgres.rs
+++ b/src/cirisnode/postgres.rs
@@ -151,7 +151,7 @@ impl NodeCoreService for PostgresBackend {
         // FederationDirectory, so `self` walks the delegates_to + community
         // graph. Admit IFF the author IS a duty-holder over the target
         // (declared subjects ∪ the target community's named moderators) or
-        // is reached by an owner-bound duty-holder via a live `takedown`-
+        // is reached by an steward-bound duty-holder via a live `takedown`-
         // scoped chain. Absence ⇒ REJECT. Runs BEFORE the INSERT — a
         // rejected emission leaves no trace.
         if takedown.is_some() {
@@ -357,7 +357,7 @@ impl NodeCoreService for PostgresBackend {
         // v8.7.1 (CIRISPersist#233, CEG §11.10) — FULL moderation gate for
         // the `ModerationEvent` primitive. Admit IFF the accuser (signer)
         // IS a duty-holder over the target (declared subjects ∪ the target
-        // community's named moderators) or is reached by an owner-bound
+        // community's named moderators) or is reached by an steward-bound
         // duty-holder via a live `moderate`-scoped chain. Absence ⇒ REJECT.
         // Runs AFTER signature verify, BEFORE INSERT.
         // v8.7.2: authority over the SIGNED content provenance — the
@@ -3129,7 +3129,7 @@ mod tests {
             .await
             .expect("(b1) subject-delegated moderation admitted");
 
-        // (b2) named-moderator (community founder, owner-bound) → ADMIT.
+        // (b2) named-moderator (community founder, steward-bound) → ADMIT.
         backend
             .put_moderation_event(build_moderation_event_pg(
                 &founder_key,
@@ -3289,7 +3289,7 @@ mod tests {
             "fail-secure: undetermined subject_of must REJECT subject-self"
         );
 
-        // named-mod path (b) still ADMITs the owner-bound founder.
+        // named-mod path (b) still ADMITs the steward-bound founder.
         backend
             .put_moderation_event(build_moderation_event_pg(
                 &founder_key,

--- a/src/cirisnode/sqlite.rs
+++ b/src/cirisnode/sqlite.rs
@@ -270,7 +270,7 @@ impl NodeCoreService for SqliteNodeCoreBackend {
         // walk runs BEFORE the INSERT closure takes the conn lock (no
         // deadlock). Admit IFF the author IS a duty-holder over the target
         // (the content's declared subjects ∪ the target community's named
-        // moderators) or is reached by an owner-bound duty-holder via a
+        // moderators) or is reached by an steward-bound duty-holder via a
         // live `takedown`-scoped chain. Absence ⇒ REJECT.
         if takedown.is_some() {
             let directory =
@@ -511,7 +511,7 @@ impl NodeCoreService for SqliteNodeCoreBackend {
         // FederationDirectory for the delegates_to + community walks; admit
         // IFF the accuser IS a duty-holder over the target (declared
         // subjects ∪ the target community's named moderators) or is reached
-        // by an owner-bound duty-holder via a live `moderate`-scoped chain.
+        // by an steward-bound duty-holder via a live `moderate`-scoped chain.
         // Absence ⇒ REJECT. Runs BEFORE the INSERT closure takes the lock.
         {
             let directory =
@@ -3650,7 +3650,7 @@ mod tests {
     }
 
     /// Seed a `federation_keys` row for `key_id` with identity_type=user
-    /// (owner-bound by clause (1) of `is_owner_bound`).
+    /// (steward-bound by clause (1) of `is_steward_bound`).
     async fn seed_user_key(backend: &SqliteBackend, key_id: &str) {
         use crate::federation::FederationDirectory;
         // v9.0.0 (CC 5.3.2.4.3.1) — register REAL deterministic hybrid
@@ -3909,7 +3909,7 @@ mod tests {
         .await
         .expect("(b1) subject-delegated moderation admitted");
 
-        // (b2) named-moderator (community founder, owner-bound) → ADMIT.
+        // (b2) named-moderator (community founder, steward-bound) → ADMIT.
         // No establishing content needed — community-scoped duty.
         cn.put_moderation_event(build_moderation_event(
             &founder_key,
@@ -4061,7 +4061,7 @@ mod tests {
             "fail-secure: undetermined subject_of must REJECT subject-self"
         );
 
-        // named-mod path (b) still ADMITs a real owner-bound founder.
+        // named-mod path (b) still ADMITs a real steward-bound founder.
         cn.put_moderation_event(build_moderation_event(
             &founder_key,
             "target",
@@ -4158,7 +4158,7 @@ mod tests {
         assert_eq!(err.kind(), "cirisnode_delegated_scope_unauthorized");
 
         // (e) chain beyond the §11.10 depth cap (5) → REJECTED. Root k0 is
-        // the owner-bound subject; every edge takedown-scoped + sub_delegation.
+        // the steward-bound subject; every edge takedown-scoped + sub_delegation.
         let depth = crate::federation::admission::MAX_MODERATION_DELEGATION_DEPTH;
         let n = depth + 2;
         let chain_keys: Vec<ed25519_dalek::SigningKey> = (0..n)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2058,7 +2058,7 @@ impl Engine {
     // the canonicalize→sign→assemble→put recipe (the #247 derived-key_id
     // floor is inherited: the attester/scrub key is always the signer's
     // DERIVED federation key_id, never a caller alias). `grant_delegation`
-    // is the general primitive; `owner_bind` / `add_moderator` specialize
+    // is the general primitive; `steward_bind` / `add_moderator` specialize
     // it with the CC 4.4.3.4.3 `infra:*` and §11.10 duty scopes; the
     // `revoke_*` pair emit a producer-self `withdraws` (rule-1 admitted)
     // against the prior edge.
@@ -2071,13 +2071,13 @@ impl Engine {
     /// `sub_delegation` bool) and composes
     /// [`Self::emit_attestation`] with `attestation_type = "delegates_to"`
     /// and `attested_key_id = delegate_key_id` (the recipient — required so
-    /// the per-edge retraction bucketing in the duty walk + `is_owner_bound`
+    /// the per-edge retraction bucketing in the duty walk + `is_steward_bound`
     /// key the edge by its recipient). Returns the `attestation_id`.
     ///
     /// `delegate_key_id` MUST exist in `federation_keys` (the
     /// `attested_key_id` FK). The CC 4.4.3.4.3 node-agency gate runs on the
     /// emitted row: a node-ONLY recipient may carry only `infra:*` scopes —
-    /// use [`Self::owner_bind`] for that case. `#247`-derived
+    /// use [`Self::steward_bind`] for that case. `#247`-derived
     /// `attesting_key_id` is internal.
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
     pub async fn grant_delegation(
@@ -2094,32 +2094,32 @@ impl Engine {
             envelope,
         );
         // The edge is keyed by its RECIPIENT: the §11.10 duty walk + the
-        // `is_owner_bound` retraction bucketing both match a delegation /
+        // `is_steward_bound` retraction bucketing both match a delegation /
         // its later `withdraws` by `attested_key_id`, so a `delegates_to`
         // MUST name the delegate there (not the self-attestation default).
         input.attested_key_id = Some(delegate_key_id.to_owned());
         self.emit_attestation(signer, input).await
     }
 
-    /// v9.3.0 (CIRISPersist#249, CC 4.4.3.4.3 owner-binding) — bind a node /
-    /// agent occurrence to its owner by granting it **`infra:*`-only**
+    /// v9.3.0 (CIRISPersist#249, CC 4.4.3.4.3 steward-binding) — bind a node /
+    /// agent occurrence to its steward by granting it **`infra:*`-only**
     /// scopes. A [`Self::grant_delegation`] specialization that carries ONLY
     /// server-class (`infra:*`) authority, so it passes the CC 4.4.3.4.3
     /// node-agency gate even when `node_or_agent_key_id` resolves to a
     /// node-ONLY identity (the gate rejects any non-`infra:*` token on such
-    /// a key). `sub_delegation` is `false` — an owner-binding is a leaf
+    /// a key). `sub_delegation` is `false` — an steward-binding is a leaf
     /// authorization, not a deputization. Returns the `attestation_id`.
     ///
     /// `infra_scopes` SHOULD be drawn from
     /// [`delegation_scope`](crate::federation::types::delegation_scope)'s
     /// `INFRA_*` constants; an empty set or any non-`infra:*` token will be
     /// rejected by the node-agency gate (`scopes_are_infra_only`) when the
-    /// recipient is a node key. The owner-binding this writes is exactly the
-    /// `delegates_to(U → k)` edge [`is_owner_bound`] reads.
+    /// recipient is a node key. The steward-binding this writes is exactly the
+    /// `delegates_to(U → k)` edge [`is_steward_bound`] reads.
     ///
-    /// [`is_owner_bound`]: crate::federation::admission::is_owner_bound
+    /// [`is_steward_bound`]: crate::federation::admission::is_steward_bound
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
-    pub async fn owner_bind(
+    pub async fn steward_bind(
         &self,
         signer: &crate::signing::LocalSigner,
         node_or_agent_key_id: &str,
@@ -2137,13 +2137,13 @@ impl Engine {
     /// holds IFF the `signer` is in the community's authority set
     /// (founder / consensus signer per
     /// [`community_authority_set`](crate::federation::admission)) AND
-    /// owner-bound — the appointment edge `signer → moderator` is the
+    /// steward-bound — the appointment edge `signer → moderator` is the
     /// root-out-edge the §11.10 duty walk traverses.
     ///
     /// `community_id` rides the appointment **implicitly**: the §11.10 walk
     /// resolves the community → its authority roots, then walks `root →*
     /// moderator` over `duty`-scoped `delegates_to` edges — so the binding
-    /// is "this owner-bound community authority delegated `duty` to the
+    /// is "this steward-bound community authority delegated `duty` to the
     /// moderator", NOT a `community_id` field on the edge. The caller is
     /// therefore responsible for `signer` BEING a community authority (this
     /// helper emits the edge; admissibility is the authority-set membership,
@@ -2174,7 +2174,7 @@ impl Engine {
     /// [`withdraws_attestation_envelope`](crate::federation::withdraws_attestation_envelope)
     /// referencing the target edge, and `attested_key_id = delegate_key_id`
     /// — the recipient the original edge named, so the §11.10 walk's
-    /// per-edge retraction bucketing (and `is_owner_bound`'s) recognize the
+    /// per-edge retraction bucketing (and `is_steward_bound`'s) recognize the
     /// retraction (both match a `withdraws` by `attested_key_id == k`).
     /// Returns the `attestation_id`.
     ///
@@ -3431,16 +3431,35 @@ impl Engine {
         .await
     }
 
-    /// #249 Cut B — the `user`-role key(s) that owner-bind `key_id`. See
-    /// [`admission::owner_bindings_of`](crate::federation::admission::owner_bindings_of).
+    /// #249 Cut B — the `user`-role key(s) that steward-bind `key_id`. See
+    /// [`admission::steward_bindings_of`](crate::federation::admission::steward_bindings_of).
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
-    pub async fn owner_bindings_of(
+    pub async fn steward_bindings_of(
         &self,
         key_id: &str,
     ) -> Result<Vec<String>, crate::federation::Error> {
-        crate::federation::admission::owner_bindings_of(
+        crate::federation::admission::steward_bindings_of(
             self.federation_directory().as_ref(),
             key_id,
+        )
+        .await
+    }
+
+    /// CIRISPersist#299 — the **outbound** steward-binding reader: the nodes
+    /// `steward_user_key_id` owns. The exact inverse of [`Self::steward_bindings_of`]
+    /// (`n ∈ nodes_stewarded_by(U)` ⟺ `U ∈ steward_bindings_of(n)`), so "list the
+    /// nodes I own" (the client node-switcher) is one substrate call instead of
+    /// a consumer-side scan-then-confirm. Inherits the
+    /// liveness/`withdraws`-`recants`-retraction/live-`user`-role-anchor logic
+    /// verbatim (membership is decided by `steward_bindings_of` itself). See
+    /// [`crate::federation::admission::nodes_stewarded_by`].
+    pub async fn nodes_stewarded_by(
+        &self,
+        steward_user_key_id: &str,
+    ) -> Result<Vec<String>, crate::federation::Error> {
+        crate::federation::admission::nodes_stewarded_by(
+            self.federation_directory().as_ref(),
+            steward_user_key_id,
         )
         .await
     }
@@ -3504,15 +3523,15 @@ impl Engine {
         .await
     }
 
-    /// #249 Cut B — the owner-binding PATH (`user → … → key_id`, anchor-
+    /// #249 Cut B — the steward-binding PATH (`user → … → key_id`, anchor-
     /// first) for audit. See
-    /// [`admission::owner_binding_chain`](crate::federation::admission::owner_binding_chain).
+    /// [`admission::steward_binding_chain`](crate::federation::admission::steward_binding_chain).
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
-    pub async fn owner_binding_chain(
+    pub async fn steward_binding_chain(
         &self,
         key_id: &str,
     ) -> Result<Vec<String>, crate::federation::Error> {
-        crate::federation::admission::owner_binding_chain(
+        crate::federation::admission::steward_binding_chain(
             self.federation_directory().as_ref(),
             key_id,
         )
@@ -8189,15 +8208,15 @@ mod tests {
     // `emit_attestation` (no re-hand-roll), so the attester/scrub key is the
     // signer's DERIVED key_id (#247 floor); we additionally assert the
     // emitted edge is ADMISSIBLE by the reader gate it targets
-    // (`is_named_moderator` / `is_owner_bound` / the moderation `scores`
+    // (`is_named_moderator` / `is_steward_bound` / the moderation `scores`
     // gate) — proving the moderate-scope tokens match the duty walk.
 
     /// A `user`-role `federation_keys` row keyed by `derived_key_id` but
     /// carrying `pubkey_label`'s REAL deterministic hybrid pubkeys — so a
     /// federation-tier row attested as `derived_key_id` and signed by
     /// `pubkey_label`'s keys both FK-resolves AND hybrid-verifies, while the
-    /// `user` identity_type makes the key owner-bound (clause 1 of
-    /// `is_owner_bound`). The owner-bound-authority shape the §11.10
+    /// `user` identity_type makes the key steward-bound (clause 1 of
+    /// `is_steward_bound`). The steward-bound-authority shape the §11.10
     /// named-moderator walk requires at the root.
     #[cfg(any(feature = "sqlite", feature = "postgres"))]
     fn user_test_key_derived_for(
@@ -8210,7 +8229,7 @@ mod tests {
     }
 
     /// Seed a `founder_only` community whose sole founder is
-    /// `founder_key_id` (already registered + owner-bound). The community's
+    /// `founder_key_id` (already registered + steward-bound). The community's
     /// own key is registered too (required by `community_authority_set`).
     #[cfg(any(feature = "sqlite", feature = "postgres"))]
     async fn seed_community_with_founder(
@@ -8290,14 +8309,14 @@ mod tests {
         assert!(by.iter().any(|a| a.attestation_id == att_id));
     }
 
-    /// #249 — `owner_bind` emits an `infra:*`-only `delegates_to` from an
-    /// owner-bound (user) signer to a node-ONLY key: it PASSES the CC
+    /// #249 — `steward_bind` emits an `infra:*`-only `delegates_to` from an
+    /// steward-bound (user) signer to a node-ONLY key: it PASSES the CC
     /// 4.4.3.4.3 node-agency gate (so it stores), and afterward
-    /// `is_owner_bound(node)` is true (the edge the reader walks).
+    /// `is_steward_bound(node)` is true (the edge the reader walks).
     #[cfg(feature = "sqlite")]
     #[tokio::test]
-    async fn owner_bind_infra_only_passes_node_agency_and_owner_binds_sqlite() {
-        use crate::federation::admission::is_owner_bound;
+    async fn steward_bind_infra_only_passes_node_agency_and_steward_binds_sqlite() {
+        use crate::federation::admission::is_steward_bound;
         use crate::federation::types::delegation_scope;
         use crate::federation::FederationDirectory;
         let signer = crate::federation::tier_ingest::test_support::local_signer("owner");
@@ -8306,7 +8325,7 @@ mod tests {
             .await
             .expect("engine");
         let sq = engine.sqlite_backend().expect("sqlite").clone();
-        // Owner is user-role (owner-bound) + verifies at the ingest gate.
+        // Owner is user-role (steward-bound) + verifies at the ingest gate.
         sq.put_public_key(user_test_key_derived_for(&derived, "owner"))
             .await
             .expect("seed owner");
@@ -8315,9 +8334,9 @@ mod tests {
         node_key.record.identity_type = crate::federation::types::identity_type::NODE.into();
         sq.put_public_key(node_key).await.expect("seed node");
 
-        // infra:*-only owner-binding → admissible on a node key.
+        // infra:*-only steward-binding → admissible on a node key.
         let att_id = engine
-            .owner_bind(
+            .steward_bind(
                 &signer,
                 "node-1",
                 vec![
@@ -8326,7 +8345,7 @@ mod tests {
                 ],
             )
             .await
-            .expect("owner_bind infra:* admitted on node key");
+            .expect("steward_bind infra:* admitted on node key");
         let row = sq.get_attestation(&att_id).await.unwrap().expect("row");
         // Edge carries infra:* only (passed the node-agency gate).
         let scope = row.attestation_envelope["scope"].as_array().unwrap();
@@ -8334,12 +8353,12 @@ mod tests {
             scope
                 .iter()
                 .all(|s| s.as_str().unwrap().starts_with("infra:")),
-            "owner_bind edge is infra:*-only"
+            "steward_bind edge is infra:*-only"
         );
-        // The node is now owner-bound (a live delegates_to(U → node), U user).
+        // The node is now steward-bound (a live delegates_to(U → node), U user).
         assert!(
-            is_owner_bound(&*sq, "node-1").await.unwrap(),
-            "node is owner-bound after owner_bind"
+            is_steward_bound(&*sq, "node-1").await.unwrap(),
+            "node is steward-bound after steward_bind"
         );
 
         // Negative control: an agency:* scope on the SAME node key is REJECTED
@@ -8358,7 +8377,7 @@ mod tests {
     }
 
     /// #249 — the add_moderator ↔ is_named_moderator round-trip: an
-    /// owner-bound community founder appoints a moderator with the
+    /// steward-bound community founder appoints a moderator with the
     /// `moderate` duty; `is_named_moderator(moderator, community, moderate)`
     /// is true after — proving SCOPE_MODERATE matches the §11.10 duty walk.
     /// Then `remove_moderator` revokes it and the authority no longer holds.
@@ -8374,7 +8393,7 @@ mod tests {
             .await
             .expect("engine");
         let sq = engine.sqlite_backend().expect("sqlite").clone();
-        // Founder: owner-bound (user) authority root of the community.
+        // Founder: steward-bound (user) authority root of the community.
         sq.put_public_key(user_test_key_derived_for(&derived, "founder"))
             .await
             .expect("seed founder");
@@ -9058,7 +9077,7 @@ mod tests {
 
         // G4 rekey/events don't verify member signatures, so members are
         // registered as PRIMITIVE keys (sweeper_test_key) — non-node/agent, so
-        // they pass the CC 3.2 community owner-binding gate without owner-binds.
+        // they pass the CC 3.2 community steward-binding gate without steward-binds.
         let joined: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
 
         // ── §7 community rekey-on-revoke (epoch bump) ──
@@ -9252,7 +9271,7 @@ mod tests {
         seed_community_with_founder(&engine, "comm-1", &derived).await;
 
         // The founder IS a named moderator (community authority root,
-        // owner-bound) → as-self duty-holder → ADMIT.
+        // steward-bound) → as-self duty-holder → ADMIT.
         let content_sha = "a".repeat(64);
         let att_id = engine
             .file_moderation(&signer, &content_sha, "comm-1", "moderate", "rogue_action")

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3453,6 +3453,7 @@ impl Engine {
     /// liveness/`withdraws`-`recants`-retraction/live-`user`-role-anchor logic
     /// verbatim (membership is decided by `steward_bindings_of` itself). See
     /// [`crate::federation::admission::nodes_stewarded_by`].
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
     pub async fn nodes_stewarded_by(
         &self,
         steward_user_key_id: &str,

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -1469,7 +1469,7 @@ async fn issuer_reaches_target_via_scoped_delegation(
 ///
 /// This is the general primitive every delegated-duty reader specializes:
 /// [`moderators_of`] / [`is_named_moderator`] root it at a community
-/// authority set, [`owner_bindings_of`] / [`owner_binding_chain`] read the
+/// authority set, [`steward_bindings_of`] / [`steward_binding_chain`] read the
 /// human anchor, and `duty_holders_*` compose it per target. It is a thin
 /// `pub` wrapper over the private predicate walk
 /// [`issuer_reaches_target_via_scoped_delegation`] with a singleton target
@@ -1705,7 +1705,7 @@ pub async fn reachable_under_scope_with_reasons(
 /// `scope_token`, under the same [`DelegationWalkPolicy`] (attenuation +
 /// `sub_delegation`-gated deputization + withdrawn-edge skipping + depth
 /// cap). The returned set EXCLUDES `issuer` itself (the caller adds the
-/// owner-bound roots separately) — it is exactly the set of delegates the
+/// steward-bound roots separately) — it is exactly the set of delegates the
 /// `issuer` root empowers under `scope_token`.
 ///
 /// Identical BFS to the predicate (same edge filters, same per-node
@@ -2038,7 +2038,7 @@ pub async fn check_withdraws_admission(
 //
 // v8.7.1 (CIRISPersist#233) REPLACES the v8.7.0 `on_behalf_of`-field model
 // entirely. RC24 §11.10 pins the principal as the chain ROOT discovered by
-// walking UP from `attesting_key_id` to an owner-bound scoped duty-holder —
+// walking UP from `attesting_key_id` to an steward-bound scoped duty-holder —
 // NOT a payload field. The v8.7.0 absent/empty/self ⇒ admit path WAS the
 // bypass: CIRISServer#15 never emits `on_behalf_of` (not a spec field), so
 // every emission hit the as-self admit path and the authority check never
@@ -2052,7 +2052,7 @@ pub async fn check_withdraws_admission(
 //       scope-bearing `delegates_to` chain `root →* attesting_key_id`
 //       (every edge `scope ⊇ {duty}`, `⊆`-parent attenuation,
 //       `sub_delegation`-gated deputization, depth ≤ 5, no `withdraws`-
-//       revoked edge) AND `is_owner_bound(root)`.
+//       revoked edge) AND `is_steward_bound(root)`.
 //   else REJECT. Absence is NEVER an admit condition.
 
 /// v8.7.0 (CIRISPersist#232, CEG §11.10) — reserved `scores` dimension
@@ -2082,7 +2082,7 @@ pub const RECONSIDERATION_DIMENSION_PREFIX: &str = "reconsideration:";
 pub const MAX_MODERATION_DELEGATION_DEPTH: usize = 5;
 
 /// v8.7.1 (CIRISPersist#233, CEG RC25/RC26 §5.6.8.10) — is key `k`
-/// **owner-bound**? A moderation chain ROOT must terminate in a real human
+/// **steward-bound**? A moderation chain ROOT must terminate in a real human
 /// (a `user`-role identity), never a free-floating agent/service key — the
 /// §11.10 "takedown isn't a coup" anchor. True iff ANY of:
 ///
@@ -2097,15 +2097,15 @@ pub const MAX_MODERATION_DELEGATION_DEPTH: usize = 5;
 ///      delegation the granter has `withdraws`/`recants`-retracted against
 ///      `k` (the §11.10 edge-retraction model) AND one whose `expires_at`
 ///      has passed (SecReview F3) — a revoked or lapsed edge confers no
-///      owner-binding.
+///      steward-binding.
 ///
 /// A key whose chain to a `user` identity cannot be shown is NOT
-/// owner-bound and cannot root a moderation duty (fail-closed). Authority
+/// steward-bound and cannot root a moderation duty (fail-closed). Authority
 /// that the `user`-role key genuinely is a human is consumer/registry
 /// policy (§5.6.8.10 normative-honesty); persist resolves it structurally
 /// over the `federation_keys` `identity_type` set + occurrence + delegation
 /// graph that are already present.
-pub async fn is_owner_bound(
+pub async fn is_steward_bound(
     directory: &dyn super::FederationDirectory,
     k: &str,
 ) -> Result<bool, Error> {
@@ -2126,7 +2126,7 @@ pub async fn is_owner_bound(
     }
     // (3) a LIVE `delegates_to(U → k)` with U user-role. k's INCOMING
     //     attestations name the granter as `attesting_key_id`. A delegation
-    //     edge confers owner-binding ONLY while genuinely live (SecReview
+    //     edge confers steward-binding ONLY while genuinely live (SecReview
     //     F3): skip it if (a) the granter has `withdraws`/`recants`-retracted
     //     it (reusing the §11.10 edge-retraction bucketing the MODERATION_DUTY
     //     walk uses — a retraction names the recipient `k` as
@@ -2169,11 +2169,11 @@ pub async fn is_owner_bound(
     Ok(false)
 }
 
-/// #249 Cut B — the **enumeration** of [`is_owner_bound`]: the `user`-role
-/// key(s) that owner-bind `k` (who `k` is owner-bound TO). Collects every
+/// #249 Cut B — the **enumeration** of [`is_steward_bound`]: the `user`-role
+/// key(s) that steward-bind `k` (who `k` is steward-bound TO). Collects every
 /// human anchor across the same three clauses the predicate tests:
 ///
-///   1. `k`'s OWN key is `user`-role → `k` owner-binds itself (`k` is in the
+///   1. `k`'s OWN key is `user`-role → `k` steward-binds itself (`k` is in the
 ///      set); AND/OR
 ///   2. `k` is an occurrence of a `user`-role identity → that identity key;
 ///      AND/OR
@@ -2181,11 +2181,11 @@ pub async fn is_owner_bound(
 ///      `user`-role (live = not `withdraws`/`recants`-retracted against `k`
 ///      by `U`, and not expired) → `U`.
 ///
-/// Consistency: `is_owner_bound(k)` ⟺ `!owner_bindings_of(k).is_empty()` —
+/// Consistency: `is_steward_bound(k)` ⟺ `!steward_bindings_of(k).is_empty()` —
 /// the predicate returns true iff ANY clause holds, and this returns the
 /// union of all satisfying anchors (deduped, sorted). An unbound `k` yields
 /// the empty set.
-pub async fn owner_bindings_of(
+pub async fn steward_bindings_of(
     directory: &dyn super::FederationDirectory,
     k: &str,
 ) -> Result<Vec<String>, Error> {
@@ -2240,26 +2240,97 @@ pub async fn owner_bindings_of(
     Ok(out)
 }
 
-/// #249 Cut B — the owner-binding **PATH** for audit: the actual delegation
-/// chain `user → … → key_id` that owner-binds `key_id`, anchor-first (the
-/// human `user`-role key at index 0, `key_id` last). Where
-/// [`owner_bindings_of`] returns just the human ENDPOINTS, this returns the
-/// resolving path so a consumer can show WHY a key is owner-bound.
+/// CIRISPersist#299 — the **outbound** steward-binding projection: the nodes a
+/// `user`-role key owns. The exact inverse of [`steward_bindings_of`]:
 ///
-/// Resolves the FIRST satisfying clause in [`is_owner_bound`]'s precedence
-/// order (so `!owner_binding_chain(k).is_empty()` ⟺ `is_owner_bound(k)`):
+/// ```text
+/// n ∈ nodes_stewarded_by(U)  ⟺  U ∈ steward_bindings_of(n)
+/// ```
+///
+/// Consumers (CIRISServer's `auth::ownership::nodes_stewarded_by`, driving the
+/// client node-switcher `GET /v1/setup/owned-nodes`) used to hand-roll this:
+/// scan `U`'s outgoing `delegates_to` edges, then confirm each candidate back
+/// through `steward_bindings_of` — re-deriving liveness/retraction/role
+/// semantics at the consumer and missing the occurrence half. This folds it
+/// into one substrate reader, with **read-after-write correctness owned where
+/// the objects live**.
+///
+/// Implementation enumerates the candidate nodes `U` could steward-bind, then
+/// **confirms each via [`steward_bindings_of`]** (the single source of truth) —
+/// so the inverse property holds by construction and the
+/// liveness/`withdraws`/`recants`-retraction/live-`user`-role-anchor logic is
+/// inherited verbatim, never re-implemented. Candidates:
+///
+///   * **clause (3)** — `U`'s OUTGOING `delegates_to` edges → each recipient
+///     (`list_attestations_by(U)`);
+///   * **clause (2)** — occurrences that speak for identity `U`
+///     (`list_identity_occurrences_for(U)`);
+///   * **clause (1)** — `U` itself (so the invariant holds exactly: `U` is
+///     returned iff `U` is `user`-role, i.e. `U` steward-binds itself). A
+///     consumer wanting "nodes OTHER than me" filters `== U` — that's a
+///     presentation choice, not substrate policy.
+///
+/// Returns the deduped, sorted set; empty when `U` owns nothing (or isn't a
+/// live `user`-role anchor — `steward_bindings_of` fails each candidate closed).
+pub async fn nodes_stewarded_by(
+    directory: &dyn super::FederationDirectory,
+    steward_user_key_id: &str,
+) -> Result<Vec<String>, Error> {
+    // Enumerate candidate nodes (cheap, indexed reads) — NOT a full scan.
+    let mut candidates: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // (3) U's outgoing delegates_to edges → recipients.
+    for r in directory.list_attestations_by(steward_user_key_id).await? {
+        if r.attestation_type == attestation_type::DELEGATES_TO {
+            candidates.insert(r.attested_key_id);
+        }
+    }
+    // (2) occurrences speaking for identity U.
+    for occ in directory
+        .list_identity_occurrences_for(steward_user_key_id)
+        .await?
+    {
+        candidates.insert(occ.occurrence_key_id);
+    }
+    // (1) U itself (exact-inverse: U owns U iff U is user-role).
+    candidates.insert(steward_user_key_id.to_owned());
+
+    // Confirm each candidate through steward_bindings_of — the inverse is exact
+    // because membership is decided by the SAME predicate, never a re-derived
+    // copy of its liveness/retraction/role rules.
+    let mut out: Vec<String> = Vec::new();
+    for cand in candidates {
+        if steward_bindings_of(directory, &cand)
+            .await?
+            .iter()
+            .any(|anchor| anchor == steward_user_key_id)
+        {
+            out.push(cand);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// #249 Cut B — the steward-binding **PATH** for audit: the actual delegation
+/// chain `user → … → key_id` that steward-binds `key_id`, anchor-first (the
+/// human `user`-role key at index 0, `key_id` last). Where
+/// [`steward_bindings_of`] returns just the human ENDPOINTS, this returns the
+/// resolving path so a consumer can show WHY a key is steward-bound.
+///
+/// Resolves the FIRST satisfying clause in [`is_steward_bound`]'s precedence
+/// order (so `!steward_binding_chain(k).is_empty()` ⟺ `is_steward_bound(k)`):
 ///   1. `k` is itself `user`-role → `[k]` (the key IS the human anchor).
 ///   2. `k` is an occurrence of a `user`-role identity → `[identity, k]`.
 ///   3. a **live** `delegates_to(U → k)` with `U` `user`-role (not
 ///      `withdraws`/`recants`-retracted against `k`, not expired) →
-///      `[U, k]`. The §11.10 owner-binding clause (3) is a DIRECT incoming
+///      `[U, k]`. The §11.10 steward-binding clause (3) is a DIRECT incoming
 ///      edge (same as the predicate), so the delegated path is one hop; a
-///      multi-hop human→…→k owner-binding is not part of the predicate and
+///      multi-hop human→…→k steward-binding is not part of the predicate and
 ///      is not synthesized here.
 ///
-/// Returns the empty vec when `k` is not owner-bound (fail-closed, mirrors
+/// Returns the empty vec when `k` is not steward-bound (fail-closed, mirrors
 /// the predicate).
-pub async fn owner_binding_chain(
+pub async fn steward_binding_chain(
     directory: &dyn super::FederationDirectory,
     key_id: &str,
 ) -> Result<Vec<String>, Error> {
@@ -2279,7 +2350,7 @@ pub async fn owner_binding_chain(
     }
     // (3) a LIVE delegates_to(U → k) with U user-role — U → k. Lowest
     //     granter key_id first for a deterministic path when several humans
-    //     delegate to k (consistent with the sorted `owner_bindings_of`).
+    //     delegate to k (consistent with the sorted `steward_bindings_of`).
     let now = chrono::Utc::now();
     let mut anchors: Vec<String> = Vec::new();
     for r in directory.list_attestations_for(key_id).await? {
@@ -2318,7 +2389,7 @@ pub async fn owner_binding_chain(
 }
 
 /// v9.0.0 SecReview F2 (CC 3.2 / CC 4.4.3.2.1) — is `community` an
-/// **authorized** infrastructure community whose carve-outs (owner-binding
+/// **authorized** infrastructure community whose carve-outs (steward-binding
 /// exemption + Commons-plaintext opt-out) may be honored?
 ///
 /// A `cohort_subkind: infrastructure` label is honored ONLY IF the
@@ -2330,13 +2401,13 @@ pub async fn owner_binding_chain(
 /// ([`default_reserved_prefix_rules`]). CC 3.2 reserves the infrastructure
 /// carve-out for genuine governance / trust roots (`ciris-canonical`);
 /// without this check ANY caller could self-label a community
-/// `infrastructure` to (a) skip the owner-binding gate and (b) force its
+/// `infrastructure` to (a) skip the steward-binding gate and (b) force its
 /// content to Commons-plaintext (no DEK).
 ///
 /// **Fail-secure:** a community labeled `infrastructure` whose key does
 /// NOT resolve to `substrate_persist` (or does not resolve at all) returns
 /// `false` — the label is NOT honored, so the caller falls through to the
-/// STRICTER non-infra path (owner-binding REQUIRED + DEK cascade applies).
+/// STRICTER non-infra path (steward-binding REQUIRED + DEK cascade applies).
 /// An unauthorized infra label can only ever get the stricter treatment,
 /// never the weaker one.
 pub async fn is_authorized_infrastructure_community<F>(
@@ -2369,13 +2440,13 @@ where
     }
 }
 
-/// v9.0.0 (CC 3.2 "owner-binding gate for non-infrastructure membership"
+/// v9.0.0 (CC 3.2 "steward-binding gate for non-infrastructure membership"
 /// / CC 3.4.7.1) — the community-admission precondition: a `node`- or
 /// `agent`-role roster member of a **non-infrastructure** community MUST
-/// be owner-bound ([`is_owner_bound`]) before admission. Non-infra
+/// be steward-bound ([`is_steward_bound`]) before admission. Non-infra
 /// membership is an *authority act* (standing to speak AS the group),
 /// and CC 1.13.2 requires authority to root in an accountable human — a
-/// fresh, unowned node/agent is **canonical-trust-and-serve only** until
+/// fresh, unstewarded node/agent is **canonical-trust-and-serve only** until
 /// owned. This is a **precondition**, not a substitute for the community's
 /// own `consensus_protocol` vote (which still governs *whether* an owned
 /// key is admitted).
@@ -2384,33 +2455,33 @@ where
 ///
 /// `cohort_subkind: infrastructure` communities (`ciris-canonical` /
 /// operator governance roots) are **EXEMPT** — a node MAY trust + serve
-/// an infrastructure community with no owner (CC 3.2 "Trust ≠
+/// an infrastructure community with no steward (CC 3.2 "Trust ≠
 /// membership"). The label is honored ONLY when
 /// [`is_authorized_infrastructure_community`] holds (the community's own
 /// key resolves to the `substrate_persist` governance authority, SecReview
 /// F2); a self-labeled infra community whose key is not `substrate_persist`
-/// gets the strict owner-binding treatment. For every other community this
+/// gets the strict steward-binding treatment. For every other community this
 /// gate runs per roster member.
 ///
 /// A member key that does NOT resolve in `federation_keys`, or whose
 /// `identity_type` set contains NEITHER `node` NOR `agent` (e.g. a pure
 /// `user`/`org` member, or an unrecognized future role), is **out of
 /// scope** — the gate constrains only node/agent standing. A `user`-role
-/// member trivially satisfies `is_owner_bound` (clause 1) and is never
+/// member trivially satisfies `is_steward_bound` (clause 1) and is never
 /// rejected here.
 ///
-/// Fail-secure: the FIRST node/agent member lacking a live owner-binding
-/// rejects the whole `put_community` with [`Error::UnownedCommunityMember`]
+/// Fail-secure: the FIRST node/agent member lacking a live steward-binding
+/// rejects the whole `put_community` with [`Error::UnstewardedCommunityMember`]
 /// BEFORE any row is stored (verify-before-mutation, AV-9).
-pub async fn check_community_membership_owner_binding(
+pub async fn check_community_membership_steward_binding(
     directory: &dyn super::FederationDirectory,
     community: &super::Community,
 ) -> Result<(), Error> {
-    // Infrastructure carve-out: trust + serve needs no owner (CC 3.2) —
+    // Infrastructure carve-out: trust + serve needs no steward (CC 3.2) —
     // honored ONLY for an AUTHORIZED infrastructure community (its own key
     // is the `substrate_persist` governance authority). A self-labeled
     // infra community whose key is NOT substrate_persist falls through to
-    // the strict owner-binding path below (SecReview F2, fail-secure).
+    // the strict steward-binding path below (SecReview F2, fail-secure).
     if is_authorized_infrastructure_community(directory, community).await? {
         return Ok(());
     }
@@ -2430,8 +2501,8 @@ pub async fn check_community_membership_owner_binding(
         } else {
             continue;
         };
-        if !is_owner_bound(directory, &member.key_id).await? {
-            return Err(Error::UnownedCommunityMember {
+        if !is_steward_bound(directory, &member.key_id).await? {
+            return Err(Error::UnstewardedCommunityMember {
                 community_key_id: community.community_key_id.clone(),
                 member_key_id: member.key_id.clone(),
                 member_role,
@@ -2452,7 +2523,7 @@ pub async fn check_community_membership_owner_binding(
 ///     `consensus_protocol` signers (resolved from the
 ///     [`Community`](crate::federation::types::Community) record via
 ///     [`FederationDirectory::lookup_community`]), AND
-///   - `is_owner_bound(root)`.
+///   - `is_steward_bound(root)`.
 ///
 /// A zero-hop appointment (`root == k`, root directly in the authority set)
 /// is admitted — a founder IS a named moderator of their own community. The
@@ -2462,7 +2533,7 @@ pub async fn check_community_membership_owner_binding(
 ///
 /// `community_id` is the community's `community_key_id`. Returns `false`
 /// (never errors) when the community is unknown, declares no authority set,
-/// or no owner-bound authority reaches `k` — fail-closed.
+/// or no steward-bound authority reaches `k` — fail-closed.
 ///
 /// [`MODERATION_DUTY`]: DelegationWalkPolicy::MODERATION_DUTY
 pub async fn is_named_moderator(
@@ -2474,11 +2545,11 @@ pub async fn is_named_moderator(
     let authority = community_authority_set(directory, community_id).await?;
     let target: std::collections::HashSet<String> = std::iter::once(k.to_owned()).collect();
     for root in authority {
-        // Owner-binding of the root is REQUIRED (§11.11 → §5.6.8.10).
-        if !is_owner_bound(directory, &root).await? {
+        // Steward-binding of the root is REQUIRED (§11.11 → §5.6.8.10).
+        if !is_steward_bound(directory, &root).await? {
             continue;
         }
-        // Zero-hop: the owner-bound authority IS the named moderator.
+        // Zero-hop: the steward-bound authority IS the named moderator.
         if root == k {
             return Ok(true);
         }
@@ -2501,21 +2572,21 @@ pub async fn is_named_moderator(
 
 /// #249 Cut B — the **enumeration** of [`is_named_moderator`]: the FULL
 /// named-moderator set of community `community_id` for `duty` — the
-/// owner-bound authority roots ∪ every delegate they reach via a live
+/// steward-bound authority roots ∪ every delegate they reach via a live
 /// `duty`-scoped `delegates_to` chain (the same [`MODERATION_DUTY`] walk
 /// `is_named_moderator` probes, but accumulated instead of target-tested).
 ///
 /// For each root in the community authority set
-/// ([`community_authority_set`]) that [`is_owner_bound`], the root itself is
+/// ([`community_authority_set`]) that [`is_steward_bound`], the root itself is
 /// a named moderator (zero-hop founder) AND every key it reaches under the
 /// §11.10 scoped walk
 /// ([`enumerate_scoped_delegation_reach`]) is one too. Returns the deduped
 /// key_id set (sorted for a deterministic surface). Consistency with the
 /// predicate: `is_named_moderator(k, …)` ⟺ `k ∈ moderators_of(…)`, because
-/// both compose the SAME authority set, the SAME owner-binding gate, and the
+/// both compose the SAME authority set, the SAME steward-binding gate, and the
 /// SAME scoped-reach walk.
 ///
-/// Fail-closed: an unknown community / no owner-bound authority yields the
+/// Fail-closed: an unknown community / no steward-bound authority yields the
 /// empty set (no named moderators), never an error.
 pub async fn moderators_of(
     directory: &dyn super::FederationDirectory,
@@ -2525,12 +2596,12 @@ pub async fn moderators_of(
     let authority = community_authority_set(directory, community_id).await?;
     let mut out: std::collections::HashSet<String> = std::collections::HashSet::new();
     for root in authority {
-        // Owner-binding of the root is REQUIRED (§11.11 → §5.6.8.10) — a
-        // non-owner-bound authority roots no moderation duty.
-        if !is_owner_bound(directory, &root).await? {
+        // Steward-binding of the root is REQUIRED (§11.11 → §5.6.8.10) — a
+        // non-steward-bound authority roots no moderation duty.
+        if !is_steward_bound(directory, &root).await? {
             continue;
         }
-        // Zero-hop: the owner-bound authority IS a named moderator.
+        // Zero-hop: the steward-bound authority IS a named moderator.
         // Then every delegate it reaches under the duty-scoped walk.
         let reach = enumerate_scoped_delegation_reach(
             directory,
@@ -2597,7 +2668,7 @@ pub const MEMBER_ROLE_FOUNDER: &str = "founder";
 ///
 ///   (a) **as-self** — `signer ∈ duty_holders` (it itself holds the duty
 ///       over the target), OR
-///   (b) **delegated** — ∃ `root ∈ duty_holders` that `is_owner_bound`
+///   (b) **delegated** — ∃ `root ∈ duty_holders` that `is_steward_bound`
 ///       AND reaches `signer` via a live `duty`-scoped chain under the
 ///       [`MODERATION_DUTY`] walk policy (every edge `scope ⊇ {duty}`,
 ///       `⊆`-parent attenuation, `sub_delegation`-gated deputization,
@@ -2628,11 +2699,11 @@ pub async fn check_moderation_admission(
     if duty_holders.contains(signer) {
         return Ok(());
     }
-    // (b) delegated: an owner-bound duty-holder root reaches signer via a
+    // (b) delegated: an steward-bound duty-holder root reaches signer via a
     //     live duty-scoped chain (§11.10 attenuation + sub_delegation).
     let target: std::collections::HashSet<String> = std::iter::once(signer.to_owned()).collect();
     for root in duty_holders {
-        if !is_owner_bound(directory, root).await? {
+        if !is_steward_bound(directory, root).await? {
             continue;
         }
         if issuer_reaches_target_via_scoped_delegation(
@@ -2733,7 +2804,7 @@ pub async fn subject_of_content(
 /// community moderators, only subjects). The named-moderator half resolves
 /// only the AUTHORITY ROOTS into the holder set — the per-signer walk-down
 /// is then done by [`check_moderation_admission`]; here we materialize the
-/// roots (the community authority set, owner-bound) so a signer who IS a
+/// roots (the community authority set, steward-bound) so a signer who IS a
 /// named moderator is admitted as-self.
 pub async fn duty_holders_for_content(
     directory: &dyn super::FederationDirectory,
@@ -2782,11 +2853,11 @@ pub async fn duty_holders_for_community(
 }
 
 /// Materialize the named-moderator AUTHORITY ROOTS for `community_id` /
-/// `duty` into the duty-holder set: each owner-bound member of the
+/// `duty` into the duty-holder set: each steward-bound member of the
 /// community authority set. (The full `is_named_moderator` relation —
 /// including delegates reached from these roots — is then enforced by
 /// [`check_moderation_admission`]'s per-signer walk-down rooted at these
-/// holders.) Empty community / no owner-bound authority ⇒ empty set.
+/// holders.) Empty community / no steward-bound authority ⇒ empty set.
 async fn named_moderator_holders(
     directory: &dyn super::FederationDirectory,
     community_id: &str,
@@ -2798,7 +2869,7 @@ async fn named_moderator_holders(
     let authority = community_authority_set(directory, community_id).await?;
     let mut holders = std::collections::HashSet::new();
     for root in authority {
-        if is_owner_bound(directory, &root).await? {
+        if is_steward_bound(directory, &root).await? {
             holders.insert(root);
         }
     }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -3333,12 +3333,12 @@ pub enum Error {
     /// §5.6.8.10; CIRISRegistry#95). A moderation / takedown / review
     /// primitive emission was refused: the `signer` is NOT a duty-holder
     /// over the target (it is neither a subject of the target content nor a
-    /// named moderator of the target community) AND no owner-bound
+    /// named moderator of the target community) AND no steward-bound
     /// duty-holder reaches it via a live `delegates_to` chain bearing the
     /// governing `scope` (`moderate` / `takedown` / `review`, with
     /// `⊆`-parent attenuation + `sub_delegation`-gated deputization + depth
     /// ≤ 5 + no `withdraws`-revoked edge). The row is not stored. This is
-    /// the §11.10 "the principal is the owner-bound chain root discovered by
+    /// the §11.10 "the principal is the steward-bound chain root discovered by
     /// walking up, and only then" gate — the child-safety scope-isolation
     /// property (a `consent_revocation`-scoped delegation cannot drive a
     /// `takedown`). **Absence is never an admit condition** (the v8.7.0
@@ -3350,7 +3350,7 @@ pub enum Error {
     #[error(
         "moderation emission by signer {signer:?} over target {on_behalf_of:?} \
          is not admitted: signer is neither a {scope:?} duty-holder as-self \
-         nor reached by an owner-bound duty-holder via a live {scope:?}-scoped \
+         nor reached by an steward-bound duty-holder via a live {scope:?}-scoped \
          delegates_to chain (CEG §11.10)"
     )]
     DelegatedScopeUnauthorized {
@@ -3436,31 +3436,31 @@ pub enum Error {
     /// v9.0.0 (CC 3.4.7.1 / CC 3.2). A `community` admission was REFUSED
     /// because one of its roster members resolves to a `node`- or
     /// `agent`-role identity ([`crate::federation::types::identity_type`])
-    /// that is **not owner-bound** — there is no live, unrevoked path from
+    /// that is **not steward-bound** — there is no live, unrevoked path from
     /// the member key to a `user`-role identity
-    /// ([`admission::is_owner_bound`]). Per the CC 3.2 "owner-binding gate
+    /// ([`admission::is_steward_bound`]). Per the CC 3.2 "steward-binding gate
     /// for non-infrastructure membership", non-infra community membership
     /// is an authority act that MUST root in an accountable human; a fresh,
-    /// unowned node/agent is canonical-trust-and-serve only. The gate is a
+    /// unstewarded node/agent is canonical-trust-and-serve only. The gate is a
     /// **precondition** to (not a substitute for) the community's own
     /// `consensus_protocol` vote. `cohort_subkind: infrastructure`
     /// communities are EXEMPT (trust + serve needs no owner). The row is
     /// NOT stored (verify-before-mutation, AV-9). Distinct from
     /// [`Error::InvalidArgument`] so consumers can pattern-match the
     /// rejection deterministically (stable `kind()` token
-    /// `federation_unowned_community_member`). See
-    /// [`admission::check_community_membership_owner_binding`].
+    /// `federation_unstewarded_community_member`). See
+    /// [`admission::check_community_membership_steward_binding`].
     #[error(
         "community {community_key_id:?} cannot admit member {member_key_id:?}: a {member_role} \
-         key MUST be owner-bound (a live delegates_to/identity_occurrence path to a user-role \
+         key MUST be steward-bound (a live delegates_to/identity_occurrence path to a user-role \
          identity) before admission to a non-infrastructure community \
          (CC 3.2 / CC 3.4.7.1 — non-infra membership is an authority act)"
     )]
-    UnownedCommunityMember {
+    UnstewardedCommunityMember {
         /// The community's `community_key_id` whose admission was refused.
         community_key_id: String,
         /// The roster member key that resolved to node/agent without a
-        /// live owner-binding.
+        /// live steward-binding.
         member_key_id: String,
         /// The offending role token (`node` or `agent`) — whichever was
         /// present in the member's `identity_type` set.
@@ -3531,7 +3531,7 @@ impl Error {
             Error::WithdrawsNotAdmitted { .. } => "federation_withdraws_not_admitted",
             Error::DelegatedScopeUnauthorized { .. } => "federation_delegated_scope_unauthorized",
             Error::NodeAgencyForbidden { .. } => "federation_node_agency_forbidden",
-            Error::UnownedCommunityMember { .. } => "federation_unowned_community_member",
+            Error::UnstewardedCommunityMember { .. } => "federation_unstewarded_community_member",
             Error::FederationTierUnverified { .. } => "federation_federation_tier_unverified",
             Error::WitnessAdmit(e) => e.kind(),
             Error::Backend(_) => "federation_backend",

--- a/src/federation/self_at_login.rs
+++ b/src/federation/self_at_login.rs
@@ -65,7 +65,7 @@ pub const SELF_AT_LOGIN_DELEGATION_SCOPE: [&str; 4] = [
 /// but we version uniformly so a future consumer can gate on it.
 pub const DIMENSION_DELEGATES_TO_AGENT: &str = "self:delegates_to:agent_occurrence:v1";
 /// v9.3.0 (CIRISPersist#249) — `dimension` for the GENERAL `delegates_to`
-/// envelope ([`delegates_to_envelope`]), the §11.10 grant/owner-bind/
+/// envelope ([`delegates_to_envelope`]), the §11.10 grant/steward-bind/
 /// add-moderator emit ceremonies' edge axis. `delegates_to` is a
 /// structural primitive (gate-exempt from the §13.1 dimension gate — only
 /// `scores` passes through [`crate::federation::admission::DimensionAdmissionPolicy`]),
@@ -120,7 +120,7 @@ pub fn delegates_to_agent_envelope(
 /// `scopes`", with an explicit `sub_delegation` deputization flag. This is
 /// the builder the §249 Cut C emit ceremonies
 /// ([`crate::Engine::grant_delegation`] and its specializations
-/// `owner_bind` / `add_moderator`) stamp; the login-specific
+/// `steward_bind` / `add_moderator`) stamp; the login-specific
 /// [`delegates_to_agent_envelope`] is the §8.1.12.7 specialization (it
 /// additionally carries `agent_occurrence_key_id` + `bilateral_pair_id`).
 ///
@@ -132,7 +132,7 @@ pub fn delegates_to_agent_envelope(
 /// ([`crate::federation::admission`]'s `delegation_grants_sub_delegation`)
 /// reads — a delegate WITHOUT it is a leaf (may exercise the duty, may not
 /// deputize onward). An edge built here is therefore directly admissible
-/// by `is_named_moderator` / `is_owner_bound` / `check_moderation_admission`.
+/// by `is_named_moderator` / `is_steward_bound` / `check_moderation_admission`.
 ///
 /// Wire shape (sorted-keys when canonicalized):
 ///

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4053,11 +4053,11 @@ impl PyEngine {
         })
     }
 
-    /// v9.3.0 (#249, CC 4.4.3.4.3) — owner-bind a node/agent occurrence by
+    /// v9.3.0 (#249, CC 4.4.3.4.3) — steward-bind a node/agent occurrence by
     /// granting it `infra:*`-only scopes (passes the node-agency gate on a
     /// node-only key). A `grant_delegation` specialization,
     /// `sub_delegation=false`.
-    fn owner_bind(
+    fn steward_bind(
         &self,
         py: Python<'_>,
         node_or_agent_key_id: &str,
@@ -4076,7 +4076,7 @@ impl PyEngine {
                 );
                 runtime.block_on(async move {
                     engine
-                        .owner_bind(&local_signer, &key, infra_scopes)
+                        .steward_bind(&local_signer, &key, infra_scopes)
                         .await
                         .map_err(federation_err_to_py)
                 })
@@ -4087,7 +4087,7 @@ impl PyEngine {
     /// v9.3.0 (#249, §11.10/§11.11) — appoint `moderator_key_id` a named
     /// moderator of `community_id` for `duty` (`moderate`/`takedown`/
     /// `review`). Admissible IFF the engine's signer is a community
-    /// authority (founder/consensus signer) AND owner-bound.
+    /// authority (founder/consensus signer) AND steward-bound.
     fn add_moderator(
         &self,
         py: Python<'_>,
@@ -6643,15 +6643,15 @@ impl PyEngine {
         })
     }
 
-    /// #249 Cut A — is `key_id` **owner-bound** (resolves to a `user`-role
+    /// #249 Cut A — is `key_id` **steward-bound** (resolves to a `user`-role
     /// human identity, directly / via occurrence / via a live `delegates_to`
     /// from a user-role granter)? Returns JSON `true` / `false`. Wraps the
     /// free function
-    /// [`admission::is_owner_bound`](crate::federation::admission::is_owner_bound) —
+    /// [`admission::is_steward_bound`](crate::federation::admission::is_steward_bound) —
     /// fail-closed (a key whose chain to a `user` identity cannot be shown is
-    /// not owner-bound). The most-reconstructed walk; exposing it stops
+    /// not steward-bound). The most-reconstructed walk; exposing it stops
     /// consumers re-deriving the §5.6.8.10 graph.
-    fn is_owner_bound_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+    fn is_steward_bound_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
             let runtime = self.runtime.clone();
@@ -6662,7 +6662,7 @@ impl PyEngine {
                         let backend = pg.clone();
                         runtime.block_on(async move {
                             use crate::federation::FederationDirectory;
-                            crate::federation::admission::is_owner_bound(
+                            crate::federation::admission::is_steward_bound(
                                 &*backend as &dyn FederationDirectory,
                                 &key_id,
                             )
@@ -6675,7 +6675,7 @@ impl PyEngine {
                         let backend = sq.clone();
                         runtime.block_on(async move {
                             use crate::federation::FederationDirectory;
-                            crate::federation::admission::is_owner_bound(
+                            crate::federation::admission::is_steward_bound(
                                 &*backend as &dyn FederationDirectory,
                                 &key_id,
                             )
@@ -6685,7 +6685,7 @@ impl PyEngine {
                     }
                 };
                 serde_json::to_string(&bound)
-                    .map_err(|e| PyValueError::new_err(format!("is_owner_bound serialize: {e}")))
+                    .map_err(|e| PyValueError::new_err(format!("is_steward_bound serialize: {e}")))
             })
         })
     }
@@ -6693,11 +6693,11 @@ impl PyEngine {
     /// #249 Cut A — the **duty-holders** of a bare community-scoped action
     /// (a `moderation:*` / `reconsideration:*` over `community_id` with no
     /// content subject) for `duty` (`moderate` / `takedown` / `review`): the
-    /// owner-bound authority roots of the community. Returns a JSON array of
+    /// steward-bound authority roots of the community. Returns a JSON array of
     /// key-id strings (the underlying `HashSet<String>` sorted for a stable
     /// payload). Wraps
     /// [`admission::duty_holders_for_community`](crate::federation::admission::duty_holders_for_community).
-    /// Empty community / no owner-bound authority ⇒ `[]`.
+    /// Empty community / no steward-bound authority ⇒ `[]`.
     fn duty_holders_for_community_json(
         &self,
         py: Python<'_>,
@@ -16159,7 +16159,7 @@ impl PyEngine {
     }
 
     /// #249 Cut B — the FULL named-moderator set of `community_key_id` for
-    /// `duty` (`moderate` / `takedown` / `review`): owner-bound authority
+    /// `duty` (`moderate` / `takedown` / `review`): steward-bound authority
     /// roots ∪ their duty-scoped delegates. Returns a JSON array of key_ids.
     fn moderators_of_json(
         &self,
@@ -16206,10 +16206,10 @@ impl PyEngine {
         })
     }
 
-    /// #249 Cut B — the `user`-role key(s) that owner-bind `key_id` (who
-    /// `key_id` is owner-bound TO). Returns a JSON array of key_ids; empty
-    /// when `key_id` is not owner-bound.
-    fn owner_bindings_of_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+    /// #249 Cut B — the `user`-role key(s) that steward-bind `key_id` (who
+    /// `key_id` is steward-bound TO). Returns a JSON array of key_ids; empty
+    /// when `key_id` is not steward-bound.
+    fn steward_bindings_of_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
             let runtime = self.runtime.clone();
@@ -16219,7 +16219,7 @@ impl PyEngine {
                     BackendDispatch::Postgres(pg) => {
                         let backend = pg.clone();
                         runtime.block_on(async move {
-                            crate::federation::admission::owner_bindings_of(&*backend, &key_id)
+                            crate::federation::admission::steward_bindings_of(&*backend, &key_id)
                                 .await
                                 .map_err(federation_err_to_py)
                         })?
@@ -16228,22 +16228,66 @@ impl PyEngine {
                     BackendDispatch::Sqlite(sq) => {
                         let backend = sq.clone();
                         runtime.block_on(async move {
-                            crate::federation::admission::owner_bindings_of(&*backend, &key_id)
+                            crate::federation::admission::steward_bindings_of(&*backend, &key_id)
                                 .await
                                 .map_err(federation_err_to_py)
                         })?
                     }
                 };
-                serde_json::to_string(&bindings)
-                    .map_err(|e| PyValueError::new_err(format!("owner_bindings_of serialize: {e}")))
+                serde_json::to_string(&bindings).map_err(|e| {
+                    PyValueError::new_err(format!("steward_bindings_of serialize: {e}"))
+                })
             })
         })
     }
 
-    /// #249 Cut B — the owner-binding PATH (`user → … → key_id`,
+    /// CIRISPersist#299 — the OUTBOUND steward-binding reader: the nodes
+    /// `steward_user_key_id` owns (exact inverse of `steward_bindings_of_json` —
+    /// `n ∈ nodes_stewarded_by(U)` ⟺ `U ∈ steward_bindings_of(n)`). Returns a JSON
+    /// array of key_ids; empty when `U` owns nothing. Inherits the
+    /// liveness/retraction/role logic verbatim (membership decided by
+    /// `steward_bindings_of`). `U` itself appears iff `U` is `user`-role — a
+    /// consumer wanting "nodes other than me" filters it client-side.
+    fn nodes_stewarded_by_json(
+        &self,
+        py: Python<'_>,
+        steward_user_key_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let owner = steward_user_key_id.to_owned();
+            py.detach(move || {
+                let nodes: Vec<String> = match &self.backend {
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::admission::nodes_stewarded_by(&*backend, &owner)
+                                .await
+                                .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::admission::nodes_stewarded_by(&*backend, &owner)
+                                .await
+                                .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(&nodes).map_err(|e| {
+                    PyValueError::new_err(format!("nodes_stewarded_by serialize: {e}"))
+                })
+            })
+        })
+    }
+
+    /// #249 Cut B — the steward-binding PATH (`user → … → key_id`,
     /// anchor-first) for audit — the chain, not just the endpoints. Returns
-    /// a JSON array of key_ids; empty when `key_id` is not owner-bound.
-    fn owner_binding_chain_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+    /// a JSON array of key_ids; empty when `key_id` is not steward-bound.
+    fn steward_binding_chain_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
             let runtime = self.runtime.clone();
@@ -16253,7 +16297,7 @@ impl PyEngine {
                     BackendDispatch::Postgres(pg) => {
                         let backend = pg.clone();
                         runtime.block_on(async move {
-                            crate::federation::admission::owner_binding_chain(&*backend, &key_id)
+                            crate::federation::admission::steward_binding_chain(&*backend, &key_id)
                                 .await
                                 .map_err(federation_err_to_py)
                         })?
@@ -16262,14 +16306,14 @@ impl PyEngine {
                     BackendDispatch::Sqlite(sq) => {
                         let backend = sq.clone();
                         runtime.block_on(async move {
-                            crate::federation::admission::owner_binding_chain(&*backend, &key_id)
+                            crate::federation::admission::steward_binding_chain(&*backend, &key_id)
                                 .await
                                 .map_err(federation_err_to_py)
                         })?
                     }
                 };
                 serde_json::to_string(&chain).map_err(|e| {
-                    PyValueError::new_err(format!("owner_binding_chain serialize: {e}"))
+                    PyValueError::new_err(format!("steward_binding_chain serialize: {e}"))
                 })
             })
         })
@@ -22971,11 +23015,11 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // node-only key is caller-side authorization failure; ValueError
         // (4xx). "Infrastructure must not have agency."
         crate::federation::Error::NodeAgencyForbidden { .. } => PyValueError::new_err(kind),
-        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — admitting an unowned node/agent to
+        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — admitting an unstewarded node/agent to
         // a non-infrastructure community is a caller-side authorization
         // failure (non-infra membership is an authority act that must root
         // in an owner); ValueError (4xx).
-        crate::federation::Error::UnownedCommunityMember { .. } => PyValueError::new_err(kind),
+        crate::federation::Error::UnstewardedCommunityMember { .. } => PyValueError::new_err(kind),
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — a federation-tier
         // attestation rejected at the bulk ingest gate (missing ML-DSA-65
         // half / tampered signature / canonicalizer mismatch /

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1272,7 +1272,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // A no-op for any non-matching row; for a moderation/review report
         // it admits IFF the signer IS a duty-holder over the target (the
         // row's subject_key_ids ∪ the envelope community_id's named
-        // moderators) or is reached by an owner-bound duty-holder via a live
+        // moderators) or is reached by an steward-bound duty-holder via a live
         // scoped delegates_to chain. Absence ⇒ REJECT. Runs BEFORE the state
         // lock for the same deadlock reason as the withdraws gate (the walk
         // calls list_attestations_by on self).
@@ -1883,13 +1883,14 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             chrono::Utc::now(),
         )
         .await?;
-        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
         // non-infrastructure community membership. Resolves member
-        // identity_type + owner-binding via the directory (locks state
+        // identity_type + steward-binding via the directory (locks state
         // itself), so it MUST run before the state lock below to avoid a
         // re-entrant deadlock. No-op for infrastructure communities and
         // for rosters with no node/agent members.
-        crate::federation::admission::check_community_membership_owner_binding(self, &row).await?;
+        crate::federation::admission::check_community_membership_steward_binding(self, &row)
+            .await?;
         let mut state = self.state.lock().expect("memory backend lock");
         if !state.federation_keys.contains_key(&row.community_key_id) {
             return Err(crate::federation::Error::InvalidArgument(format!(
@@ -6035,9 +6036,9 @@ mod tests {
     // (c2) nothing → REJECT (the bypass-closed guard), (d) scope isolation,
     // (e) depth>5, (f) ⊆-parent attenuation violation, (g) deputization
     // without sub_delegation, (h) withdraws on mid-chain edge, (i)
-    // non-owner-bound root.
+    // non-steward-bound root.
 
-    /// A `user`-role key (owner-bound by clause (1) of `is_owner_bound`).
+    /// A `user`-role key (steward-bound by clause (1) of `is_steward_bound`).
     fn fix_user_key(key_id: &str) -> KeyRecord {
         let mut k = fix_key(key_id, "primitive", key_id);
         k.identity_type = crate::federation::types::identity_type::USER.into();
@@ -6122,9 +6123,9 @@ mod tests {
     #[tokio::test]
     async fn memory_moderation_scores_review_full_matrix() {
         let backend = MemoryBackend::new();
-        // `subject` is a user (owner-bound), the content's own subject.
+        // `subject` is a user (steward-bound), the content's own subject.
         // `delegate`/`deep` are agent keys; `founder` is the community's
-        // owner-bound authority; `rando`/`modkey` are unauthorized.
+        // steward-bound authority; `rando`/`modkey` are unauthorized.
         backend
             .put_public_key(SignedKeyRecord {
                 record: fix_user_key("subject"),
@@ -6188,7 +6189,7 @@ mod tests {
             .expect("(b1) subject-delegated review admitted");
         assert!(backend.get_attestation("r-deleg").await.unwrap().is_some());
 
-        // (b2) named-moderator: community founder (owner-bound authority)
+        // (b2) named-moderator: community founder (steward-bound authority)
         // → ADMIT as-self (community-moderation case #95 unblocked).
         backend
             .put_attestation(SignedAttestation {
@@ -6352,7 +6353,7 @@ mod tests {
         // (MAX_MODERATION_DELEGATION_DEPTH = 5) is refused.
         let backend = MemoryBackend::new();
         let depth = crate::federation::admission::MAX_MODERATION_DELEGATION_DEPTH;
-        // k0 (the owner-bound subject root) → k1 → ... → k(depth+1).
+        // k0 (the steward-bound subject root) → k1 → ... → k(depth+1).
         let n = depth + 2;
         backend
             .put_public_key(SignedKeyRecord {
@@ -6405,7 +6406,7 @@ mod tests {
     async fn memory_moderation_scores_attenuation_and_subdelegation() {
         // (f) ⊆-parent attenuation violation → REJECT; (g) deputization
         // without sub_delegation → REJECT; (h) withdraws on a mid-chain
-        // edge → downstream REJECT; (i) non-owner-bound root → REJECT (b).
+        // edge → downstream REJECT; (i) non-steward-bound root → REJECT (b).
         let backend = MemoryBackend::new();
         backend
             .put_public_key(SignedKeyRecord {
@@ -6480,8 +6481,8 @@ mod tests {
             .await
             .expect("(g) direct delegate (mid) is admitted");
 
-        // (i) non-owner-bound root: agentroot (NOT user-role) → agdel
-        // (review). agentroot reaches agdel, but is NOT owner-bound, and is
+        // (i) non-steward-bound root: agentroot (NOT user-role) → agdel
+        // (review). agentroot reaches agdel, but is NOT steward-bound, and is
         // not in any community authority set → agdel REJECT under (b).
         backend
             .put_attestation(SignedAttestation {
@@ -6509,7 +6510,7 @@ mod tests {
         assert_eq!(
             err.kind(),
             "federation_delegated_scope_unauthorized",
-            "(i) non-owner-bound root cannot confer a delegated duty"
+            "(i) non-steward-bound root cannot confer a delegated duty"
         );
 
         // (h) withdraws on a mid-chain edge: subject → h_mid (review, sub),
@@ -6659,10 +6660,10 @@ mod tests {
         );
     }
 
-    // ── v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+    // ── v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
     // non-infrastructure community membership (memory backend; 3-backend
     // parity with sqlite + postgres). A node/agent roster member of a
-    // non-infra community MUST be owner-bound; infra communities + pure
+    // non-infra community MUST be steward-bound; infra communities + pure
     // user/canonical participation are not over-rejected.
 
     /// Submit a community `community_id` (its own key seeded) with the
@@ -6753,17 +6754,17 @@ mod tests {
             .unwrap();
     }
 
-    /// An UNOWNED node member of a non-infra community → REJECTED + not
+    /// An UNSTEWARDED node member of a non-infra community → REJECTED + not
     /// stored (the load-bearing CC 3.2 gate).
     #[tokio::test]
-    async fn community_unowned_node_member_rejected() {
+    async fn community_unstewarded_node_member_rejected() {
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         let err = put_community_with(&backend, "comm-ob-1", vec![member("ob-node")], None)
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref community_key_id,
                 ref member_key_id,
                 member_role,
@@ -6772,9 +6773,9 @@ mod tests {
                 assert_eq!(member_key_id, "ob-node");
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
-        assert_eq!(err.kind(), "federation_unowned_community_member");
+        assert_eq!(err.kind(), "federation_unstewarded_community_member");
         // Verify-before-mutation: nothing stored.
         assert!(backend
             .lookup_community("comm-ob-1")
@@ -6783,19 +6784,19 @@ mod tests {
             .is_none());
     }
 
-    /// An UNOWNED agent member → REJECTED (role reported as `agent`).
+    /// An UNSTEWARDED agent member → REJECTED (role reported as `agent`).
     #[tokio::test]
-    async fn community_unowned_agent_member_rejected() {
+    async fn community_unstewarded_agent_member_rejected() {
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         let err = put_community_with(&backend, "comm-ob-2", vec![member("ob-agent")], None)
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember { member_role, .. } => {
+            crate::federation::Error::UnstewardedCommunityMember { member_role, .. } => {
                 assert_eq!(member_role, crate::federation::types::identity_type::AGENT);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
         assert!(backend
             .lookup_community("comm-ob-2")
@@ -6804,15 +6805,15 @@ mod tests {
             .is_none());
     }
 
-    /// An OWNER-BOUND node member (live `delegates_to(user → node, infra:*)`)
+    /// An STEWARD-BOUND node member (live `delegates_to(user → node, infra:*)`)
     /// → ADMITTED. The infra-only scope both stores the delegation (past
-    /// the node-agency gate) and satisfies `is_owner_bound` clause (3).
+    /// the node-agency gate) and satisfies `is_steward_bound` clause (3).
     #[tokio::test]
-    async fn community_owner_bound_node_member_admitted() {
+    async fn community_steward_bound_node_member_admitted() {
         use crate::federation::types::delegation_scope as ds;
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
-        // owner (user) delegates infra:* to the node → owner-binding.
+        // owner (user) delegates infra:* to the node → steward-binding.
         backend
             .put_attestation(SignedAttestation {
                 attestation: fix_node_delegates_to(
@@ -6827,7 +6828,7 @@ mod tests {
             .unwrap();
         put_community_with(&backend, "comm-ob-3", vec![member("ob-node")], None)
             .await
-            .expect("owner-bound node admitted");
+            .expect("steward-bound node admitted");
         assert!(backend
             .lookup_community("comm-ob-3")
             .await
@@ -6836,15 +6837,15 @@ mod tests {
     }
 
     /// SecReview F3: a `delegates_to(user → node)` that the granter has
-    /// WITHDRAWN no longer confers owner-binding. The node is admitted while
+    /// WITHDRAWN no longer confers steward-binding. The node is admitted while
     /// the delegation is live, then a second community (same owner-withdrawn
     /// node) is REJECTED — the withdrawn edge is not "live".
     #[tokio::test]
-    async fn community_owner_binding_withdrawn_delegation_not_live() {
+    async fn community_steward_binding_withdrawn_delegation_not_live() {
         use crate::federation::types::delegation_scope as ds;
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
-        // owner (user) delegates infra:* → node → owner-binding (live).
+        // owner (user) delegates infra:* → node → steward-binding (live).
         backend
             .put_attestation(SignedAttestation {
                 attestation: fix_node_delegates_to(
@@ -6860,7 +6861,7 @@ mod tests {
         // Live → admitted.
         put_community_with(&backend, "comm-ob-wd-live", vec![member("ob-node")], None)
             .await
-            .expect("owner-bound (live delegation) node admitted");
+            .expect("steward-bound (live delegation) node admitted");
 
         // owner WITHDRAWS the delegation edge (issuer-against-recipient: the
         // withdraws' attested_key_id is the recipient `ob-node`).
@@ -6879,13 +6880,13 @@ mod tests {
             .await
             .expect("owner withdraws own delegation edge");
 
-        // Withdrawn → NOT owner-bound → REJECTED.
+        // Withdrawn → NOT steward-bound → REJECTED.
         let err = put_community_with(&backend, "comm-ob-wd-dead", vec![member("ob-node")], None)
             .await
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend
             .lookup_community("comm-ob-wd-dead")
@@ -6895,10 +6896,10 @@ mod tests {
     }
 
     /// SecReview F3: an EXPIRED `delegates_to(user → node)` (`expires_at` in
-    /// the past) does NOT confer owner-binding — the unowned node is
+    /// the past) does NOT confer steward-binding — the unstewarded node is
     /// REJECTED.
     #[tokio::test]
-    async fn community_owner_binding_expired_delegation_not_live() {
+    async fn community_steward_binding_expired_delegation_not_live() {
         use crate::federation::types::delegation_scope as ds;
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
@@ -6919,7 +6920,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend
             .lookup_community("comm-ob-exp")
@@ -6928,11 +6929,11 @@ mod tests {
             .is_none());
     }
 
-    /// An OWNER-BOUND agent member (live `delegates_to(user → agent)`) →
+    /// An STEWARD-BOUND agent member (live `delegates_to(user → agent)`) →
     /// ADMITTED. Agent is not node-only, so the delegation needs no infra
     /// scope to store.
     #[tokio::test]
-    async fn community_owner_bound_agent_member_admitted() {
+    async fn community_steward_bound_agent_member_admitted() {
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         backend
@@ -6948,7 +6949,7 @@ mod tests {
             .unwrap();
         put_community_with(&backend, "comm-ob-4", vec![member("ob-agent")], None)
             .await
-            .expect("owner-bound agent admitted");
+            .expect("steward-bound agent admitted");
         assert!(backend
             .lookup_community("comm-ob-4")
             .await
@@ -6956,10 +6957,10 @@ mod tests {
             .is_some());
     }
 
-    /// `cohort_subkind: infrastructure` community → an UNOWNED node member
+    /// `cohort_subkind: infrastructure` community → an UNSTEWARDED node member
     /// is ADMITTED (trust + serve needs no owner — CC 3.2 carve-out).
     #[tokio::test]
-    async fn community_infrastructure_exempts_unowned_node() {
+    async fn community_infrastructure_exempts_unstewarded_node() {
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         put_community_with(
@@ -6969,7 +6970,7 @@ mod tests {
             Some("infrastructure"),
         )
         .await
-        .expect("infrastructure community exempt from owner-binding");
+        .expect("infrastructure community exempt from steward-binding");
         assert!(backend
             .lookup_community("comm-ob-infra")
             .await
@@ -6978,11 +6979,11 @@ mod tests {
     }
 
     /// SecReview F2: an `infrastructure`-LABELED community whose own key is
-    /// NOT `substrate_persist` does NOT get the carve-out — owner-binding is
-    /// STILL enforced, so an UNOWNED node member is REJECTED + not stored
+    /// NOT `substrate_persist` does NOT get the carve-out — steward-binding is
+    /// STILL enforced, so an UNSTEWARDED node member is REJECTED + not stored
     /// (fail-secure: a self-applied infra label can never skip the gate).
     #[tokio::test]
-    async fn community_unauthorized_infra_label_still_enforces_owner_binding() {
+    async fn community_unauthorized_infra_label_still_enforces_steward_binding() {
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         let err = put_community_with_authority(
@@ -6995,7 +6996,7 @@ mod tests {
         .await
         .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref member_key_id,
                 member_role,
                 ..
@@ -7003,7 +7004,7 @@ mod tests {
                 assert_eq!(member_key_id, "ob-node");
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
         assert!(backend
             .lookup_community("comm-ob-fakeinfra")
@@ -7021,7 +7022,7 @@ mod tests {
         seed_ob_keys(&backend).await;
         put_community_with(&backend, "comm-ob-user", vec![member("ob-owner")], None)
             .await
-            .expect("user member admitted (trivially owner-bound)");
+            .expect("user member admitted (trivially steward-bound)");
         assert!(backend
             .lookup_community("comm-ob-user")
             .await
@@ -8029,8 +8030,8 @@ mod tests {
 
     // ── #249 Cut B — CEG-native graph DX enumerators + add_community_member.
 
-    /// Register `n` user-role keys `pfx-0..pfx-(n-1)` (trivially owner-bound,
-    /// so a community of them passes the owner-binding gate).
+    /// Register `n` user-role keys `pfx-0..pfx-(n-1)` (trivially steward-bound,
+    /// so a community of them passes the steward-binding gate).
     async fn seed_user_keys(backend: &MemoryBackend, pfx: &str, n: usize) -> Vec<String> {
         let mut ids = Vec::new();
         for i in 0..n {
@@ -8204,7 +8205,7 @@ mod tests {
                 .add_community_member("no-such-comm", member("addc-2"))
                 .await
                 .unwrap_err(),
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
                 | crate::federation::Error::InvalidArgument(_)
         ));
     }
@@ -8216,7 +8217,7 @@ mod tests {
     async fn moderators_of_enumerates_roots_and_delegates() {
         use crate::federation::admission::DELEGATION_SCOPE_MODERATE;
         let backend = MemoryBackend::new();
-        // founder is a user-role key (owner-bound + authority root).
+        // founder is a user-role key (steward-bound + authority root).
         let mut founder = fix_key("mod-founder", "user", "mod-founder");
         founder.identity_type = crate::federation::types::identity_type::USER.into();
         backend
@@ -8299,21 +8300,21 @@ mod tests {
         .unwrap());
     }
 
-    /// owner_bindings_of: an owner-bound node (live `delegates_to(user →
+    /// steward_bindings_of: an steward-bound node (live `delegates_to(user →
     /// node, infra:*)`) → returns the binding user; an unbound node → empty.
     #[tokio::test]
-    async fn owner_bindings_of_returns_user_anchors() {
+    async fn steward_bindings_of_returns_user_anchors() {
         use crate::federation::types::delegation_scope as ds;
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await; // ob-owner (user), ob-node (node), ob-agent
                                       // Unbound node → empty.
         assert!(
-            crate::federation::admission::owner_bindings_of(&backend, "ob-node")
+            crate::federation::admission::steward_bindings_of(&backend, "ob-node")
                 .await
                 .unwrap()
                 .is_empty()
         );
-        // Live delegates_to(user → node, infra:*) → owner-bound to ob-owner.
+        // Live delegates_to(user → node, infra:*) → steward-bound to ob-owner.
         backend
             .put_attestation(SignedAttestation {
                 attestation: fix_node_delegates_to(
@@ -8326,43 +8327,84 @@ mod tests {
             })
             .await
             .unwrap();
-        let bindings = crate::federation::admission::owner_bindings_of(&backend, "ob-node")
+        let bindings = crate::federation::admission::steward_bindings_of(&backend, "ob-node")
             .await
             .unwrap();
         assert_eq!(bindings, vec!["ob-owner".to_string()]);
-        // The user key owner-binds itself (clause 1).
+        // The user key steward-binds itself (clause 1).
         assert_eq!(
-            crate::federation::admission::owner_bindings_of(&backend, "ob-owner")
+            crate::federation::admission::steward_bindings_of(&backend, "ob-owner")
                 .await
                 .unwrap(),
             vec!["ob-owner".to_string()]
         );
         // Consistency with the predicate.
         assert!(
-            crate::federation::admission::is_owner_bound(&backend, "ob-node")
+            crate::federation::admission::is_steward_bound(&backend, "ob-node")
                 .await
                 .unwrap()
         );
     }
 
-    /// owner_binding_chain: the PATH (anchor-first), not just endpoints.
+    /// CIRISPersist#299 — `nodes_stewarded_by` is the exact inverse of
+    /// `steward_bindings_of` (memory-backend parity): pre-delegation the user
+    /// owns only itself; after `delegates_to(ob-owner → ob-node)` it owns
+    /// `{ob-node, ob-owner}`; a node owns nothing.
+    #[tokio::test]
+    async fn nodes_stewarded_by_is_inverse_of_steward_bindings() {
+        use crate::federation::admission::nodes_stewarded_by;
+        use crate::federation::types::delegation_scope as ds;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await; // ob-owner (user), ob-node (node), ob-agent
+                                      // Pre-delegation: owner owns only itself.
+        assert_eq!(
+            nodes_stewarded_by(&backend, "ob-owner").await.unwrap(),
+            vec!["ob-owner".to_string()]
+        );
+        // A node owns nothing.
+        assert!(nodes_stewarded_by(&backend, "ob-node")
+            .await
+            .unwrap()
+            .is_empty());
+
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ob-bind",
+                    "ob-owner",
+                    "ob-node",
+                    "ob-owner",
+                    &[ds::INFRA_SERVE, ds::INFRA_NETWORK_PRESENCE],
+                ),
+            })
+            .await
+            .unwrap();
+
+        // Post-delegation: owns ob-node + self (deduped, sorted).
+        assert_eq!(
+            nodes_stewarded_by(&backend, "ob-owner").await.unwrap(),
+            vec!["ob-node".to_string(), "ob-owner".to_string()]
+        );
+    }
+
+    /// steward_binding_chain: the PATH (anchor-first), not just endpoints.
     /// clause 1 (user key) → [self]; clause 3 (delegated node) → [user, k];
     /// unbound → empty.
     #[tokio::test]
-    async fn owner_binding_chain_returns_audit_path() {
+    async fn steward_binding_chain_returns_audit_path() {
         use crate::federation::types::delegation_scope as ds;
         let backend = MemoryBackend::new();
         seed_ob_keys(&backend).await;
         // Unbound → empty.
         assert!(
-            crate::federation::admission::owner_binding_chain(&backend, "ob-node")
+            crate::federation::admission::steward_binding_chain(&backend, "ob-node")
                 .await
                 .unwrap()
                 .is_empty()
         );
         // Clause 1: the user key is its own anchor → [self].
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, "ob-owner")
+            crate::federation::admission::steward_binding_chain(&backend, "ob-owner")
                 .await
                 .unwrap(),
             vec!["ob-owner".to_string()]
@@ -8381,18 +8423,18 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, "ob-node")
+            crate::federation::admission::steward_binding_chain(&backend, "ob-node")
                 .await
                 .unwrap(),
             vec!["ob-owner".to_string(), "ob-node".to_string()]
         );
-        // Predicate consistency: a non-empty chain ⟺ owner-bound.
+        // Predicate consistency: a non-empty chain ⟺ steward-bound.
         let chain_nonempty =
-            !crate::federation::admission::owner_binding_chain(&backend, "ob-node")
+            !crate::federation::admission::steward_binding_chain(&backend, "ob-node")
                 .await
                 .unwrap()
                 .is_empty();
-        let bound = crate::federation::admission::is_owner_bound(&backend, "ob-node")
+        let bound = crate::federation::admission::is_steward_bound(&backend, "ob-node")
             .await
             .unwrap();
         assert_eq!(chain_nonempty, bound);

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2461,7 +2461,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         // no-op for any non-matching row; for a moderation/review report it
         // admits IFF the signer IS a duty-holder over the target (the row's
         // subject_key_ids ∪ the envelope community_id's named moderators) or
-        // is reached by an owner-bound duty-holder via a live scoped
+        // is reached by an steward-bound duty-holder via a live scoped
         // delegates_to chain. Absence ⇒ REJECT. Runs AFTER the withdraws
         // gate and BEFORE persist_row_hash + INSERT — a rejected emission
         // leaves no trace.
@@ -3380,11 +3380,12 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             chrono::Utc::now(),
         )
         .await?;
-        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
         // non-infrastructure community membership. No-op for
         // infrastructure communities and rosters with no node/agent
         // members.
-        crate::federation::admission::check_community_membership_owner_binding(self, &row).await?;
+        crate::federation::admission::check_community_membership_steward_binding(self, &row)
+            .await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let members_value = serde_json::to_value(&row.members)
             .map_err(|e| crate::federation::Error::Backend(format!("members serialize: {e}")))?;
@@ -16853,7 +16854,7 @@ mod tests {
         let bob = format!("bob-root-{suffix}");
         let carol = format!("carol-root-{suffix}");
         // The community key itself is infra-class; the `*-root` members are
-        // user-role human identities (trivially owner-bound — the v9.0.0
+        // user-role human identities (trivially steward-bound — the v9.0.0
         // CC 3.2 / CC 3.4.7.1 non-infra membership precondition).
         backend
             .put_public_key(crate::federation::SignedKeyRecord {
@@ -17247,7 +17248,7 @@ mod tests {
         for kid in [&comm, &infra, &fakeinfra, &alice, &bob, &alice_p, &bob_p] {
             let mut record = fix_section_i_key(kid, "acme", now, true);
             // Community members (alice/bob) are user-role humans — trivially
-            // owner-bound, satisfying the v9.0.0 G3 owner-binding precondition
+            // steward-bound, satisfying the v9.0.0 G3 steward-binding precondition
             // for non-infra community membership (CC 3.4.7.1). The DEK cascade
             // under test is orthogonal to membership authority.
             if kid == &alice || kid == &bob {
@@ -20631,17 +20632,17 @@ mod tests {
         assert_eq!(on_hybrid[0].attestation_id, id);
     }
 
-    /// v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+    /// v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
     /// non-infrastructure community membership, PG backend (3-backend
-    /// parity with memory + sqlite). Covers: UNOWNED node → REJECTED + not
-    /// stored, UNOWNED agent → REJECTED, OWNER-BOUND node (infra delegation)
-    /// → ADMITTED, OWNER-BOUND agent → ADMITTED, `infrastructure` carve-out
-    /// admits an unowned node, pure-user member not over-rejected. Each
+    /// parity with memory + sqlite). Covers: UNSTEWARDED node → REJECTED + not
+    /// stored, UNSTEWARDED agent → REJECTED, STEWARD-BOUND node (infra delegation)
+    /// → ADMITTED, STEWARD-BOUND agent → ADMITTED, `infrastructure` carve-out
+    /// admits an unstewarded node, pure-user member not over-rejected. Each
     /// community uses a run-scoped uuid-suffixed key id and asserts only on
     /// its own row.
     #[tokio::test]
     #[serial_test::serial(postgres)]
-    async fn pg_community_owner_binding_matrix() {
+    async fn pg_community_steward_binding_matrix() {
         use crate::federation::types::delegation_scope as ds;
         use crate::federation::FederationDirectory;
         let Some(dsn) = pg_dsn() else {
@@ -20657,14 +20658,17 @@ mod tests {
         let agent = format!("ob-agent-{suffix}");
         let node_wd = format!("ob-node-wd-{suffix}");
         let node_exp = format!("ob-node-exp-{suffix}");
-        let node_unowned = format!("ob-node-unowned-{suffix}");
+        let node_unstewarded = format!("ob-node-unstewarded-{suffix}");
         for (kid, ity) in [
             (&owner, crate::federation::types::identity_type::USER),
             (&node, crate::federation::types::identity_type::NODE),
             (&agent, crate::federation::types::identity_type::AGENT),
             (&node_wd, crate::federation::types::identity_type::NODE),
             (&node_exp, crate::federation::types::identity_type::NODE),
-            (&node_unowned, crate::federation::types::identity_type::NODE),
+            (
+                &node_unstewarded,
+                crate::federation::types::identity_type::NODE,
+            ),
         ] {
             let mut k = fix_section_i_key(kid, "x", now, true);
             k.identity_type = ity.into();
@@ -20700,8 +20704,8 @@ mod tests {
             }
         };
         // Seed every community key up front.
-        let comm_unowned_node = format!("ob-c1-{suffix}");
-        let comm_unowned_agent = format!("ob-c2-{suffix}");
+        let comm_unstewarded_node = format!("ob-c1-{suffix}");
+        let comm_unstewarded_agent = format!("ob-c2-{suffix}");
         let comm_node_ok = format!("ob-c3-{suffix}");
         let comm_agent_ok = format!("ob-c4-{suffix}");
         let comm_infra = format!("ob-cinfra-{suffix}");
@@ -20711,8 +20715,8 @@ mod tests {
         let comm_wd_dead = format!("ob-cwddead-{suffix}");
         let comm_exp = format!("ob-cexp-{suffix}");
         for cid in [
-            &comm_unowned_node,
-            &comm_unowned_agent,
+            &comm_unstewarded_node,
+            &comm_unstewarded_agent,
             &comm_node_ok,
             &comm_agent_ok,
             &comm_infra,
@@ -20737,47 +20741,47 @@ mod tests {
                 .unwrap();
         }
 
-        // UNOWNED node → REJECTED + not stored.
+        // UNSTEWARDED node → REJECTED + not stored.
         let err = backend
-            .put_community(put_comm(&comm_unowned_node, vec![&node], None))
+            .put_community(put_comm(&comm_unstewarded_node, vec![&node], None))
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref community_key_id,
                 ref member_key_id,
                 member_role,
             } => {
-                assert_eq!(community_key_id, &comm_unowned_node);
+                assert_eq!(community_key_id, &comm_unstewarded_node);
                 assert_eq!(member_key_id, &node);
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
-        assert_eq!(err.kind(), "federation_unowned_community_member");
+        assert_eq!(err.kind(), "federation_unstewarded_community_member");
         assert!(backend
-            .lookup_community(&comm_unowned_node)
+            .lookup_community(&comm_unstewarded_node)
             .await
             .unwrap()
             .is_none());
 
-        // UNOWNED agent → REJECTED (role reported as agent).
+        // UNSTEWARDED agent → REJECTED (role reported as agent).
         let err = backend
-            .put_community(put_comm(&comm_unowned_agent, vec![&agent], None))
+            .put_community(put_comm(&comm_unstewarded_agent, vec![&agent], None))
             .await
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { member_role, .. }
+            crate::federation::Error::UnstewardedCommunityMember { member_role, .. }
                 if member_role == crate::federation::types::identity_type::AGENT
         ));
         assert!(backend
-            .lookup_community(&comm_unowned_agent)
+            .lookup_community(&comm_unstewarded_agent)
             .await
             .unwrap()
             .is_none());
 
-        // OWNER-BOUND node (live delegates_to(user → node, infra:*)) → ADMITTED.
+        // STEWARD-BOUND node (live delegates_to(user → node, infra:*)) → ADMITTED.
         backend
             .put_attestation(crate::federation::SignedAttestation {
                 attestation: pg_delegates_to(
@@ -20792,14 +20796,14 @@ mod tests {
         backend
             .put_community(put_comm(&comm_node_ok, vec![&node], None))
             .await
-            .expect("owner-bound node admitted");
+            .expect("steward-bound node admitted");
         assert!(backend
             .lookup_community(&comm_node_ok)
             .await
             .unwrap()
             .is_some());
 
-        // OWNER-BOUND agent (live delegates_to(user → agent)) → ADMITTED.
+        // STEWARD-BOUND agent (live delegates_to(user → agent)) → ADMITTED.
         backend
             .put_attestation(crate::federation::SignedAttestation {
                 attestation: pg_delegates_to(&owner, &agent, serde_json::json!(["share"]), false),
@@ -20809,14 +20813,14 @@ mod tests {
         backend
             .put_community(put_comm(&comm_agent_ok, vec![&agent], None))
             .await
-            .expect("owner-bound agent admitted");
+            .expect("steward-bound agent admitted");
         assert!(backend
             .lookup_community(&comm_agent_ok)
             .await
             .unwrap()
             .is_some());
 
-        // `infrastructure` carve-out → unowned node admitted (AUTHORIZED:
+        // `infrastructure` carve-out → unstewarded node admitted (AUTHORIZED:
         // comm_infra's key is substrate_persist).
         backend
             .put_community(put_comm(&comm_infra, vec![&node], Some("infrastructure")))
@@ -20829,26 +20833,26 @@ mod tests {
             .is_some());
 
         // SecReview F2: an `infrastructure`-LABELED community whose own key
-        // is NOT substrate_persist does NOT get the carve-out — owner-binding
-        // is STILL enforced, so the UNOWNED node is REJECTED + not stored.
+        // is NOT substrate_persist does NOT get the carve-out — steward-binding
+        // is STILL enforced, so the UNSTEWARDED node is REJECTED + not stored.
         let err = backend
             .put_community(put_comm(
                 &comm_fakeinfra,
-                vec![&node_unowned],
+                vec![&node_unstewarded],
                 Some("infrastructure"),
             ))
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref member_key_id,
                 member_role,
                 ..
             } => {
-                assert_eq!(member_key_id, &node_unowned);
+                assert_eq!(member_key_id, &node_unstewarded);
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
         assert!(backend
             .lookup_community(&comm_fakeinfra)
@@ -20857,7 +20861,7 @@ mod tests {
             .is_none());
 
         // SecReview F3: a WITHDRAWN delegation no longer confers
-        // owner-binding. owner delegates infra:* → node_wd (admitted while
+        // steward-binding. owner delegates infra:* → node_wd (admitted while
         // live); owner then withdraws the edge → a fresh community with
         // node_wd is REJECTED.
         let d_wd = pg_delegates_to(
@@ -20874,7 +20878,7 @@ mod tests {
         backend
             .put_community(put_comm(&comm_wd_live, vec![&node_wd], None))
             .await
-            .expect("owner-bound (live) node admitted");
+            .expect("steward-bound (live) node admitted");
         // owner withdraws the edge (issuer-against-recipient: attested = node_wd).
         let mut w = pg_scores_attestation(&owner, &node_wd, &owner, "x");
         w.attestation_type = crate::federation::types::attestation_type::WITHDRAWS.into();
@@ -20890,7 +20894,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend
             .lookup_community(&comm_wd_dead)
@@ -20898,7 +20902,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        // SecReview F3: an EXPIRED delegation does NOT confer owner-binding.
+        // SecReview F3: an EXPIRED delegation does NOT confer steward-binding.
         let mut d_exp = pg_delegates_to(
             &owner,
             &node_exp,
@@ -20916,7 +20920,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend.lookup_community(&comm_exp).await.unwrap().is_none());
 
@@ -20955,7 +20959,7 @@ mod tests {
         let rando = format!("rando-{suffix}");
         let founder = format!("founder-{suffix}");
         let comm = format!("comm-{suffix}");
-        // subject + founder are user-role (owner-bound); the rest agents.
+        // subject + founder are user-role (steward-bound); the rest agents.
         for kid in [&subject, &founder, &comm] {
             let mut k = fix_section_i_key(kid, "u", now, true);
             k.identity_type = crate::federation::types::identity_type::USER.into();
@@ -21032,7 +21036,7 @@ mod tests {
             .await
             .expect("(b1) subject-delegated admitted");
 
-        // (b2) named-moderator (community founder, owner-bound) → ADMIT.
+        // (b2) named-moderator (community founder, steward-bound) → ADMIT.
         backend
             .put_attestation(crate::federation::SignedAttestation {
                 attestation: report(&founder, &[], Some(&comm)),
@@ -28251,7 +28255,7 @@ mod tests {
         let now = chrono::Utc::now();
         let s = uuid_like();
         // Run-scoped key ids. All members are user-role (trivially
-        // owner-bound) so put_community passes the owner-binding gate.
+        // steward-bound) so put_community passes the steward-binding gate.
         let comm = format!("cb-comm-{s}");
         let u0 = format!("cb-u0-{s}");
         let u1 = format!("cb-u1-{s}");
@@ -28410,10 +28414,10 @@ mod tests {
         assert!(mods.contains(&deputy));
         assert!(!mods.contains(&outsider));
 
-        // ── owner_bindings_of ── unbound node → empty; live infra
+        // ── steward_bindings_of ── unbound node → empty; live infra
         //    delegation → [owner=founder].
         assert!(
-            crate::federation::admission::owner_bindings_of(&backend, &node)
+            crate::federation::admission::steward_bindings_of(&backend, &node)
                 .await
                 .unwrap()
                 .is_empty()
@@ -28430,22 +28434,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            crate::federation::admission::owner_bindings_of(&backend, &node)
+            crate::federation::admission::steward_bindings_of(&backend, &node)
                 .await
                 .unwrap(),
             vec![founder.clone()]
         );
 
-        // ── owner_binding_chain ── the audit PATH. founder (user) → [self];
+        // ── steward_binding_chain ── the audit PATH. founder (user) → [self];
         //    node (via the live infra delegation above) → [founder, node].
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, &founder)
+            crate::federation::admission::steward_binding_chain(&backend, &founder)
                 .await
                 .unwrap(),
             vec![founder.clone()]
         );
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, &node)
+            crate::federation::admission::steward_binding_chain(&backend, &node)
                 .await
                 .unwrap(),
             vec![founder.clone(), node.clone()]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2149,7 +2149,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // no-op for any non-matching row; for a moderation/review report it
         // admits IFF the signer IS a duty-holder over the target (the row's
         // subject_key_ids ∪ the envelope community_id's named moderators) or
-        // is reached by an owner-bound duty-holder via a live scoped
+        // is reached by an steward-bound duty-holder via a live scoped
         // delegates_to chain. Absence ⇒ REJECT. Runs AFTER the withdraws
         // gate and BEFORE persist_row_hash + INSERT — a rejected emission
         // leaves no trace.
@@ -3034,11 +3034,12 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             chrono::Utc::now(),
         )
         .await?;
-        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+        // v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
         // non-infrastructure community membership. Directory reads run
         // before the write lock below. No-op for infrastructure
         // communities and for rosters with no node/agent members.
-        crate::federation::admission::check_community_membership_owner_binding(self, &row).await?;
+        crate::federation::admission::check_community_membership_steward_binding(self, &row)
+            .await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let members_json = serde_json::to_string(&row.members)
             .map_err(|e| crate::federation::Error::Backend(format!("members serialize: {e}")))?;
@@ -24467,7 +24468,7 @@ mod tests {
         assert_eq!(stored[0].attestation_id, id);
     }
 
-    // ── v9.0.0 (CC 3.2 / CC 3.4.7.1) — owner-binding precondition for
+    // ── v9.0.0 (CC 3.2 / CC 3.4.7.1) — steward-binding precondition for
     // non-infrastructure community membership (sqlite parity).
 
     /// Seed the community's own key + submit a community with `members`
@@ -24525,15 +24526,15 @@ mod tests {
             .await
     }
 
-    /// UNOWNED node member of a non-infra community → REJECTED + not stored.
+    /// UNSTEWARDED node member of a non-infra community → REJECTED + not stored.
     #[tokio::test]
-    async fn community_unowned_node_member_rejected_sqlite() {
+    async fn community_unstewarded_node_member_rejected_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
         let err = put_community_ob_sqlite(&backend, "comm-ob-1", vec!["node-key"], None)
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref community_key_id,
                 ref member_key_id,
                 member_role,
@@ -24542,9 +24543,9 @@ mod tests {
                 assert_eq!(member_key_id, "node-key");
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
-        assert_eq!(err.kind(), "federation_unowned_community_member");
+        assert_eq!(err.kind(), "federation_unstewarded_community_member");
         assert!(backend
             .lookup_community("comm-ob-1")
             .await
@@ -24552,18 +24553,18 @@ mod tests {
             .is_none());
     }
 
-    /// UNOWNED agent member → REJECTED (role reported as `agent`).
+    /// UNSTEWARDED agent member → REJECTED (role reported as `agent`).
     #[tokio::test]
-    async fn community_unowned_agent_member_rejected_sqlite() {
+    async fn community_unstewarded_agent_member_rejected_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
         let err = put_community_ob_sqlite(&backend, "comm-ob-2", vec!["agent-key"], None)
             .await
             .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember { member_role, .. } => {
+            crate::federation::Error::UnstewardedCommunityMember { member_role, .. } => {
                 assert_eq!(member_role, crate::federation::types::identity_type::AGENT);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
         assert!(backend
             .lookup_community("comm-ob-2")
@@ -24572,10 +24573,10 @@ mod tests {
             .is_none());
     }
 
-    /// OWNER-BOUND node member (live `delegates_to(user → node, infra:*)`)
+    /// STEWARD-BOUND node member (live `delegates_to(user → node, infra:*)`)
     /// → ADMITTED.
     #[tokio::test]
-    async fn community_owner_bound_node_member_admitted_sqlite() {
+    async fn community_steward_bound_node_member_admitted_sqlite() {
         use crate::federation::types::delegation_scope as ds;
         let backend = bootstrap_node_agency_sqlite().await;
         backend
@@ -24590,7 +24591,7 @@ mod tests {
             .unwrap();
         put_community_ob_sqlite(&backend, "comm-ob-3", vec!["node-key"], None)
             .await
-            .expect("owner-bound node admitted");
+            .expect("steward-bound node admitted");
         assert!(backend
             .lookup_community("comm-ob-3")
             .await
@@ -24599,10 +24600,10 @@ mod tests {
     }
 
     /// SecReview F3: a WITHDRAWN `delegates_to(user → node)` no longer
-    /// confers owner-binding (sqlite parity) — admitted while live, REJECTED
+    /// confers steward-binding (sqlite parity) — admitted while live, REJECTED
     /// after the granter withdraws the edge.
     #[tokio::test]
-    async fn community_owner_binding_withdrawn_delegation_not_live_sqlite() {
+    async fn community_steward_binding_withdrawn_delegation_not_live_sqlite() {
         use crate::federation::types::{attestation_type, delegation_scope as ds};
         let backend = bootstrap_node_agency_sqlite().await;
         let d = node_delegates_to_sqlite(
@@ -24617,7 +24618,7 @@ mod tests {
             .unwrap();
         put_community_ob_sqlite(&backend, "comm-ob-wd-live", vec!["node-key"], None)
             .await
-            .expect("owner-bound (live) node admitted");
+            .expect("steward-bound (live) node admitted");
 
         // owner withdraws the edge (issuer-against-recipient: attested = node-key).
         let mut w = topo_attestation(
@@ -24642,7 +24643,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend
             .lookup_community("comm-ob-wd-dead")
@@ -24652,9 +24653,9 @@ mod tests {
     }
 
     /// SecReview F3: an EXPIRED `delegates_to(user → node)` does NOT confer
-    /// owner-binding (sqlite parity) — unowned node REJECTED.
+    /// steward-binding (sqlite parity) — unstewarded node REJECTED.
     #[tokio::test]
-    async fn community_owner_binding_expired_delegation_not_live_sqlite() {
+    async fn community_steward_binding_expired_delegation_not_live_sqlite() {
         use crate::federation::types::delegation_scope as ds;
         let backend = bootstrap_node_agency_sqlite().await;
         let mut d = node_delegates_to_sqlite(
@@ -24672,7 +24673,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(
             err,
-            crate::federation::Error::UnownedCommunityMember { .. }
+            crate::federation::Error::UnstewardedCommunityMember { .. }
         ));
         assert!(backend
             .lookup_community("comm-ob-exp")
@@ -24681,10 +24682,10 @@ mod tests {
             .is_none());
     }
 
-    /// OWNER-BOUND agent member (live `delegates_to(user → agent)`) →
+    /// STEWARD-BOUND agent member (live `delegates_to(user → agent)`) →
     /// ADMITTED.
     #[tokio::test]
-    async fn community_owner_bound_agent_member_admitted_sqlite() {
+    async fn community_steward_bound_agent_member_admitted_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
         backend
             .put_attestation(SignedAttestation {
@@ -24699,7 +24700,7 @@ mod tests {
             .unwrap();
         put_community_ob_sqlite(&backend, "comm-ob-4", vec!["agent-key"], None)
             .await
-            .expect("owner-bound agent admitted");
+            .expect("steward-bound agent admitted");
         assert!(backend
             .lookup_community("comm-ob-4")
             .await
@@ -24707,9 +24708,9 @@ mod tests {
             .is_some());
     }
 
-    /// `cohort_subkind: infrastructure` → UNOWNED node admitted (carve-out).
+    /// `cohort_subkind: infrastructure` → UNSTEWARDED node admitted (carve-out).
     #[tokio::test]
-    async fn community_infrastructure_exempts_unowned_node_sqlite() {
+    async fn community_infrastructure_exempts_unstewarded_node_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
         put_community_ob_sqlite(
             &backend,
@@ -24726,38 +24727,38 @@ mod tests {
             .is_some());
     }
 
-    /// #249 Cut A — the owner-binding + duty-holders readers
-    /// (`is_owner_bound_json` / `duty_holders_for_community_json`) the FFI
-    /// exposes: a `user`-role key IS owner-bound, a bare `node` key is NOT,
+    /// #249 Cut A — the steward-binding + duty-holders readers
+    /// (`is_steward_bound_json` / `duty_holders_for_community_json`) the FFI
+    /// exposes: a `user`-role key IS steward-bound, a bare `node` key is NOT,
     /// and the duty-holder set of a MAJORITY community (whole roster =
-    /// authority) is exactly its owner-bound members — proven through the
+    /// authority) is exactly its steward-bound members — proven through the
     /// serde_json array shape the wrapper emits (HashSet sorted to a stable
     /// `Vec`), the #104 PERSIST_DELEGATES_TO blocker's by-construction view.
     #[tokio::test]
-    async fn cut_a_owner_binding_and_duty_holders_json_sqlite() {
-        use crate::federation::admission::{duty_holders_for_community, is_owner_bound};
+    async fn cut_a_steward_binding_and_duty_holders_json_sqlite() {
+        use crate::federation::admission::{duty_holders_for_community, is_steward_bound};
         use crate::federation::FederationDirectory;
         let backend = bootstrap_node_agency_sqlite().await;
 
-        // is_owner_bound: `owner` (USER) is bound; `node-key` (NODE, no
+        // is_steward_bound: `owner` (USER) is bound; `node-key` (NODE, no
         // delegation) is not — the exact bools the JSON wrapper serializes.
-        let owner_bound = is_owner_bound(&backend as &dyn FederationDirectory, "owner")
+        let steward_bound = is_steward_bound(&backend as &dyn FederationDirectory, "owner")
             .await
             .unwrap();
-        let node_bound = is_owner_bound(&backend as &dyn FederationDirectory, "node-key")
+        let node_bound = is_steward_bound(&backend as &dyn FederationDirectory, "node-key")
             .await
             .unwrap();
         assert!(
-            serde_json::from_str::<bool>(&serde_json::to_string(&owner_bound).unwrap()).unwrap()
+            serde_json::from_str::<bool>(&serde_json::to_string(&steward_bound).unwrap()).unwrap()
         );
         assert!(
             !serde_json::from_str::<bool>(&serde_json::to_string(&node_bound).unwrap()).unwrap()
         );
 
         // A MAJORITY community whose whole roster is the authority set; only
-        // the owner-bound member surfaces as a duty-holder. Seed the
-        // community's own key, then a single owner-bound member (`owner`) —
-        // owner-binding admission accepts it (`owner` is a USER).
+        // the steward-bound member surfaces as a duty-holder. Seed the
+        // community's own key, then a single steward-bound member (`owner`) —
+        // steward-binding admission accepts it (`owner` is a USER).
         backend
             .put_public_key(SignedKeyRecord {
                 record: fed_key("duty-comm", "duty-comm", "duty-comm"),
@@ -24775,7 +24776,7 @@ mod tests {
                 ),
             })
             .await
-            .expect("owner-bound member admitted under MAJORITY");
+            .expect("steward-bound member admitted under MAJORITY");
 
         // duty_holders_for_community → exactly {owner}, through the sorted
         // JSON array the FFI wrapper returns.
@@ -24804,11 +24805,11 @@ mod tests {
     }
 
     /// SecReview F2: an `infrastructure`-LABELED community whose own key is
-    /// NOT `substrate_persist` does NOT get the carve-out — owner-binding is
-    /// STILL enforced, so an UNOWNED node member is REJECTED + not stored
+    /// NOT `substrate_persist` does NOT get the carve-out — steward-binding is
+    /// STILL enforced, so an UNSTEWARDED node member is REJECTED + not stored
     /// (fail-secure: a self-applied infra label can never skip the gate).
     #[tokio::test]
-    async fn community_unauthorized_infra_label_still_enforces_owner_binding_sqlite() {
+    async fn community_unauthorized_infra_label_still_enforces_steward_binding_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
         let err = put_community_ob_sqlite_authority(
             &backend,
@@ -24820,7 +24821,7 @@ mod tests {
         .await
         .unwrap_err();
         match err {
-            crate::federation::Error::UnownedCommunityMember {
+            crate::federation::Error::UnstewardedCommunityMember {
                 ref member_key_id,
                 member_role,
                 ..
@@ -24828,7 +24829,7 @@ mod tests {
                 assert_eq!(member_key_id, "node-key");
                 assert_eq!(member_role, crate::federation::types::identity_type::NODE);
             }
-            other => panic!("expected UnownedCommunityMember, got {other:?}"),
+            other => panic!("expected UnstewardedCommunityMember, got {other:?}"),
         }
         assert!(backend
             .lookup_community("comm-ob-fakeinfra")
@@ -24837,7 +24838,7 @@ mod tests {
             .is_none());
     }
 
-    /// Pure `user`-role member → NOT over-rejected (trivially owner-bound).
+    /// Pure `user`-role member → NOT over-rejected (trivially steward-bound).
     #[tokio::test]
     async fn community_user_member_not_over_rejected_sqlite() {
         let backend = bootstrap_node_agency_sqlite().await;
@@ -27835,7 +27836,7 @@ mod tests {
 
     // ── #249 Cut B — enumerators + add_community_member (sqlite parity).
 
-    /// Seed `n` user-role keys `pfx-0..` (trivially owner-bound) + a fresh
+    /// Seed `n` user-role keys `pfx-0..` (trivially steward-bound) + a fresh
     /// migrated backend; returns the backend.
     async fn cutb_backend_with_users(pfx: &str, n: usize) -> SqliteBackend {
         use crate::federation::types::identity_type;
@@ -28112,14 +28113,14 @@ mod tests {
         assert!(!set.contains("mod-outsider"));
     }
 
-    /// owner_bindings_of: owner-bound node (live infra:* delegation) →
+    /// steward_bindings_of: steward-bound node (live infra:* delegation) →
     /// [owner]; unbound → empty.
     #[tokio::test]
-    async fn owner_bindings_of_returns_user_anchors_sqlite() {
+    async fn steward_bindings_of_returns_user_anchors_sqlite() {
         use crate::federation::types::delegation_scope as ds;
         let backend = bootstrap_node_agency_sqlite().await;
         assert!(
-            crate::federation::admission::owner_bindings_of(&backend, "node-key")
+            crate::federation::admission::steward_bindings_of(&backend, "node-key")
                 .await
                 .unwrap()
                 .is_empty()
@@ -28135,27 +28136,72 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            crate::federation::admission::owner_bindings_of(&backend, "node-key")
+            crate::federation::admission::steward_bindings_of(&backend, "node-key")
                 .await
                 .unwrap(),
             vec!["owner".to_string()]
         );
     }
 
-    /// owner_binding_chain: the audit PATH. clause 1 → [self]; clause 3 →
+    /// CIRISPersist#299 — `nodes_stewarded_by` is the EXACT inverse of
+    /// `steward_bindings_of` (`n ∈ nodes_stewarded_by(U)` ⟺ `U ∈ steward_bindings_of(n)`):
+    /// pre-delegation the user owns only itself (clause-1 user-role self-bind);
+    /// after `delegates_to(owner → node-key)` it owns `{node-key, owner}`; a
+    /// node owns nothing (sqlite parity).
+    #[tokio::test]
+    async fn nodes_stewarded_by_is_inverse_of_steward_bindings_sqlite() {
+        use crate::federation::admission::{nodes_stewarded_by, steward_bindings_of};
+        use crate::federation::types::delegation_scope as ds;
+        let backend = bootstrap_node_agency_sqlite().await;
+        // Pre-delegation: owner owns only itself (user-role self-binding).
+        assert_eq!(
+            nodes_stewarded_by(&backend, "owner").await.unwrap(),
+            vec!["owner".to_string()]
+        );
+        // A node owns nothing (it is not user-role, so it self-binds nobody).
+        assert!(nodes_stewarded_by(&backend, "node-key")
+            .await
+            .unwrap()
+            .is_empty());
+
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: node_delegates_to_sqlite(
+                    "owner",
+                    "node-key",
+                    &[ds::INFRA_SERVE, ds::INFRA_NETWORK_PRESENCE],
+                ),
+            })
+            .await
+            .unwrap();
+
+        // Post-delegation: owns node-key + self (deduped, sorted).
+        assert_eq!(
+            nodes_stewarded_by(&backend, "owner").await.unwrap(),
+            vec!["node-key".to_string(), "owner".to_string()]
+        );
+        // Exact-inverse invariant: node-key ∈ nodes_stewarded_by(owner) ⟺
+        // owner ∈ steward_bindings_of(node-key).
+        assert!(steward_bindings_of(&backend, "node-key")
+            .await
+            .unwrap()
+            .contains(&"owner".to_string()));
+    }
+
+    /// steward_binding_chain: the audit PATH. clause 1 → [self]; clause 3 →
     /// [user, node]; unbound → empty (sqlite parity).
     #[tokio::test]
-    async fn owner_binding_chain_returns_audit_path_sqlite() {
+    async fn steward_binding_chain_returns_audit_path_sqlite() {
         use crate::federation::types::delegation_scope as ds;
         let backend = bootstrap_node_agency_sqlite().await;
         assert!(
-            crate::federation::admission::owner_binding_chain(&backend, "node-key")
+            crate::federation::admission::steward_binding_chain(&backend, "node-key")
                 .await
                 .unwrap()
                 .is_empty()
         );
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, "owner")
+            crate::federation::admission::steward_binding_chain(&backend, "owner")
                 .await
                 .unwrap(),
             vec!["owner".to_string()]
@@ -28171,7 +28217,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            crate::federation::admission::owner_binding_chain(&backend, "node-key")
+            crate::federation::admission::steward_binding_chain(&backend, "node-key")
                 .await
                 .unwrap(),
             vec!["owner".to_string(), "node-key".to_string()]

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -432,8 +432,8 @@ def test_put_community_json_round_trip_290() -> None:
     try:
         # The community_key_id + each member must FK a registered
         # federation_keys row. Register as `primitive` — the put_community
-        # owner-binding gate (CC 3.2 UnownedCommunityMember) is exempt for
-        # primitive identities; agent/node members would need an owner-
+        # steward-binding gate (CC 3.2 UnstewardedCommunityMember) is exempt for
+        # primitive identities; agent/node members would need a steward-
         # binding chain (which the conformance harness supplies in the real
         # moderation flow, but isn't needed to prove the FFI admits a row).
         kid = eng.register_self_federation_key("primitive", "ref", None, None, None)
@@ -531,6 +531,47 @@ def test_emit_attestation_self_rejects_uppercase_subject_key_id_293():
                 }
             )
         )
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()
+
+
+def test_nodes_stewarded_by_json_pyo3_299():
+    """#299 — the outbound steward-binding reader nodes_stewarded_by_json() is bound
+    to Python and returns valid JSON. A freshly registered user-role key owns
+    itself (clause-1 self-binding, the exact inverse of steward_bindings_of);
+    an unrelated key owns nothing. Skips on a non-sqlite wheel."""
+    import json
+    import os
+    import secrets
+    import tempfile
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    seed = os.path.join(tempfile.mkdtemp(), "seed")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "user-" + secrets.token_hex(8)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:", alias, local_key_id=alias, local_key_path=seed
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        kid = eng.register_self_federation_key("user", "ref", None, None, None)
+        # A user-role key owns itself (exact inverse: kid ∈ nodes_stewarded_by(kid)
+        # ⟺ kid ∈ steward_bindings_of(kid), the clause-1 self-binding).
+        owned = json.loads(eng.nodes_stewarded_by_json(kid))
+        assert isinstance(owned, list)
+        assert kid in owned, owned
+        # The inverse holds the other way too.
+        assert kid in json.loads(eng.steward_bindings_of_json(kid))
+        # An unknown key owns nothing.
+        assert json.loads(eng.nodes_stewarded_by_json("nobody-" + secrets.token_hex(4))) == []
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()


### PR DESCRIPTION
Constitution-alignment MAJOR. Closes #299.

## Why (CC 0.5.1 §3.2)
The Constitution makes **owner** the wrong word for node/agent stewardship:

> *Steward-binding is **responsibility, not property** — a steward is responsible *for* a ward, never a holder *of* one … You never steward a node, an agent, or a person as a possession* — the **structural no-slavery guarantee**.

It names the predicate **`is_steward_bound(K)`** and the concept **steward-binding**. Persist`s `owner_*` naming was exactly the property framing the Constitution rejects. Clean break, no aliases (per standing preference).

## Renamed public API — downstream MUST update (CIRISServer / Agent)
| Was | Now |
|---|---|
| `owner_bind` | `steward_bind` |
| `owner_bindings_of` / `owner_bindings_of_json` | `steward_bindings_of` / `steward_bindings_of_json` |
| `owner_binding_chain` / `_json` | `steward_binding_chain` / `_json` |
| `is_owner_bound` / `is_owner_bound_json` | `is_steward_bound` / `is_steward_bound_json` |
| `Error::UnownedCommunityMember` (kind `federation_unowned_community_member`) | `UnstewardedCommunityMember` (kind `federation_unstewarded_community_member`) |

Consumers matching the `federation_unowned_community_member` **error kind** (CIRISConformance) must update to `federation_unstewarded_community_member`. The gate fn `check_community_membership_steward_binding` was already steward-named — only its error lagged.

## Preserved — genuinely different "owner" concepts (NOT renamed)
- `SharedInstanceLease` leader-election: `owner_pid` / `owner_hostname` (real lease ownership, CIRISEdge#100 — DB columns).
- `EngineCell` lifecycle owner; cohabitation consumer-ownership declarations.
- At-rest-cascade `owner_or_family_key_id` (data recipient, not stewardship).

## Folds in #299 — `nodes_stewarded_by` (ships steward-named, never `owner`)
Outbound steward-binding reader, exact inverse of `steward_bindings_of` (`n ∈ nodes_stewarded_by(U)` ⟺ `U ∈ steward_bindings_of(n)`). Enumerate candidates (U`s outgoing `delegates_to` + occurrences + self) + confirm each via `steward_bindings_of` → liveness/retraction/role logic inherited verbatim, read-after-write correctness in the substrate. CIRISServer`s hand-rolled scan collapses to one call. Rust `Engine` + pyo3 `nodes_stewarded_by_json`.

## Validation
- 78 community/steward/node-agency/delegation sqlite tests + Rust (memory+sqlite both-directions) + 5 Python regression tests green.
- Full clippy (`-D warnings`) + fmt clean; full-feature build (`postgres server pyo3 sqlite cirisaudit secrets cirisnode cirisgraph telemetry`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ