### PR TITLE
v11.1.0 — #302 (FSD-004): accord live-quorum storage substrate + verify v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.1.0] — 2026-06-26
+
+### Added — #302 (FSD-004): accord live-quorum storage substrate
+
+The durable half of the constitutional kill-switch's decimation-recovery live
+quorum. CIRISVerify ships the stateless machinery in
+`ciris_verify_core::accord_live_quorum` (CIRISVerify#150, re-pinned here to
+**v8.2.0**); the CIRISServer Phase-3 runtime (CIRISServer#122) writes the wire
+objects + anti-replay state **through** persist. Division of labour: **persist
+stores + dedups + verifies participations + holds nonce/halt state; the server
+runs the tally.**
+
+**V091 migrations (pg + sqlite lockstep), five append-only tables + the
+`accord_quorum` module + `FederationDirectory` surface (12 methods, 3 backends:
+postgres/sqlite/memory) + pyo3 write-through:**
+
+- **`accord_proposal`** — server-issued proposals, stored VERBATIM; the digest
+  is derived via verify-core (`AccordProposal::digest`), never caller-supplied.
+  Indexed by `(action, prior_family_digest)` for proposal coalescing (H4).
+- **`accord_participation`** — proof-of-life + vote. **Verify-before-mutation**:
+  the proposal must exist, the member must be in the caller-supplied standing
+  roster (C3), and `AccordParticipation::verify` must pass (fail-closed) before
+  the row lands. **M6 durable dedup by PINNED pubkey** (PK
+  `(proposal_digest, pinned_pubkey)`, not the self-attested `member_id`). **C2**:
+  persist stamps the authoritative `server_arrival_at`; `signed_at` is advisory.
+- **`accord_decision`** — the frozen-L snapshot, **immutable** (M2): a differing
+  re-PUT is rejected, an identical one no-ops.
+- **`accord_active_halt`** (H2) — the active CONSTITUTIONAL halt per family; a
+  resume clears only the matching halt (a stale-halt resume is a no-op).
+- **`accord_issued_nonce`** (M4) — `put_accord_proposal` is fail-closed on an
+  unissued nonce.
+
+The anti-replay anchor is the STANDING roster's `prior_family_digest` (C3),
+never the live set L. **Recovery (`verify_recovery_supersede`, H7) is
+deliberately absent** — it bends entrenchment for the captured-roster case and
+cannot go live until the Constitution sanctions it (CIRISAccord#4); only
+`fire` / `roster_change` / `resume` objects are handled.
+
+Parity proven from one shared `exercise_accord_storage` body across memory +
+sqlite + postgres (the pg test gated on `CIRIS_PERSIST_TEST_PG_URL`), with real
+hybrid-signed participations; full clippy (`-D warnings`) + fmt clean. Also
+re-pins CIRISVerify v8.1.0 → **v8.2.0** (the tag that first ships #150);
+`Requires-Dist ciris-verify>=8.0.0,<9` unchanged.
+
 ## [11.0.1] — 2026-06-26
 
 ### Changed — re-pin CIRISVerify v8.0.0 → v8.1.0 (wheel concurrence)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.0.1"
+version = "11.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -755,10 +755,10 @@ tokio-stream = "0.1"
 # key). Placed AFTER every platform-independent dep — see the v0.9.0
 # bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -769,7 +769,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.1.0", version = "8", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/migrations/postgres/lens/V091__accord_live_quorum.sql
+++ b/migrations/postgres/lens/V091__accord_live_quorum.sql
@@ -1,0 +1,138 @@
+-- V091 — #302 FSD-004 accord live-quorum storage (Postgres dialect).
+--
+-- The durable storage substrate for the constitutional kill-switch's
+-- decimation-recovery live quorum. CIRISVerify shipped the STATELESS
+-- machinery in `ciris_verify_core::accord_live_quorum` (CIRISVerify#150 /
+-- #98); the CIRISServer Phase-3 runtime (CIRISServer#122) drives it and
+-- writes the wire objects + anti-replay state THROUGH persist. Persist is
+-- the storage substrate, so the tables are ours — the live-quorum sibling
+-- of the `federation_keys` accord-holder storage (V048).
+--
+-- Persist's job: store the verify-core canonical objects VERBATIM (never
+-- re-derive the bytes), enforce durable dedup / immutability / fail-closed
+-- nonce + active-halt state. The TALLY (verify_fire_by_live_quorum etc.) is
+-- the SERVER runtime's job — it reads these back and computes the verdict;
+-- persist stores the inputs (proposal + participations) and the server's
+-- frozen `accord_decision`.
+--
+-- Recovery (`verify_recovery_supersede`, H7) is DELIBERATELY ABSENT from
+-- this cut: it bends entrenchment for the captured-roster case and cannot
+-- go live until the CIRIS Constitution sanctions it (CIRISAccord#4). The
+-- fire / roster_change / resume objects are unaffected.
+--
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+-- ─── accord_proposal (append-only; server-issued) ──────────────────
+--
+-- One row per AccordProposal, keyed by its verify-core digest
+-- (`AccordProposal::digest()` = hex-SHA256 of the domain-separated
+-- canonical bytes). `proposal_json` is the object VERBATIM so the server
+-- reads back byte-identical inputs for the tally. The `(action,
+-- prior_family_digest)` index serves proposal COALESCING (H4 — collapse
+-- duplicate proposals over the same standing roster). `prior_family_digest`
+-- is the digest of the STANDING family envelope, the anti-replay anchor
+-- (C3) — never the live set L.
+CREATE TABLE IF NOT EXISTS cirislens.accord_proposal (
+    proposal_digest      TEXT PRIMARY KEY,
+    family_key_id        TEXT NOT NULL,
+    action               TEXT NOT NULL
+        CHECK (action IN ('fire', 'roster_change', 'resume')),
+    nonce                TEXT NOT NULL,
+    window_until         TIMESTAMPTZ NOT NULL,
+    prior_family_digest  TEXT NOT NULL,
+    payload_sha256       TEXT NOT NULL,
+    proposal_json        JSONB NOT NULL,
+    authority_signature  JSONB,
+    persist_row_hash     TEXT NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS accord_proposal_by_anchor
+    ON cirislens.accord_proposal (action, prior_family_digest);
+
+CREATE INDEX IF NOT EXISTS accord_proposal_by_family
+    ON cirislens.accord_proposal (family_key_id);
+
+-- ─── accord_participation (append-only; proof-of-life + vote) ───────
+--
+-- M6 DURABLE DEDUP: the PRIMARY KEY is `(proposal_digest, pinned_pubkey)`
+-- — dedup keyed by the PINNED pubkey, NOT the plaintext `member_id` string
+-- (a relay cannot double-count a holder by varying the self-attested seat
+-- string). Replaces the in-process per-`valid_until` dedup.
+--
+-- C2 WINDOW CLOCK: `server_arrival_at` is the AUTHORITATIVE arrival time
+-- the server stamps on receipt; `signed_at` is advisory display only and is
+-- NOT trusted as the window clock. The server filters L membership by
+-- `server_arrival_at <= window_until`.
+--
+-- `participation_json` is the AccordParticipation VERBATIM (incl. the hybrid
+-- ThresholdSignature) — persist verifies it (verify-core
+-- AccordParticipation::verify against the pinned member + the stored
+-- proposal) BEFORE the row lands, then stores it byte-exact for the tally.
+CREATE TABLE IF NOT EXISTS cirislens.accord_participation (
+    proposal_digest      TEXT NOT NULL
+        REFERENCES cirislens.accord_proposal (proposal_digest),
+    member_id            TEXT NOT NULL,
+    pinned_pubkey        TEXT NOT NULL,
+    vote                 TEXT NOT NULL
+        CHECK (vote IN ('yes', 'no', 'abstain')),
+    window_until         TIMESTAMPTZ NOT NULL,
+    signed_at            TIMESTAMPTZ NOT NULL,
+    server_arrival_at    TIMESTAMPTZ NOT NULL,
+    participation_json   JSONB NOT NULL,
+    persist_row_hash     TEXT NOT NULL,
+    PRIMARY KEY (proposal_digest, pinned_pubkey)
+);
+
+CREATE INDEX IF NOT EXISTS accord_participation_by_proposal
+    ON cirislens.accord_participation (proposal_digest);
+
+-- ─── accord_decision (frozen-L snapshot; IMMUTABLE — M2) ────────────
+--
+-- The server's frozen verdict over the live set L, one per proposal. Once
+-- written it is IMMUTABLE (no UPDATE path; a re-PUT with identical content
+-- is an idempotent no-op, a differing one is rejected) — the M2
+-- transparency-loggable record. `live_set` is the frozen member_id set; the
+-- vote breakdown is `yes/no/abstain`; `steward_signatures` carries the
+-- 2-of-3 backstop sigs when |L| < L_FLOOR (H6). `decision_json` is the
+-- verify-core AccordDecision VERBATIM.
+CREATE TABLE IF NOT EXISTS cirislens.accord_decision (
+    proposal_digest      TEXT PRIMARY KEY
+        REFERENCES cirislens.accord_proposal (proposal_digest),
+    family_key_id        TEXT NOT NULL,
+    authorized           BOOLEAN NOT NULL,
+    yes                  BIGINT NOT NULL,
+    no                   BIGINT NOT NULL,
+    abstain              BIGINT NOT NULL,
+    live_set             JSONB NOT NULL,
+    window_until         TIMESTAMPTZ NOT NULL,
+    steward_signatures   JSONB,
+    decision_json        JSONB NOT NULL,
+    persist_row_hash     TEXT NOT NULL,
+    decided_at           TIMESTAMPTZ NOT NULL
+);
+
+-- ─── accord_active_halt (H2 support; mutable state) ─────────────────
+--
+-- The currently-active CONSTITUTIONAL halt id per family, fed to
+-- `verify_resume_by_live_quorum` (H2: a resume binds `payload_sha256 ==
+-- sha256(active_halt_id)`). Resuming halt-X clears X as active (the row is
+-- deleted), so a replayed resume against a no-longer-active halt fails
+-- closed. At most one active halt per family.
+CREATE TABLE IF NOT EXISTS cirislens.accord_active_halt (
+    family_key_id        TEXT PRIMARY KEY,
+    active_halt_id       TEXT NOT NULL,
+    set_at               TIMESTAMPTZ NOT NULL
+);
+
+-- ─── accord_issued_nonce (M4 support; fail-closed) ──────────────────
+--
+-- The set of server-issued proposal nonces. A proposal / participation
+-- referencing a nonce NOT in this set is rejected fail-closed (an attacker
+-- cannot mint a proposal against an unissued nonce). Append-only.
+CREATE TABLE IF NOT EXISTS cirislens.accord_issued_nonce (
+    family_key_id        TEXT NOT NULL,
+    nonce                TEXT NOT NULL,
+    issued_at            TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (family_key_id, nonce)
+);

--- a/migrations/sqlite/lens/V091__accord_live_quorum.sql
+++ b/migrations/sqlite/lens/V091__accord_live_quorum.sql
@@ -1,0 +1,110 @@
+-- V091 — #302 FSD-004 accord live-quorum storage (SQLite dialect).
+--
+-- Postgres parity: postgres/lens/V091. See that file for the full design
+-- rationale. The durable storage substrate for the constitutional
+-- kill-switch's decimation-recovery live quorum — the live-quorum sibling
+-- of the `federation_keys` accord-holder storage. CIRISVerify ships the
+-- stateless machinery (`ciris_verify_core::accord_live_quorum`,
+-- CIRISVerify#150); CIRISServer Phase-3 (CIRISServer#122) writes through.
+--
+-- Persist stores the verify-core canonical objects VERBATIM (never
+-- re-derives the bytes) and enforces durable dedup / immutability /
+-- fail-closed nonce + active-halt state. The tally is the server's job.
+-- Recovery (verify_recovery_supersede, H7) is absent — gated on
+-- CIRISAccord#4 (cannot go live until the Constitution sanctions it).
+--
+-- SQLite dialect: bare table names (no schema), TEXT RFC-3339 timestamps,
+-- INTEGER (0/1) booleans, `json_valid()` CHECKs in place of JSONB.
+--
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+-- ─── accord_proposal (append-only; server-issued) ──────────────────
+-- PK = verify-core AccordProposal::digest(). proposal_json verbatim.
+-- (action, prior_family_digest) index = H4 coalescing. prior_family_digest
+-- is the STANDING family envelope digest (anti-replay anchor C3).
+CREATE TABLE IF NOT EXISTS accord_proposal (
+    proposal_digest      TEXT PRIMARY KEY,
+    family_key_id        TEXT NOT NULL,
+    action               TEXT NOT NULL
+        CHECK (action IN ('fire', 'roster_change', 'resume')),
+    nonce                TEXT NOT NULL,
+    window_until         TEXT NOT NULL,            -- RFC-3339
+    prior_family_digest  TEXT NOT NULL,
+    payload_sha256       TEXT NOT NULL,
+    proposal_json        TEXT NOT NULL
+        CHECK (json_valid(proposal_json)),
+    authority_signature  TEXT
+        CHECK (authority_signature IS NULL OR json_valid(authority_signature)),
+    persist_row_hash     TEXT NOT NULL,
+    created_at           TEXT NOT NULL             -- RFC-3339
+);
+
+CREATE INDEX IF NOT EXISTS accord_proposal_by_anchor
+    ON accord_proposal (action, prior_family_digest);
+
+CREATE INDEX IF NOT EXISTS accord_proposal_by_family
+    ON accord_proposal (family_key_id);
+
+-- ─── accord_participation (append-only; proof-of-life + vote) ───────
+-- M6 dedup = PK (proposal_digest, pinned_pubkey) — by PINNED pubkey, not
+-- the plaintext member_id. C2: server_arrival_at is authoritative,
+-- signed_at advisory. participation_json verbatim (incl. ThresholdSignature),
+-- verify-core-verified before insert.
+CREATE TABLE IF NOT EXISTS accord_participation (
+    proposal_digest      TEXT NOT NULL
+        REFERENCES accord_proposal (proposal_digest),
+    member_id            TEXT NOT NULL,
+    pinned_pubkey        TEXT NOT NULL,
+    vote                 TEXT NOT NULL
+        CHECK (vote IN ('yes', 'no', 'abstain')),
+    window_until         TEXT NOT NULL,            -- RFC-3339
+    signed_at            TEXT NOT NULL,            -- RFC-3339 (advisory, C2)
+    server_arrival_at    TEXT NOT NULL,            -- RFC-3339 (authoritative, C2)
+    participation_json   TEXT NOT NULL
+        CHECK (json_valid(participation_json)),
+    persist_row_hash     TEXT NOT NULL,
+    PRIMARY KEY (proposal_digest, pinned_pubkey)
+);
+
+CREATE INDEX IF NOT EXISTS accord_participation_by_proposal
+    ON accord_participation (proposal_digest);
+
+-- ─── accord_decision (frozen-L snapshot; IMMUTABLE — M2) ────────────
+-- One per proposal; immutable once written. authorized stored as INTEGER
+-- (0/1). live_set / steward_signatures / decision_json are JSON text.
+CREATE TABLE IF NOT EXISTS accord_decision (
+    proposal_digest      TEXT PRIMARY KEY
+        REFERENCES accord_proposal (proposal_digest),
+    family_key_id        TEXT NOT NULL,
+    authorized           INTEGER NOT NULL
+        CHECK (authorized IN (0, 1)),
+    yes                  INTEGER NOT NULL,
+    no                   INTEGER NOT NULL,
+    abstain              INTEGER NOT NULL,
+    live_set             TEXT NOT NULL
+        CHECK (json_valid(live_set)),
+    window_until         TEXT NOT NULL,            -- RFC-3339
+    steward_signatures   TEXT
+        CHECK (steward_signatures IS NULL OR json_valid(steward_signatures)),
+    decision_json        TEXT NOT NULL
+        CHECK (json_valid(decision_json)),
+    persist_row_hash     TEXT NOT NULL,
+    decided_at           TEXT NOT NULL             -- RFC-3339
+);
+
+-- ─── accord_active_halt (H2 support; mutable state) ─────────────────
+-- At most one active CONSTITUTIONAL halt per family; resume deletes the row.
+CREATE TABLE IF NOT EXISTS accord_active_halt (
+    family_key_id        TEXT PRIMARY KEY,
+    active_halt_id       TEXT NOT NULL,
+    set_at               TEXT NOT NULL             -- RFC-3339
+);
+
+-- ─── accord_issued_nonce (M4 support; fail-closed) ──────────────────
+-- Server-issued proposal nonces; an unissued nonce is rejected fail-closed.
+CREATE TABLE IF NOT EXISTS accord_issued_nonce (
+    family_key_id        TEXT NOT NULL,
+    nonce                TEXT NOT NULL,
+    issued_at            TEXT NOT NULL,            -- RFC-3339
+    PRIMARY KEY (family_key_id, nonce)
+);

--- a/src/federation/accord_quorum.rs
+++ b/src/federation/accord_quorum.rs
@@ -1,0 +1,463 @@
+//! #302 (FSD-004) — accord live-quorum storage substrate.
+//!
+//! The durable half of the constitutional kill-switch's decimation-recovery
+//! live quorum. CIRISVerify ships the **stateless** machinery in
+//! [`ciris_verify_core::accord_live_quorum`] (CIRISVerify#150 / #98); the
+//! CIRISServer Phase-3 runtime (CIRISServer#122) drives it and writes the
+//! wire objects + anti-replay state **through** persist. Persist is the
+//! storage substrate, so the tables are ours (V091) — the live-quorum
+//! sibling of the `federation_keys` accord-holder storage.
+//!
+//! Division of labour (from #302): **persist stores + dedups + verifies
+//! participations + holds nonce/halt state; the SERVER runs the tally**
+//! (`verify_fire_by_live_quorum` etc. re-verify every participation at tally
+//! time — persist stores the inputs + the server's frozen `AccordDecision`).
+//!
+//! Load-bearing rule: store the verify-core canonical objects **verbatim**
+//! and DERIVE the indexed columns from them via verify-core
+//! ([`AccordProposal::digest`] etc.) — never trust a caller-supplied digest,
+//! never re-derive the bytes by hand.
+//!
+//! **Recovery (`verify_recovery_supersede`, H7) is deliberately absent** —
+//! it bends entrenchment for the captured-roster case and cannot go live
+//! until the CIRIS Constitution sanctions it (CIRISAccord#4). This module
+//! handles `fire` / `roster_change` / `resume` only.
+
+use chrono::{DateTime, Utc};
+use ciris_verify_core::accord_live_quorum::{AccordDecision, AccordParticipation, AccordProposal};
+use ciris_verify_core::threshold::ThresholdMember;
+
+use super::types::compute_persist_row_hash;
+use super::Error;
+
+/// Parse an RFC-3339 timestamp (the verify-core wire form) into a UTC
+/// instant for the indexed timestamp columns. Fail-closed on a malformed
+/// `window_until` / `signed_at` — a row with an unparseable window can't be
+/// filtered by the C2 server-arrival gate.
+fn parse_rfc3339(field: &str, value: &str) -> Result<DateTime<Utc>, Error> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            Error::InvalidArgument(format!("accord {field} not RFC-3339 ({value:?}): {e}"))
+        })
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Prepared write columns — derived from the verify-core objects, ready for
+// the backends to INSERT. Backends do the SQL; this module owns the
+// derivation + verification so all three stay byte-identical.
+// ─────────────────────────────────────────────────────────────────────
+
+/// The indexed + verbatim columns for an `accord_proposal` INSERT, derived
+/// from a verify-core [`AccordProposal`].
+pub(crate) struct PreparedProposal {
+    pub proposal_digest: String,
+    pub family_key_id: String,
+    pub action: String,
+    pub nonce: String,
+    pub window_until: DateTime<Utc>,
+    pub prior_family_digest: String,
+    pub payload_sha256: String,
+    pub proposal_json: serde_json::Value,
+    pub authority_signature: Option<serde_json::Value>,
+    pub persist_row_hash: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Derive the `accord_proposal` columns from the verify-core object. The
+/// digest is `AccordProposal::digest()` (never caller-supplied); the action
+/// is the canonical token. Stores the object verbatim.
+pub(crate) fn prepare_proposal(
+    proposal: &AccordProposal,
+    authority_signature: Option<serde_json::Value>,
+    created_at: DateTime<Utc>,
+) -> Result<PreparedProposal, Error> {
+    let window_until = parse_rfc3339("proposal.window_until", &proposal.window_until)?;
+    let proposal_json = serde_json::to_value(proposal)
+        .map_err(|e| Error::Backend(format!("serialize accord proposal: {e}")))?;
+    Ok(PreparedProposal {
+        proposal_digest: proposal.digest(),
+        family_key_id: proposal.family_key_id.clone(),
+        action: proposal.action.as_str().to_owned(),
+        nonce: proposal.nonce.clone(),
+        window_until,
+        prior_family_digest: proposal.prior_family_digest.clone(),
+        payload_sha256: proposal.payload_sha256.clone(),
+        persist_row_hash: compute_persist_row_hash(proposal)?,
+        proposal_json,
+        authority_signature,
+        created_at,
+    })
+}
+
+/// The columns for an `accord_participation` INSERT, after a fail-closed
+/// verify-core verification.
+pub(crate) struct PreparedParticipation {
+    pub proposal_digest: String,
+    pub member_id: String,
+    /// The M6 dedup key — the member's PINNED Ed25519 pubkey (base64), NOT
+    /// the self-attested `member_id` string.
+    pub pinned_pubkey: String,
+    pub vote: String,
+    pub window_until: DateTime<Utc>,
+    pub signed_at: DateTime<Utc>,
+    pub server_arrival_at: DateTime<Utc>,
+    pub participation_json: serde_json::Value,
+    pub persist_row_hash: String,
+}
+
+/// Verify a participation against the stored proposal + the caller-supplied
+/// standing roster, then derive its INSERT columns. Fail-closed:
+///
+/// 1. The participation's `member_id` MUST resolve to a member of the
+///    standing roster (C3 — L ⊆ standing roster; the live set only narrows
+///    which standing signers count).
+/// 2. [`AccordParticipation::verify`] (verify-core) MUST pass — it binds the
+///    proposal digest, family, member seat, vote + window inside the hybrid
+///    signature (C1/M3/M5). Persist verifies BEFORE the row lands.
+///
+/// The M6 dedup key is the member's PINNED Ed25519 pubkey (so a relay can't
+/// double-count a holder by varying the `member_id` string). C2: the caller
+/// passes `server_arrival_at` (the authoritative arrival instant) — never
+/// the advisory `signed_at`.
+pub(crate) fn verify_and_prepare_participation(
+    proposal: &AccordProposal,
+    participation: &AccordParticipation,
+    standing_roster: &[ThresholdMember],
+    server_arrival_at: DateTime<Utc>,
+) -> Result<PreparedParticipation, Error> {
+    // (1) member ∈ standing roster (C3).
+    let member = standing_roster
+        .iter()
+        .find(|m| m.member_id == participation.member_id)
+        .ok_or_else(|| {
+            Error::InvalidArgument(format!(
+                "accord participation: member {:?} is not in the standing roster (C3)",
+                participation.member_id
+            ))
+        })?;
+    // (2) verify-core fail-closed verify (sig + proposal-digest + family +
+    //     seat consistency). Binds participation to THIS proposal.
+    participation.verify(member, proposal).map_err(|e| {
+        Error::InvalidArgument(format!(
+            "accord participation verify failed (fail-closed): {e}"
+        ))
+    })?;
+
+    let window_until = parse_rfc3339("participation.window_until", &participation.window_until)?;
+    let signed_at = parse_rfc3339("participation.signed_at", &participation.signed_at)?;
+    let participation_json = serde_json::to_value(participation)
+        .map_err(|e| Error::Backend(format!("serialize accord participation: {e}")))?;
+    Ok(PreparedParticipation {
+        proposal_digest: participation.proposal_digest.clone(),
+        member_id: participation.member_id.clone(),
+        pinned_pubkey: member.ed25519_public_key_base64.clone(),
+        vote: participation.vote.as_str().to_owned(),
+        window_until,
+        signed_at,
+        server_arrival_at,
+        participation_json,
+        persist_row_hash: compute_persist_row_hash(participation)?,
+    })
+}
+
+/// The columns for an `accord_decision` INSERT (the frozen-L snapshot, M2).
+pub(crate) struct PreparedDecision {
+    pub proposal_digest: String,
+    pub family_key_id: String,
+    pub authorized: bool,
+    pub yes: i64,
+    pub no: i64,
+    pub abstain: i64,
+    pub live_set: serde_json::Value,
+    pub window_until: DateTime<Utc>,
+    pub steward_signatures: Option<serde_json::Value>,
+    pub decision_json: serde_json::Value,
+    pub persist_row_hash: String,
+    pub decided_at: DateTime<Utc>,
+}
+
+/// Derive the `accord_decision` columns from the verify-core
+/// [`AccordDecision`]. The decision is IMMUTABLE once written (M2): backends
+/// reject a differing re-PUT and no-op an identical one (keyed on the
+/// `persist_row_hash`). `steward_signatures` carries the |L|<L_FLOOR backstop
+/// sigs (H6) when present.
+pub(crate) fn prepare_decision(
+    decision: &AccordDecision,
+    steward_signatures: Option<serde_json::Value>,
+    decided_at: DateTime<Utc>,
+) -> Result<PreparedDecision, Error> {
+    let window_until = parse_rfc3339(
+        "decision.proposal.window_until",
+        &decision.proposal.window_until,
+    )?;
+    let live_set = serde_json::to_value(&decision.live_set)
+        .map_err(|e| Error::Backend(format!("serialize accord live_set: {e}")))?;
+    let decision_json = serde_json::to_value(decision)
+        .map_err(|e| Error::Backend(format!("serialize accord decision: {e}")))?;
+    Ok(PreparedDecision {
+        proposal_digest: decision.proposal.digest(),
+        family_key_id: decision.proposal.family_key_id.clone(),
+        authorized: decision.authorized,
+        yes: decision.yes as i64,
+        no: decision.no as i64,
+        abstain: decision.abstain as i64,
+        live_set,
+        window_until,
+        steward_signatures,
+        persist_row_hash: compute_persist_row_hash(decision)?,
+        decision_json,
+        decided_at,
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Read row types — what list/get return. The verbatim `*_json` round-trips
+// back to the verify-core object for the server's tally.
+// ─────────────────────────────────────────────────────────────────────
+
+/// A stored `accord_proposal`: the verbatim verify-core object + the
+/// server-supplied authority signature envelope.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StoredProposal {
+    /// The verbatim verify-core proposal (round-trips for the server tally).
+    pub proposal: AccordProposal,
+    /// The server-supplied authority-signature envelope, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_signature: Option<serde_json::Value>,
+    /// Substrate row hash (canonical SHA-256 of the stored proposal).
+    pub persist_row_hash: String,
+    /// When persist admitted the proposal.
+    pub created_at: DateTime<Utc>,
+}
+
+/// A stored `accord_participation`: the verbatim verify-core object + the
+/// authoritative server-arrival instant (C2).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StoredParticipation {
+    /// The verbatim verify-core participation (incl. the hybrid signature).
+    pub participation: AccordParticipation,
+    /// The member's PINNED Ed25519 pubkey — the M6 dedup key.
+    pub pinned_pubkey: String,
+    /// The AUTHORITATIVE arrival instant persist stamped (C2 window clock);
+    /// `participation.signed_at` is advisory only.
+    pub server_arrival_at: DateTime<Utc>,
+    /// Substrate row hash (canonical SHA-256 of the stored participation).
+    pub persist_row_hash: String,
+}
+
+/// A stored `accord_decision`: the verbatim frozen-L snapshot.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct StoredDecision {
+    /// The verbatim verify-core frozen-L decision snapshot (M2, immutable).
+    pub decision: AccordDecision,
+    /// The |L|<L_FLOOR steward-backstop signatures (H6), if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steward_signatures: Option<serde_json::Value>,
+    /// Substrate row hash (canonical SHA-256 of the stored decision).
+    pub persist_row_hash: String,
+    /// When persist admitted the decision.
+    pub decided_at: DateTime<Utc>,
+}
+
+/// The active CONSTITUTIONAL halt for a family (H2). `None` when no halt is
+/// active (a resume cleared it).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ActiveHalt {
+    /// The accord family the halt applies to.
+    pub family_key_id: String,
+    /// The active CONSTITUTIONAL halt id (a resume binds `sha256(this)`).
+    pub active_halt_id: String,
+    /// When the halt became active.
+    pub set_at: DateTime<Utc>,
+}
+
+/// #302 — shared test fixtures for the backend parity tests (build a proposal
+/// + a validly-signed participation that passes verify-core's verify).
+#[cfg(test)]
+pub(crate) mod test_fixtures {
+    use super::*;
+    use crate::federation::operational::test_support::Identity;
+    use ciris_verify_core::accord_live_quorum::{AccordAction, Vote};
+    use ciris_verify_core::threshold::ThresholdSignature;
+
+    /// A `fire` proposal over `family` with `nonce` (far-future window).
+    pub fn proposal(family: &str, nonce: &str) -> AccordProposal {
+        AccordProposal {
+            family_key_id: family.to_owned(),
+            action: AccordAction::Fire,
+            nonce: nonce.to_owned(),
+            window_until: "2031-01-01T00:00:00Z".to_owned(),
+            prior_family_digest: "prior-family-digest-abc".to_owned(),
+            payload_sha256: "payload-sha256-def".to_owned(),
+        }
+    }
+
+    /// A participation by `id` on `proposal` with `vote`, hybrid-signed so
+    /// [`AccordParticipation::verify`] passes against `id.member()`.
+    pub fn signed_participation(
+        id: &Identity,
+        proposal: &AccordProposal,
+        vote: Vote,
+    ) -> AccordParticipation {
+        let mut p = AccordParticipation {
+            family_key_id: proposal.family_key_id.clone(),
+            proposal_digest: proposal.digest(),
+            member_id: id.key_id.clone(),
+            vote,
+            window_until: proposal.window_until.clone(),
+            signed_at: "2025-06-01T00:00:00Z".to_owned(),
+            signature: ThresholdSignature {
+                member_id: id.key_id.clone(),
+                ed25519_signature_base64: String::new(),
+                mldsa65_signature_base64: None,
+            },
+        };
+        // canonical_bytes excludes the signature, so sign over it then set.
+        p.signature = id.threshold_sig(&p.canonical_bytes());
+        p
+    }
+
+    /// #302 — the full accord live-quorum storage flow, run against ANY
+    /// backend so the three impls assert identical behaviour from ONE source
+    /// (no pg/sqlite/memory asymmetry): M4 nonce fail-closed,
+    /// verify-before-mutation (C3 roster + verify-core verify), M6 dedup by
+    /// pinned pubkey, decision immutability (M2), active-halt clear-on-resume
+    /// (H2).
+    pub async fn exercise_accord_storage<B>(backend: &B, suffix: &str)
+    where
+        B: crate::federation::FederationDirectory + ?Sized,
+    {
+        use crate::federation::Error;
+        use ciris_verify_core::accord_live_quorum::{AccordDecision, LiveQuorumTally};
+
+        // Scope family + nonce by `suffix` so the pg parity test (shared DB)
+        // doesn't collide across runs; the standing-roster anchor below is
+        // this proposal's own `prior_family_digest`.
+        let family = format!("fam-{suffix}");
+        let nonce = format!("nonce-{suffix}");
+        let alice = Identity::new("alice");
+        let bob = Identity::new("bob");
+        let roster = vec![alice.member(), bob.member()];
+        let prop = proposal(&family, &nonce);
+        let anchor = prop.prior_family_digest.clone();
+        let digest = prop.digest();
+
+        // M4 fail-closed: proposal before its nonce is issued → rejected.
+        let err = backend
+            .put_accord_proposal(prop.clone(), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidArgument(_)), "M4: {err:?}");
+        // Issue the nonce → admitted (+ idempotent re-PUT).
+        backend.issue_accord_nonce(&family, &nonce).await.unwrap();
+        backend
+            .put_accord_proposal(prop.clone(), None)
+            .await
+            .unwrap();
+        backend
+            .put_accord_proposal(prop.clone(), None)
+            .await
+            .unwrap();
+        assert!(backend
+            .get_accord_proposal(&digest)
+            .await
+            .unwrap()
+            .is_some());
+        // Anchor index returns exactly this proposal (digest match below
+        // guards against cross-run rows sharing the fixed anchor).
+        assert!(backend
+            .list_accord_proposals_by_anchor("fire", &anchor)
+            .await
+            .unwrap()
+            .iter()
+            .any(|p| p.proposal.digest() == digest));
+
+        // Participation referencing an unknown proposal → rejected.
+        let unknown = proposal(&family, &format!("{nonce}-other"));
+        assert!(backend
+            .put_accord_participation(signed_participation(&alice, &unknown, Vote::Yes), &roster)
+            .await
+            .is_err());
+
+        // Valid participation; re-PUT idempotent (one row).
+        let pa_yes = signed_participation(&alice, &prop, Vote::Yes);
+        backend
+            .put_accord_participation(pa_yes.clone(), &roster)
+            .await
+            .unwrap();
+        backend
+            .put_accord_participation(pa_yes, &roster)
+            .await
+            .unwrap();
+        let parts = backend.list_accord_participations(&digest).await.unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(
+            parts[0].pinned_pubkey,
+            alice.member().ed25519_public_key_base64
+        );
+
+        // M6: alice voting DIFFERENTLY on the same proposal → Conflict.
+        let err = backend
+            .put_accord_participation(signed_participation(&alice, &prop, Vote::No), &roster)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Conflict(_)), "M6: {err:?}");
+
+        // Member outside the standing roster → rejected (C3).
+        let carol = Identity::new("carol");
+        assert!(backend
+            .put_accord_participation(signed_participation(&carol, &prop, Vote::Yes), &roster)
+            .await
+            .is_err());
+
+        // Decision immutability (M2).
+        let tally = LiveQuorumTally {
+            live_set: vec!["alice".to_owned()],
+            yes: 1,
+            no: 0,
+            abstain: 0,
+        };
+        backend
+            .put_accord_decision(AccordDecision::new(prop.clone(), &tally, true), None)
+            .await
+            .unwrap();
+        backend
+            .put_accord_decision(AccordDecision::new(prop.clone(), &tally, true), None)
+            .await
+            .unwrap(); // idempotent
+        let err = backend
+            .put_accord_decision(AccordDecision::new(prop.clone(), &tally, false), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::Conflict(_)), "M2: {err:?}");
+        assert!(
+            backend
+                .get_accord_decision(&digest)
+                .await
+                .unwrap()
+                .unwrap()
+                .decision
+                .authorized
+        );
+
+        // Active halt (H2): set; wrong-id resume no-ops; right-id clears.
+        backend.set_active_halt(&family, "halt-X").await.unwrap();
+        assert_eq!(
+            backend
+                .get_active_halt(&family)
+                .await
+                .unwrap()
+                .unwrap()
+                .active_halt_id,
+            "halt-X"
+        );
+        backend
+            .clear_active_halt(&family, "halt-WRONG")
+            .await
+            .unwrap();
+        assert!(backend.get_active_halt(&family).await.unwrap().is_some());
+        backend.clear_active_halt(&family, "halt-X").await.unwrap();
+        assert!(backend.get_active_halt(&family).await.unwrap().is_none());
+    }
+}

--- a/src/federation/accord_quorum.rs
+++ b/src/federation/accord_quorum.rs
@@ -50,6 +50,7 @@ fn parse_rfc3339(field: &str, value: &str) -> Result<DateTime<Utc>, Error> {
 
 /// The indexed + verbatim columns for an `accord_proposal` INSERT, derived
 /// from a verify-core [`AccordProposal`].
+#[allow(dead_code)] // #302: fields are the SQL write contract (sqlite/postgres); memory ignores some via `..`
 pub(crate) struct PreparedProposal {
     pub proposal_digest: String,
     pub family_key_id: String,
@@ -92,6 +93,7 @@ pub(crate) fn prepare_proposal(
 
 /// The columns for an `accord_participation` INSERT, after a fail-closed
 /// verify-core verification.
+#[allow(dead_code)] // #302: fields are the SQL write contract (sqlite/postgres); memory ignores some via `..`
 pub(crate) struct PreparedParticipation {
     pub proposal_digest: String,
     pub member_id: String,
@@ -162,6 +164,7 @@ pub(crate) fn verify_and_prepare_participation(
 }
 
 /// The columns for an `accord_decision` INSERT (the frozen-L snapshot, M2).
+#[allow(dead_code)] // #302: fields are the SQL write contract (sqlite/postgres); memory ignores some via `..`
 pub(crate) struct PreparedDecision {
     pub proposal_digest: String,
     pub family_key_id: String,

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -32,6 +32,7 @@
 //! and the registry-side `docs/FEDERATION_CLIENT.md` for the consumer
 //! complement.
 
+pub mod accord_quorum;
 pub mod admission;
 pub mod at_rest_cascade;
 #[cfg(feature = "cirisaudit")]
@@ -2856,6 +2857,105 @@ pub trait FederationDirectory: Send + Sync {
         content_id: &str,
         corpus_kind: &str,
     ) -> Result<u64, Error>;
+
+    // ── #302 (FSD-004) accord live-quorum storage ──────────────────────
+    //
+    // The durable substrate for the constitutional kill-switch's
+    // decimation-recovery live quorum (CIRISVerify#150 stateless machinery;
+    // CIRISServer#122 runtime writes through). Persist STORES the verify-core
+    // objects verbatim + dedups + verifies participations + holds nonce/halt
+    // state; the SERVER runs the tally. Recovery (H7) is absent (CIRISAccord#4
+    // gate). See [`crate::federation::accord_quorum`].
+
+    /// #302 — admit an `accord_proposal` (server-issued). M4 fail-closed: the
+    /// proposal's `nonce` MUST already be issued for its family
+    /// ([`Self::issue_accord_nonce`]) or the write is rejected. The digest is
+    /// derived via verify-core ([`AccordProposal::digest`](ciris_verify_core::accord_live_quorum::AccordProposal::digest));
+    /// the object is stored verbatim. Idempotent on a byte-identical re-PUT.
+    async fn put_accord_proposal(
+        &self,
+        proposal: ciris_verify_core::accord_live_quorum::AccordProposal,
+        authority_signature: Option<serde_json::Value>,
+    ) -> Result<(), Error>;
+
+    /// #302 — the stored proposal for `proposal_digest`, or `None`.
+    async fn get_accord_proposal(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<accord_quorum::StoredProposal>, Error>;
+
+    /// #302 — proposals over `(action, prior_family_digest)` — the H4
+    /// coalescing index (collapse duplicate proposals over one standing
+    /// roster). `prior_family_digest` is the STANDING envelope digest (C3).
+    async fn list_accord_proposals_by_anchor(
+        &self,
+        action: &str,
+        prior_family_digest: &str,
+    ) -> Result<Vec<accord_quorum::StoredProposal>, Error>;
+
+    /// #302 — admit an `accord_participation`. Verify-before-mutation: the
+    /// proposal MUST exist, the member MUST be in `standing_roster` (C3), and
+    /// [`AccordParticipation::verify`](ciris_verify_core::accord_live_quorum::AccordParticipation::verify)
+    /// MUST pass (fail-closed). M6 durable dedup by PINNED pubkey: a second
+    /// participation by the same pinned key for the same proposal is an
+    /// idempotent no-op if byte-identical, else [`Error::Conflict`]
+    /// (one vote per holder per proposal). C2: persist stamps the
+    /// authoritative `server_arrival_at`.
+    async fn put_accord_participation(
+        &self,
+        participation: ciris_verify_core::accord_live_quorum::AccordParticipation,
+        standing_roster: &[ciris_verify_core::threshold::ThresholdMember],
+    ) -> Result<(), Error>;
+
+    /// #302 — all stored participations for a proposal (the server's tally
+    /// input). Deduped by pinned pubkey at write time (M6).
+    async fn list_accord_participations(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Vec<accord_quorum::StoredParticipation>, Error>;
+
+    /// #302 — record the server's frozen-L decision (M2). IMMUTABLE: a
+    /// differing re-PUT for the same proposal is [`Error::Conflict`]; an
+    /// identical one is an idempotent no-op. `steward_signatures` carries the
+    /// |L|<L_FLOOR backstop (H6) when present.
+    async fn put_accord_decision(
+        &self,
+        decision: ciris_verify_core::accord_live_quorum::AccordDecision,
+        steward_signatures: Option<serde_json::Value>,
+    ) -> Result<(), Error>;
+
+    /// #302 — the stored decision for `proposal_digest`, or `None`.
+    async fn get_accord_decision(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<accord_quorum::StoredDecision>, Error>;
+
+    /// #302 (H2) — set the active CONSTITUTIONAL halt for a family (upsert;
+    /// at most one active halt per family).
+    async fn set_active_halt(&self, family_key_id: &str, active_halt_id: &str)
+        -> Result<(), Error>;
+
+    /// #302 (H2) — the active halt for a family, or `None`.
+    async fn get_active_halt(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Option<accord_quorum::ActiveHalt>, Error>;
+
+    /// #302 (H2) — clear the active halt iff it matches `active_halt_id` (a
+    /// resume un-fires the specific halt). A no-op if a different / no halt is
+    /// active, so a replayed resume against a stale halt has no effect.
+    async fn clear_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), Error>;
+
+    /// #302 (M4) — record a server-issued proposal nonce (idempotent).
+    async fn issue_accord_nonce(&self, family_key_id: &str, nonce: &str) -> Result<(), Error>;
+
+    /// #302 (M4) — has this `(family_key_id, nonce)` been issued? The
+    /// fail-closed gate `put_accord_proposal` consults.
+    async fn accord_nonce_issued(&self, family_key_id: &str, nonce: &str) -> Result<bool, Error>;
 }
 
 /// Federation directory errors. Distinct from

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1008,6 +1008,49 @@ impl PyEngine {
     }
 }
 
+/// #302 — two-backend dispatch for the accord write-through methods: bind the
+/// backend as `$b`, run `$body` (which uses `$b` + `.await`) on the runtime,
+/// with the `FederationDirectory` trait in scope. Collapses the otherwise
+/// 2×-repeated pg/sqlite match for each of the dozen accord FFI methods.
+macro_rules! accord_dispatch {
+    ($self:ident, $runtime:ident, $b:ident, $body:expr) => {
+        match &$self.backend {
+            BackendDispatch::Postgres(pg) => {
+                let $b = pg.clone();
+                $runtime.block_on(async move {
+                    #[allow(unused_imports)]
+                    use crate::federation::FederationDirectory;
+                    $body
+                })
+            }
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(sq) => {
+                let $b = sq.clone();
+                $runtime.block_on(async move {
+                    #[allow(unused_imports)]
+                    use crate::federation::FederationDirectory;
+                    $body
+                })
+            }
+        }
+    };
+}
+
+/// #302 — serialize an optional read result to `Option<String>` JSON.
+fn accord_opt_json<T: serde::Serialize>(v: Option<T>) -> PyResult<Option<String>> {
+    match v {
+        Some(x) => Ok(Some(serde_json::to_string(&x).map_err(|e| {
+            PyValueError::new_err(format!("accord serialize: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}
+
+/// #302 — serialize a list read result to a JSON array string.
+fn accord_vec_json<T: serde::Serialize>(v: Vec<T>) -> PyResult<String> {
+    serde_json::to_string(&v).map_err(|e| PyValueError::new_err(format!("accord serialize: {e}")))
+}
+
 #[pymethods]
 impl PyEngine {
     /// Connect to Postgres, run migrations, instantiate the
@@ -6221,6 +6264,330 @@ impl PyEngine {
                             .map_err(federation_err_to_py)
                     })
                 }
+            })
+        })
+    }
+
+    // ── #302 (FSD-004) accord live-quorum write-through (CIRISServer#122) ──
+    //
+    // CIRISServer's Phase-3 runtime writes the verify-core wire objects +
+    // anti-replay state through these. JSON in/out; persist verifies +
+    // dedups + holds state (see `crate::federation::accord_quorum`).
+
+    /// #302 — admit an `accord_proposal`. `payload_json` =
+    /// `{ "proposal": <AccordProposal>, "authority_signature": <obj|null> }`.
+    /// M4 fail-closed on an unissued nonce.
+    fn put_accord_proposal_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let v: serde_json::Value = serde_json::from_str(payload_json)
+                .map_err(|e| PyValueError::new_err(format!("accord proposal decode: {e}")))?;
+            let proposal: ciris_verify_core::accord_live_quorum::AccordProposal =
+                serde_json::from_value(
+                    v.get("proposal")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                )
+                .map_err(|e| PyValueError::new_err(format!("proposal decode: {e}")))?;
+            let authority_signature = v
+                .get("authority_signature")
+                .cloned()
+                .filter(|x| !x.is_null());
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.put_accord_proposal(proposal, authority_signature)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 — the stored proposal as JSON, or `None`.
+    fn get_accord_proposal_json(
+        &self,
+        py: Python<'_>,
+        proposal_digest: &str,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key = proposal_digest.to_owned();
+            py.detach(move || {
+                let stored = accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.get_accord_proposal(&key)
+                        .await
+                        .map_err(federation_err_to_py)
+                )?;
+                accord_opt_json(stored)
+            })
+        })
+    }
+
+    /// #302 — proposals over `(action, prior_family_digest)` (H4) as a JSON
+    /// array.
+    fn list_accord_proposals_by_anchor_json(
+        &self,
+        py: Python<'_>,
+        action: &str,
+        prior_family_digest: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let action = action.to_owned();
+            let anchor = prior_family_digest.to_owned();
+            py.detach(move || {
+                let rows = accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.list_accord_proposals_by_anchor(&action, &anchor)
+                        .await
+                        .map_err(federation_err_to_py)
+                )?;
+                accord_vec_json(rows)
+            })
+        })
+    }
+
+    /// #302 — admit an `accord_participation`. `payload_json` =
+    /// `{ "participation": <AccordParticipation>, "standing_roster":
+    /// [<ThresholdMember>...] }`. Verify-before-mutation + M6 dedup.
+    fn put_accord_participation_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let v: serde_json::Value = serde_json::from_str(payload_json)
+                .map_err(|e| PyValueError::new_err(format!("accord participation decode: {e}")))?;
+            let participation: ciris_verify_core::accord_live_quorum::AccordParticipation =
+                serde_json::from_value(
+                    v.get("participation")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                )
+                .map_err(|e| PyValueError::new_err(format!("participation decode: {e}")))?;
+            let standing_roster: Vec<ciris_verify_core::threshold::ThresholdMember> =
+                serde_json::from_value(
+                    v.get("standing_roster")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                )
+                .map_err(|e| PyValueError::new_err(format!("standing_roster decode: {e}")))?;
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.put_accord_participation(participation, &standing_roster)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 — all participations for a proposal as a JSON array.
+    fn list_accord_participations_json(
+        &self,
+        py: Python<'_>,
+        proposal_digest: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key = proposal_digest.to_owned();
+            py.detach(move || {
+                let rows = accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.list_accord_participations(&key)
+                        .await
+                        .map_err(federation_err_to_py)
+                )?;
+                accord_vec_json(rows)
+            })
+        })
+    }
+
+    /// #302 — record the server's frozen-L decision. `payload_json` =
+    /// `{ "decision": <AccordDecision>, "steward_signatures": <obj|null> }`.
+    /// Immutable (M2).
+    fn put_accord_decision_json(&self, py: Python<'_>, payload_json: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let v: serde_json::Value = serde_json::from_str(payload_json)
+                .map_err(|e| PyValueError::new_err(format!("accord decision decode: {e}")))?;
+            let decision: ciris_verify_core::accord_live_quorum::AccordDecision =
+                serde_json::from_value(
+                    v.get("decision")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                )
+                .map_err(|e| PyValueError::new_err(format!("decision decode: {e}")))?;
+            let steward_signatures = v
+                .get("steward_signatures")
+                .cloned()
+                .filter(|x| !x.is_null());
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.put_accord_decision(decision, steward_signatures)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 — the stored decision as JSON, or `None`.
+    fn get_accord_decision_json(
+        &self,
+        py: Python<'_>,
+        proposal_digest: &str,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key = proposal_digest.to_owned();
+            py.detach(move || {
+                let stored = accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.get_accord_decision(&key)
+                        .await
+                        .map_err(federation_err_to_py)
+                )?;
+                accord_opt_json(stored)
+            })
+        })
+    }
+
+    /// #302 (H2) — set the active CONSTITUTIONAL halt for a family.
+    fn set_active_halt(
+        &self,
+        py: Python<'_>,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let fam = family_key_id.to_owned();
+            let halt = active_halt_id.to_owned();
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.set_active_halt(&fam, &halt)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 (H2) — the active halt for a family as JSON, or `None`.
+    fn get_active_halt_json(
+        &self,
+        py: Python<'_>,
+        family_key_id: &str,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let fam = family_key_id.to_owned();
+            py.detach(move || {
+                let halt = accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.get_active_halt(&fam).await.map_err(federation_err_to_py)
+                )?;
+                accord_opt_json(halt)
+            })
+        })
+    }
+
+    /// #302 (H2) — clear the active halt iff it matches (a resume).
+    fn clear_active_halt(
+        &self,
+        py: Python<'_>,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let fam = family_key_id.to_owned();
+            let halt = active_halt_id.to_owned();
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.clear_active_halt(&fam, &halt)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 (M4) — record a server-issued proposal nonce.
+    fn issue_accord_nonce(&self, py: Python<'_>, family_key_id: &str, nonce: &str) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let fam = family_key_id.to_owned();
+            let n = nonce.to_owned();
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.issue_accord_nonce(&fam, &n)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
+            })
+        })
+    }
+
+    /// #302 (M4) — has `(family_key_id, nonce)` been issued?
+    fn accord_nonce_issued(
+        &self,
+        py: Python<'_>,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> PyResult<bool> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let fam = family_key_id.to_owned();
+            let n = nonce.to_owned();
+            py.detach(move || {
+                accord_dispatch!(
+                    self,
+                    runtime,
+                    b,
+                    b.accord_nonce_issued(&fam, &n)
+                        .await
+                        .map_err(federation_err_to_py)
+                )
             })
         })
     }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -175,6 +175,17 @@ struct State {
     /// community-DEK rotation *state* (`federation_community_dek_epoch`) is
     /// carried on memory while its crypto half is BlobStorage-only.
     federation_scope_blobs: HashMap<([u8; 32], u16), MemScopeBlob>,
+    /// #302 (FSD-004) — accord live-quorum storage, parity with the
+    /// pg/sqlite V091 tables. Proposals keyed by `proposal_digest`;
+    /// participations a flat vec (deduped by `(proposal_digest,
+    /// pinned_pubkey)` at write time, M6); decisions keyed by
+    /// `proposal_digest` (immutable, M2); active halts keyed by family (H2);
+    /// issued nonces a `(family_key_id, nonce)` set (M4).
+    accord_proposals: HashMap<String, crate::federation::accord_quorum::StoredProposal>,
+    accord_participations: Vec<crate::federation::accord_quorum::StoredParticipation>,
+    accord_decisions: HashMap<String, crate::federation::accord_quorum::StoredDecision>,
+    accord_active_halts: HashMap<String, crate::federation::accord_quorum::ActiveHalt>,
+    accord_issued_nonces: std::collections::HashSet<(String, String)>,
 }
 
 /// v9.1.0 (CIRISPersist#243) — one in-memory scope-blob symbol + its LRU
@@ -227,6 +238,11 @@ impl Default for MemoryBackend {
                 wholeness_witnesses: HashMap::new(),
                 content_aggregations: HashMap::new(),
                 federation_scope_blobs: HashMap::new(),
+                accord_proposals: HashMap::new(),
+                accord_participations: Vec::new(),
+                accord_decisions: HashMap::new(),
+                accord_active_halts: HashMap::new(),
+                accord_issued_nonces: std::collections::HashSet::new(),
             }),
         }
     }
@@ -1926,6 +1942,271 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .collect();
         rows.sort_by(|a, b| a.community_key_id.cmp(&b.community_key_id));
         Ok(rows)
+    }
+
+    // ─── #302 (FSD-004) accord live-quorum storage ──────────────────────
+
+    async fn put_accord_proposal(
+        &self,
+        proposal: ciris_verify_core::accord_live_quorum::AccordProposal,
+        authority_signature: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        // M4 fail-closed (self.accord_nonce_issued locks state — run before).
+        if !self
+            .accord_nonce_issued(&proposal.family_key_id, &proposal.nonce)
+            .await?
+        {
+            return Err(Error::InvalidArgument(format!(
+                "accord proposal nonce {:?} not issued for family {:?} (M4 fail-closed)",
+                proposal.nonce, proposal.family_key_id
+            )));
+        }
+        let prep = crate::federation::accord_quorum::prepare_proposal(
+            &proposal,
+            authority_signature,
+            chrono::Utc::now(),
+        )?;
+        let crate::federation::accord_quorum::PreparedProposal {
+            proposal_digest,
+            persist_row_hash,
+            created_at,
+            authority_signature,
+            ..
+        } = prep;
+        let stored = crate::federation::accord_quorum::StoredProposal {
+            proposal,
+            authority_signature,
+            persist_row_hash,
+            created_at,
+        };
+        let mut state = self.state.lock().expect("memory backend lock");
+        // Content-derived digest ⇒ insert-if-absent is idempotent.
+        state
+            .accord_proposals
+            .entry(proposal_digest)
+            .or_insert(stored);
+        Ok(())
+    }
+
+    async fn get_accord_proposal(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state.accord_proposals.get(proposal_digest).cloned())
+    }
+
+    async fn list_accord_proposals_by_anchor(
+        &self,
+        action: &str,
+        prior_family_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .accord_proposals
+            .values()
+            .filter(|p| {
+                p.proposal.action.as_str() == action
+                    && p.proposal.prior_family_digest == prior_family_digest
+            })
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.proposal.digest().cmp(&b.proposal.digest()))
+        });
+        Ok(rows)
+    }
+
+    async fn put_accord_participation(
+        &self,
+        participation: ciris_verify_core::accord_live_quorum::AccordParticipation,
+        standing_roster: &[ciris_verify_core::threshold::ThresholdMember],
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        // Proposal must exist (get locks state — run before our lock).
+        let stored_proposal = self
+            .get_accord_proposal(&participation.proposal_digest)
+            .await?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "accord participation references unknown proposal {:?}",
+                    participation.proposal_digest
+                ))
+            })?;
+        let prep = crate::federation::accord_quorum::verify_and_prepare_participation(
+            &stored_proposal.proposal,
+            &participation,
+            standing_roster,
+            chrono::Utc::now(),
+        )?;
+        let crate::federation::accord_quorum::PreparedParticipation {
+            proposal_digest,
+            pinned_pubkey,
+            server_arrival_at,
+            persist_row_hash,
+            ..
+        } = prep;
+        let mut state = self.state.lock().expect("memory backend lock");
+        // M6 durable dedup by (proposal_digest, pinned_pubkey).
+        if let Some(existing) = state.accord_participations.iter().find(|p| {
+            p.participation.proposal_digest == proposal_digest && p.pinned_pubkey == pinned_pubkey
+        }) {
+            if existing.persist_row_hash == persist_row_hash {
+                return Ok(());
+            }
+            return Err(Error::Conflict(format!(
+                "accord participation: holder (pinned pubkey) already voted differently on proposal {proposal_digest:?} (M6 — one vote per holder)"
+            )));
+        }
+        state
+            .accord_participations
+            .push(crate::federation::accord_quorum::StoredParticipation {
+                participation,
+                pinned_pubkey,
+                server_arrival_at,
+                persist_row_hash,
+            });
+        Ok(())
+    }
+
+    async fn list_accord_participations(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredParticipation>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .accord_participations
+            .iter()
+            .filter(|p| p.participation.proposal_digest == proposal_digest)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            a.server_arrival_at
+                .cmp(&b.server_arrival_at)
+                .then_with(|| a.pinned_pubkey.cmp(&b.pinned_pubkey))
+        });
+        Ok(rows)
+    }
+
+    async fn put_accord_decision(
+        &self,
+        decision: ciris_verify_core::accord_live_quorum::AccordDecision,
+        steward_signatures: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        let prep = crate::federation::accord_quorum::prepare_decision(
+            &decision,
+            steward_signatures,
+            chrono::Utc::now(),
+        )?;
+        let crate::federation::accord_quorum::PreparedDecision {
+            proposal_digest,
+            persist_row_hash,
+            decided_at,
+            steward_signatures,
+            ..
+        } = prep;
+        let mut state = self.state.lock().expect("memory backend lock");
+        // Immutable (M2): identical re-PUT no-ops, a differing one conflicts.
+        if let Some(existing) = state.accord_decisions.get(&proposal_digest) {
+            if existing.persist_row_hash == persist_row_hash {
+                return Ok(());
+            }
+            return Err(Error::Conflict(format!(
+                "accord decision for proposal {proposal_digest:?} already recorded with different content (M2 — immutable)"
+            )));
+        }
+        state.accord_decisions.insert(
+            proposal_digest,
+            crate::federation::accord_quorum::StoredDecision {
+                decision,
+                steward_signatures,
+                persist_row_hash,
+                decided_at,
+            },
+        );
+        Ok(())
+    }
+
+    async fn get_accord_decision(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredDecision>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state.accord_decisions.get(proposal_digest).cloned())
+    }
+
+    async fn set_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let mut state = self.state.lock().expect("memory backend lock");
+        state.accord_active_halts.insert(
+            family_key_id.to_owned(),
+            crate::federation::accord_quorum::ActiveHalt {
+                family_key_id: family_key_id.to_owned(),
+                active_halt_id: active_halt_id.to_owned(),
+                set_at: chrono::Utc::now(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn get_active_halt(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::ActiveHalt>, crate::federation::Error>
+    {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state.accord_active_halts.get(family_key_id).cloned())
+    }
+
+    async fn clear_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let mut state = self.state.lock().expect("memory backend lock");
+        // Only clear the matching halt (a stale-halt resume is a no-op).
+        let matches = state
+            .accord_active_halts
+            .get(family_key_id)
+            .is_some_and(|h| h.active_halt_id == active_halt_id);
+        if matches {
+            state.accord_active_halts.remove(family_key_id);
+        }
+        Ok(())
+    }
+
+    async fn issue_accord_nonce(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let mut state = self.state.lock().expect("memory backend lock");
+        state
+            .accord_issued_nonces
+            .insert((family_key_id.to_owned(), nonce.to_owned()));
+        Ok(())
+    }
+
+    async fn accord_nonce_issued(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<bool, crate::federation::Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state
+            .accord_issued_nonces
+            .contains(&(family_key_id.to_owned(), nonce.to_owned())))
     }
 
     // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
@@ -4195,6 +4476,21 @@ impl crate::derived::DerivedSchema for MemoryBackend {
         _version: i32,
     ) -> Result<Option<crate::derived::CalibrationBundle>, crate::derived::Error> {
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod accord_tests {
+    use super::*;
+
+    /// #302 — full accord live-quorum storage flow on the memory backend (M4
+    /// nonce / verify-before-mutation / M6 dedup / M2 immutability / H2 halt).
+    /// Shares the assertion body with the sqlite + pg parity tests.
+    #[tokio::test]
+    async fn accord_live_quorum_storage_flow() {
+        let backend = MemoryBackend::new();
+        crate::federation::accord_quorum::test_fixtures::exercise_accord_storage(&backend, "mem")
+            .await;
     }
 }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3471,6 +3471,380 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         rows.into_iter().map(pg_row_to_community).collect()
     }
 
+    // ─── #302 (FSD-004) accord live-quorum storage ──────────────────────
+
+    async fn put_accord_proposal(
+        &self,
+        proposal: ciris_verify_core::accord_live_quorum::AccordProposal,
+        authority_signature: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        if !self
+            .accord_nonce_issued(&proposal.family_key_id, &proposal.nonce)
+            .await?
+        {
+            return Err(Error::InvalidArgument(format!(
+                "accord proposal nonce {:?} not issued for family {:?} (M4 fail-closed)",
+                proposal.nonce, proposal.family_key_id
+            )));
+        }
+        let prep = crate::federation::accord_quorum::prepare_proposal(
+            &proposal,
+            authority_signature,
+            chrono::Utc::now(),
+        )?;
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.accord_proposal (\
+                    proposal_digest, family_key_id, action, nonce, window_until, \
+                    prior_family_digest, payload_sha256, proposal_json, \
+                    authority_signature, persist_row_hash, created_at\
+                 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) \
+                 ON CONFLICT (proposal_digest) DO NOTHING",
+                &[
+                    &prep.proposal_digest,
+                    &prep.family_key_id,
+                    &prep.action,
+                    &prep.nonce,
+                    &prep.window_until,
+                    &prep.prior_family_digest,
+                    &prep.payload_sha256,
+                    &prep.proposal_json,
+                    &prep.authority_signature,
+                    &prep.persist_row_hash,
+                    &prep.created_at,
+                ],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("insert accord_proposal: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_accord_proposal(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let row_opt = client
+            .query_opt(
+                "SELECT proposal_json, authority_signature, persist_row_hash, created_at \
+                 FROM cirislens.accord_proposal WHERE proposal_digest = $1",
+                &[&proposal_digest],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("get_accord_proposal: {e}")))?;
+        row_opt.map(pg_row_to_stored_proposal).transpose()
+    }
+
+    async fn list_accord_proposals_by_anchor(
+        &self,
+        action: &str,
+        prior_family_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT proposal_json, authority_signature, persist_row_hash, created_at \
+                 FROM cirislens.accord_proposal WHERE action = $1 AND prior_family_digest = $2 \
+                 ORDER BY created_at ASC, proposal_digest ASC",
+                &[&action, &prior_family_digest],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("list_accord_proposals_by_anchor: {e}"))
+            })?;
+        rows.into_iter().map(pg_row_to_stored_proposal).collect()
+    }
+
+    async fn put_accord_participation(
+        &self,
+        participation: ciris_verify_core::accord_live_quorum::AccordParticipation,
+        standing_roster: &[ciris_verify_core::threshold::ThresholdMember],
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        let stored = self
+            .get_accord_proposal(&participation.proposal_digest)
+            .await?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "accord participation references unknown proposal {:?}",
+                    participation.proposal_digest
+                ))
+            })?;
+        let prep = crate::federation::accord_quorum::verify_and_prepare_participation(
+            &stored.proposal,
+            &participation,
+            standing_roster,
+            chrono::Utc::now(),
+        )?;
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+        // M6 dedup by (proposal_digest, pinned_pubkey): idempotent if
+        // identical, conflict if a different vote.
+        let existing: Option<String> = client
+            .query_opt(
+                "SELECT persist_row_hash FROM cirislens.accord_participation \
+                 WHERE proposal_digest = $1 AND pinned_pubkey = $2",
+                &[&prep.proposal_digest, &prep.pinned_pubkey],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("accord_participation dedup check: {e}")))?
+            .map(|r| r.safe_get_with("persist_row_hash", Error::Backend))
+            .transpose()?;
+        if let Some(h) = existing {
+            if h == prep.persist_row_hash {
+                return Ok(());
+            }
+            return Err(Error::Conflict(format!(
+                "accord participation: holder (pinned pubkey) already voted differently on proposal {:?} (M6 — one vote per holder)",
+                participation.proposal_digest
+            )));
+        }
+        client
+            .execute(
+                "INSERT INTO cirislens.accord_participation (\
+                    proposal_digest, member_id, pinned_pubkey, vote, window_until, \
+                    signed_at, server_arrival_at, participation_json, persist_row_hash\
+                 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+                &[
+                    &prep.proposal_digest,
+                    &prep.member_id,
+                    &prep.pinned_pubkey,
+                    &prep.vote,
+                    &prep.window_until,
+                    &prep.signed_at,
+                    &prep.server_arrival_at,
+                    &prep.participation_json,
+                    &prep.persist_row_hash,
+                ],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("insert accord_participation: {e}")))?;
+        Ok(())
+    }
+
+    async fn list_accord_participations(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredParticipation>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT participation_json, pinned_pubkey, server_arrival_at, persist_row_hash \
+                 FROM cirislens.accord_participation WHERE proposal_digest = $1 \
+                 ORDER BY server_arrival_at ASC, pinned_pubkey ASC",
+                &[&proposal_digest],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("list_accord_participations: {e}"))
+            })?;
+        rows.into_iter()
+            .map(pg_row_to_stored_participation)
+            .collect()
+    }
+
+    async fn put_accord_decision(
+        &self,
+        decision: ciris_verify_core::accord_live_quorum::AccordDecision,
+        steward_signatures: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        let prep = crate::federation::accord_quorum::prepare_decision(
+            &decision,
+            steward_signatures,
+            chrono::Utc::now(),
+        )?;
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| Error::Backend(e.to_string()))?;
+        // Immutable (M2).
+        let existing: Option<String> = client
+            .query_opt(
+                "SELECT persist_row_hash FROM cirislens.accord_decision WHERE proposal_digest = $1",
+                &[&prep.proposal_digest],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("accord_decision immutability check: {e}")))?
+            .map(|r| r.safe_get_with("persist_row_hash", Error::Backend))
+            .transpose()?;
+        if let Some(h) = existing {
+            if h == prep.persist_row_hash {
+                return Ok(());
+            }
+            return Err(Error::Conflict(format!(
+                "accord decision for proposal {:?} already recorded with different content (M2 — immutable)",
+                prep.proposal_digest
+            )));
+        }
+        client
+            .execute(
+                "INSERT INTO cirislens.accord_decision (\
+                    proposal_digest, family_key_id, authorized, yes, no, abstain, \
+                    live_set, window_until, steward_signatures, decision_json, \
+                    persist_row_hash, decided_at\
+                 ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)",
+                &[
+                    &prep.proposal_digest,
+                    &prep.family_key_id,
+                    &prep.authorized,
+                    &prep.yes,
+                    &prep.no,
+                    &prep.abstain,
+                    &prep.live_set,
+                    &prep.window_until,
+                    &prep.steward_signatures,
+                    &prep.decision_json,
+                    &prep.persist_row_hash,
+                    &prep.decided_at,
+                ],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("insert accord_decision: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_accord_decision(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredDecision>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let row_opt = client
+            .query_opt(
+                "SELECT decision_json, steward_signatures, persist_row_hash, decided_at \
+                 FROM cirislens.accord_decision WHERE proposal_digest = $1",
+                &[&proposal_digest],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("get_accord_decision: {e}")))?;
+        row_opt.map(pg_row_to_stored_decision).transpose()
+    }
+
+    async fn set_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.accord_active_halt (family_key_id, active_halt_id, set_at) \
+                 VALUES ($1, $2, $3) \
+                 ON CONFLICT (family_key_id) DO UPDATE SET \
+                    active_halt_id = EXCLUDED.active_halt_id, set_at = EXCLUDED.set_at",
+                &[&family_key_id, &active_halt_id, &chrono::Utc::now()],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("set_active_halt: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_active_halt(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::ActiveHalt>, crate::federation::Error>
+    {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let row_opt = client
+            .query_opt(
+                "SELECT family_key_id, active_halt_id, set_at FROM cirislens.accord_active_halt \
+                 WHERE family_key_id = $1",
+                &[&family_key_id],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("get_active_halt: {e}")))?;
+        row_opt.map(pg_row_to_active_halt).transpose()
+    }
+
+    async fn clear_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "DELETE FROM cirislens.accord_active_halt \
+                 WHERE family_key_id = $1 AND active_halt_id = $2",
+                &[&family_key_id, &active_halt_id],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("clear_active_halt: {e}")))?;
+        Ok(())
+    }
+
+    async fn issue_accord_nonce(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO cirislens.accord_issued_nonce (family_key_id, nonce, issued_at) \
+                 VALUES ($1, $2, $3) ON CONFLICT (family_key_id, nonce) DO NOTHING",
+                &[&family_key_id, &nonce, &chrono::Utc::now()],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("issue_accord_nonce: {e}")))?;
+        Ok(())
+    }
+
+    async fn accord_nonce_issued(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<bool, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let row_opt = client
+            .query_opt(
+                "SELECT 1 FROM cirislens.accord_issued_nonce \
+                 WHERE family_key_id = $1 AND nonce = $2",
+                &[&family_key_id, &nonce],
+            )
+            .await
+            .map_err(|e| crate::federation::Error::Backend(format!("accord_nonce_issued: {e}")))?;
+        Ok(row_opt.is_some())
+    }
+
     // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
 
     async fn put_identity_occurrence_revocation(
@@ -9601,6 +9975,67 @@ fn pg_row_to_family(
     })
 }
 
+/// #302 — pg row → `StoredProposal`.
+fn pg_row_to_stored_proposal(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::accord_quorum::StoredProposal, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let proposal_json: serde_json::Value = row.safe_get_with("proposal_json", mk_err)?;
+    let proposal = serde_json::from_value(proposal_json)
+        .map_err(|e| crate::federation::Error::Backend(format!("proposal deserialize: {e}")))?;
+    Ok(crate::federation::accord_quorum::StoredProposal {
+        proposal,
+        authority_signature: row.safe_get_with("authority_signature", mk_err)?,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+        created_at: row.safe_get_with("created_at", mk_err)?,
+    })
+}
+
+/// #302 — pg row → `StoredParticipation`.
+fn pg_row_to_stored_participation(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::accord_quorum::StoredParticipation, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let participation_json: serde_json::Value = row.safe_get_with("participation_json", mk_err)?;
+    let participation = serde_json::from_value(participation_json).map_err(|e| {
+        crate::federation::Error::Backend(format!("participation deserialize: {e}"))
+    })?;
+    Ok(crate::federation::accord_quorum::StoredParticipation {
+        participation,
+        pinned_pubkey: row.safe_get_with("pinned_pubkey", mk_err)?,
+        server_arrival_at: row.safe_get_with("server_arrival_at", mk_err)?,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+    })
+}
+
+/// #302 — pg row → `StoredDecision`.
+fn pg_row_to_stored_decision(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::accord_quorum::StoredDecision, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    let decision_json: serde_json::Value = row.safe_get_with("decision_json", mk_err)?;
+    let decision = serde_json::from_value(decision_json)
+        .map_err(|e| crate::federation::Error::Backend(format!("decision deserialize: {e}")))?;
+    Ok(crate::federation::accord_quorum::StoredDecision {
+        decision,
+        steward_signatures: row.safe_get_with("steward_signatures", mk_err)?,
+        persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
+        decided_at: row.safe_get_with("decided_at", mk_err)?,
+    })
+}
+
+/// #302 — pg row → `ActiveHalt`.
+fn pg_row_to_active_halt(
+    row: tokio_postgres::Row,
+) -> Result<crate::federation::accord_quorum::ActiveHalt, crate::federation::Error> {
+    let mk_err = crate::federation::Error::Backend;
+    Ok(crate::federation::accord_quorum::ActiveHalt {
+        family_key_id: row.safe_get_with("family_key_id", mk_err)?,
+        active_halt_id: row.safe_get_with("active_halt_id", mk_err)?,
+        set_at: row.safe_get_with("set_at", mk_err)?,
+    })
+}
+
 fn pg_row_to_community(
     row: tokio_postgres::Row,
 ) -> Result<crate::federation::Community, crate::federation::Error> {
@@ -14390,6 +14825,23 @@ mod tests {
 
     fn pg_dsn() -> Option<String> {
         env::var("CIRIS_PERSIST_TEST_PG_URL").ok()
+    }
+
+    /// #302 — accord live-quorum storage parity on postgres (shares the
+    /// assertion body with memory + sqlite). A unique suffix scopes the
+    /// fixtures so the shared test DB doesn't collide across runs.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn accord_live_quorum_storage_flow_postgres() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.expect("connect");
+        backend.run_migrations().await.expect("migrations run");
+        let suffix = uuid_like();
+        crate::federation::accord_quorum::test_fixtures::exercise_accord_storage(&backend, &suffix)
+            .await;
     }
 
     /// Smoke: connect + run_migrations. Skipped if no test DB is

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3129,6 +3129,416 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         .map_err(|e| crate::federation::Error::Backend(format!("list_communities_for_member: {e}")))
     }
 
+    // ─── #302 (FSD-004) accord live-quorum storage ──────────────────────
+
+    async fn put_accord_proposal(
+        &self,
+        proposal: ciris_verify_core::accord_live_quorum::AccordProposal,
+        authority_signature: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        // M4 fail-closed: the nonce must already be issued for this family.
+        if !self
+            .accord_nonce_issued(&proposal.family_key_id, &proposal.nonce)
+            .await?
+        {
+            return Err(Error::InvalidArgument(format!(
+                "accord proposal nonce {:?} not issued for family {:?} (M4 fail-closed)",
+                proposal.nonce, proposal.family_key_id
+            )));
+        }
+        let prep = crate::federation::accord_quorum::prepare_proposal(
+            &proposal,
+            authority_signature,
+            chrono::Utc::now(),
+        )?;
+        let proposal_json = serde_json::to_string(&prep.proposal_json)
+            .map_err(|e| Error::Backend(format!("proposal_json encode: {e}")))?;
+        let auth_sig = match &prep.authority_signature {
+            Some(v) => Some(
+                serde_json::to_string(v)
+                    .map_err(|e| Error::Backend(format!("authority_signature encode: {e}")))?,
+            ),
+            None => None,
+        };
+        let conn = self.conn.clone();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            // ON CONFLICT DO NOTHING — the digest is content-derived, so a
+            // re-PUT of the same proposal is idempotent and a different
+            // proposal cannot collide.
+            conn.execute(
+                "INSERT INTO accord_proposal (\
+                    proposal_digest, family_key_id, action, nonce, window_until, \
+                    prior_family_digest, payload_sha256, proposal_json, \
+                    authority_signature, persist_row_hash, created_at\
+                 ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11) \
+                 ON CONFLICT(proposal_digest) DO NOTHING",
+                rusqlite::params![
+                    prep.proposal_digest,
+                    prep.family_key_id,
+                    prep.action,
+                    prep.nonce,
+                    prep.window_until.to_rfc3339(),
+                    prep.prior_family_digest,
+                    prep.payload_sha256,
+                    proposal_json,
+                    auth_sig,
+                    prep.persist_row_hash,
+                    prep.created_at.to_rfc3339(),
+                ],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| Error::Backend(format!("insert accord_proposal: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_accord_proposal(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let key = proposal_digest.to_owned();
+        (move || -> Result<Option<crate::federation::accord_quorum::StoredProposal>, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT proposal_json, authority_signature, persist_row_hash, created_at \
+                 FROM accord_proposal WHERE proposal_digest = ?1",
+                [&key],
+                sqlite_row_to_stored_proposal,
+            )
+            .optional()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("get_accord_proposal: {e}")))
+    }
+
+    async fn list_accord_proposals_by_anchor(
+        &self,
+        action: &str,
+        prior_family_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredProposal>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let action = action.to_owned();
+        let anchor = prior_family_digest.to_owned();
+        (move || -> Result<Vec<crate::federation::accord_quorum::StoredProposal>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT proposal_json, authority_signature, persist_row_hash, created_at \
+                 FROM accord_proposal WHERE action = ?1 AND prior_family_digest = ?2 \
+                 ORDER BY created_at ASC, proposal_digest ASC",
+            )?;
+            let rows = stmt.query_map(
+                rusqlite::params![action, anchor],
+                sqlite_row_to_stored_proposal,
+            )?;
+            rows.collect()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("list_accord_proposals_by_anchor: {e}")))
+    }
+
+    async fn put_accord_participation(
+        &self,
+        participation: ciris_verify_core::accord_live_quorum::AccordParticipation,
+        standing_roster: &[ciris_verify_core::threshold::ThresholdMember],
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        // The proposal MUST exist (verify-before-mutation needs it to verify
+        // the participation binding).
+        let stored = self
+            .get_accord_proposal(&participation.proposal_digest)
+            .await?
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "accord participation references unknown proposal {:?}",
+                    participation.proposal_digest
+                ))
+            })?;
+        let prep = crate::federation::accord_quorum::verify_and_prepare_participation(
+            &stored.proposal,
+            &participation,
+            standing_roster,
+            chrono::Utc::now(),
+        )?;
+        let participation_json = serde_json::to_string(&prep.participation_json)
+            .map_err(|e| Error::Backend(format!("participation_json encode: {e}")))?;
+        let conn = self.conn.clone();
+        let outcome = (move || -> Result<&'static str, rusqlite::Error> {
+            let conn = conn.lock();
+            // M6 durable dedup by (proposal_digest, pinned_pubkey): a second
+            // participation by the same pinned holder is idempotent if
+            // byte-identical, else a conflict (one vote per holder).
+            let existing: Option<String> = conn
+                .query_row(
+                    "SELECT persist_row_hash FROM accord_participation \
+                     WHERE proposal_digest = ?1 AND pinned_pubkey = ?2",
+                    rusqlite::params![prep.proposal_digest, prep.pinned_pubkey],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if let Some(h) = existing {
+                return Ok(if h == prep.persist_row_hash {
+                    "noop"
+                } else {
+                    "conflict"
+                });
+            }
+            conn.execute(
+                "INSERT INTO accord_participation (\
+                    proposal_digest, member_id, pinned_pubkey, vote, window_until, \
+                    signed_at, server_arrival_at, participation_json, persist_row_hash\
+                 ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
+                rusqlite::params![
+                    prep.proposal_digest,
+                    prep.member_id,
+                    prep.pinned_pubkey,
+                    prep.vote,
+                    prep.window_until.to_rfc3339(),
+                    prep.signed_at.to_rfc3339(),
+                    prep.server_arrival_at.to_rfc3339(),
+                    participation_json,
+                    prep.persist_row_hash,
+                ],
+            )?;
+            Ok("inserted")
+        })()
+        .map_err(|e| Error::Backend(format!("insert accord_participation: {e}")))?;
+        if outcome == "conflict" {
+            return Err(Error::Conflict(format!(
+                "accord participation: holder (pinned pubkey) already voted differently on proposal {:?} (M6 — one vote per holder)",
+                participation.proposal_digest
+            )));
+        }
+        Ok(())
+    }
+
+    async fn list_accord_participations(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Vec<crate::federation::accord_quorum::StoredParticipation>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let key = proposal_digest.to_owned();
+        (move || -> Result<Vec<crate::federation::accord_quorum::StoredParticipation>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT participation_json, pinned_pubkey, server_arrival_at, persist_row_hash \
+                 FROM accord_participation WHERE proposal_digest = ?1 \
+                 ORDER BY server_arrival_at ASC, pinned_pubkey ASC",
+            )?;
+            let rows = stmt.query_map([&key], sqlite_row_to_stored_participation)?;
+            rows.collect()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("list_accord_participations: {e}")))
+    }
+
+    async fn put_accord_decision(
+        &self,
+        decision: ciris_verify_core::accord_live_quorum::AccordDecision,
+        steward_signatures: Option<serde_json::Value>,
+    ) -> Result<(), crate::federation::Error> {
+        use crate::federation::Error;
+        let prep = crate::federation::accord_quorum::prepare_decision(
+            &decision,
+            steward_signatures,
+            chrono::Utc::now(),
+        )?;
+        let live_set = serde_json::to_string(&prep.live_set)
+            .map_err(|e| Error::Backend(format!("live_set encode: {e}")))?;
+        let decision_json = serde_json::to_string(&prep.decision_json)
+            .map_err(|e| Error::Backend(format!("decision_json encode: {e}")))?;
+        let steward = match &prep.steward_signatures {
+            Some(v) => Some(
+                serde_json::to_string(v)
+                    .map_err(|e| Error::Backend(format!("steward_signatures encode: {e}")))?,
+            ),
+            None => None,
+        };
+        let digest_for_err = prep.proposal_digest.clone();
+        let conn = self.conn.clone();
+        let outcome = (move || -> Result<&'static str, rusqlite::Error> {
+            let conn = conn.lock();
+            // Immutable (M2): identical re-PUT is a no-op, a differing one is
+            // a conflict.
+            let existing: Option<String> = conn
+                .query_row(
+                    "SELECT persist_row_hash FROM accord_decision WHERE proposal_digest = ?1",
+                    [&prep.proposal_digest],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if let Some(h) = existing {
+                return Ok(if h == prep.persist_row_hash {
+                    "noop"
+                } else {
+                    "conflict"
+                });
+            }
+            conn.execute(
+                "INSERT INTO accord_decision (\
+                    proposal_digest, family_key_id, authorized, yes, no, abstain, \
+                    live_set, window_until, steward_signatures, decision_json, \
+                    persist_row_hash, decided_at\
+                 ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12)",
+                rusqlite::params![
+                    prep.proposal_digest,
+                    prep.family_key_id,
+                    prep.authorized as i64,
+                    prep.yes,
+                    prep.no,
+                    prep.abstain,
+                    live_set,
+                    prep.window_until.to_rfc3339(),
+                    steward,
+                    decision_json,
+                    prep.persist_row_hash,
+                    prep.decided_at.to_rfc3339(),
+                ],
+            )?;
+            Ok("inserted")
+        })()
+        .map_err(|e| Error::Backend(format!("insert accord_decision: {e}")))?;
+        if outcome == "conflict" {
+            return Err(Error::Conflict(format!(
+                "accord decision for proposal {digest_for_err:?} already recorded with different content (M2 — immutable)"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn get_accord_decision(
+        &self,
+        proposal_digest: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::StoredDecision>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let key = proposal_digest.to_owned();
+        (move || -> Result<Option<crate::federation::accord_quorum::StoredDecision>, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT decision_json, steward_signatures, persist_row_hash, decided_at \
+                 FROM accord_decision WHERE proposal_digest = ?1",
+                [&key],
+                sqlite_row_to_stored_decision,
+            )
+            .optional()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("get_accord_decision: {e}")))
+    }
+
+    async fn set_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let conn = self.conn.clone();
+        let fam = family_key_id.to_owned();
+        let halt = active_halt_id.to_owned();
+        let now = chrono::Utc::now().to_rfc3339();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO accord_active_halt (family_key_id, active_halt_id, set_at) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(family_key_id) DO UPDATE SET \
+                    active_halt_id = excluded.active_halt_id, set_at = excluded.set_at",
+                rusqlite::params![fam, halt, now],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("set_active_halt: {e}")))?;
+        Ok(())
+    }
+
+    async fn get_active_halt(
+        &self,
+        family_key_id: &str,
+    ) -> Result<Option<crate::federation::accord_quorum::ActiveHalt>, crate::federation::Error>
+    {
+        let conn = self.conn.clone();
+        let fam = family_key_id.to_owned();
+        (move || -> Result<Option<crate::federation::accord_quorum::ActiveHalt>, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.query_row(
+                "SELECT family_key_id, active_halt_id, set_at FROM accord_active_halt \
+                 WHERE family_key_id = ?1",
+                [&fam],
+                sqlite_row_to_active_halt,
+            )
+            .optional()
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("get_active_halt: {e}")))
+    }
+
+    async fn clear_active_halt(
+        &self,
+        family_key_id: &str,
+        active_halt_id: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let conn = self.conn.clone();
+        let fam = family_key_id.to_owned();
+        let halt = active_halt_id.to_owned();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            // Clear only the matching halt — a replayed resume against a stale
+            // halt id is a no-op (0 rows).
+            conn.execute(
+                "DELETE FROM accord_active_halt \
+                 WHERE family_key_id = ?1 AND active_halt_id = ?2",
+                rusqlite::params![fam, halt],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("clear_active_halt: {e}")))?;
+        Ok(())
+    }
+
+    async fn issue_accord_nonce(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<(), crate::federation::Error> {
+        let conn = self.conn.clone();
+        let fam = family_key_id.to_owned();
+        let n = nonce.to_owned();
+        let now = chrono::Utc::now().to_rfc3339();
+        (move || -> Result<(), rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "INSERT INTO accord_issued_nonce (family_key_id, nonce, issued_at) \
+                 VALUES (?1, ?2, ?3) ON CONFLICT(family_key_id, nonce) DO NOTHING",
+                rusqlite::params![fam, n, now],
+            )?;
+            Ok(())
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("issue_accord_nonce: {e}")))?;
+        Ok(())
+    }
+
+    async fn accord_nonce_issued(
+        &self,
+        family_key_id: &str,
+        nonce: &str,
+    ) -> Result<bool, crate::federation::Error> {
+        let conn = self.conn.clone();
+        let fam = family_key_id.to_owned();
+        let n = nonce.to_owned();
+        (move || -> Result<bool, rusqlite::Error> {
+            let conn = conn.lock();
+            let found: Option<i64> = conn
+                .query_row(
+                    "SELECT 1 FROM accord_issued_nonce WHERE family_key_id = ?1 AND nonce = ?2",
+                    rusqlite::params![fam, n],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            Ok(found.is_some())
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("accord_nonce_issued: {e}")))
+    }
+
     // ─── v4.8.0 (CIRISPersist#161, CEG §11.7.1) — membership revocations.
 
     async fn put_identity_occurrence_revocation(
@@ -9481,6 +9891,84 @@ fn sqlite_row_to_family(row: &rusqlite::Row<'_>) -> rusqlite::Result<crate::fede
     })
 }
 
+/// #302 — map a serde decode failure on a stored JSON column to a rusqlite
+/// conversion error (the accord `*_json` columns round-trip to verify-core
+/// objects).
+fn accord_json_err(e: serde_json::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    )
+}
+
+/// #302 — sqlite row → `StoredProposal` (verbatim proposal + authority sig).
+fn sqlite_row_to_stored_proposal(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::accord_quorum::StoredProposal> {
+    let proposal_json: String = row.get("proposal_json")?;
+    let proposal = serde_json::from_str(&proposal_json).map_err(accord_json_err)?;
+    let auth_text: Option<String> = row.get("authority_signature")?;
+    let authority_signature = match auth_text {
+        Some(t) => Some(serde_json::from_str(&t).map_err(accord_json_err)?),
+        None => None,
+    };
+    let created_at: String = row.get("created_at")?;
+    Ok(crate::federation::accord_quorum::StoredProposal {
+        proposal,
+        authority_signature,
+        persist_row_hash: row.get("persist_row_hash")?,
+        created_at: parse_rfc3339(&created_at),
+    })
+}
+
+/// #302 — sqlite row → `StoredParticipation` (verbatim + server arrival).
+fn sqlite_row_to_stored_participation(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::accord_quorum::StoredParticipation> {
+    let participation_json: String = row.get("participation_json")?;
+    let participation = serde_json::from_str(&participation_json).map_err(accord_json_err)?;
+    let server_arrival_at: String = row.get("server_arrival_at")?;
+    Ok(crate::federation::accord_quorum::StoredParticipation {
+        participation,
+        pinned_pubkey: row.get("pinned_pubkey")?,
+        server_arrival_at: parse_rfc3339(&server_arrival_at),
+        persist_row_hash: row.get("persist_row_hash")?,
+    })
+}
+
+/// #302 — sqlite row → `StoredDecision` (verbatim frozen-L snapshot).
+fn sqlite_row_to_stored_decision(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::accord_quorum::StoredDecision> {
+    let decision_json: String = row.get("decision_json")?;
+    let decision = serde_json::from_str(&decision_json).map_err(accord_json_err)?;
+    let steward_text: Option<String> = row.get("steward_signatures")?;
+    let steward_signatures = match steward_text {
+        Some(t) => Some(serde_json::from_str(&t).map_err(accord_json_err)?),
+        None => None,
+    };
+    let decided_at: String = row.get("decided_at")?;
+    Ok(crate::federation::accord_quorum::StoredDecision {
+        decision,
+        steward_signatures,
+        persist_row_hash: row.get("persist_row_hash")?,
+        decided_at: parse_rfc3339(&decided_at),
+    })
+}
+
+/// #302 — sqlite row → `ActiveHalt`.
+fn sqlite_row_to_active_halt(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::federation::accord_quorum::ActiveHalt> {
+    let set_at: String = row.get("set_at")?;
+    Ok(crate::federation::accord_quorum::ActiveHalt {
+        family_key_id: row.get("family_key_id")?,
+        active_halt_id: row.get("active_halt_id")?,
+        set_at: parse_rfc3339(&set_at),
+    })
+}
+
 fn sqlite_row_to_community(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<crate::federation::Community> {
@@ -13997,6 +14485,21 @@ impl crate::derived::DerivedSchema for SqliteBackend {
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod accord_tests {
+    use super::*;
+
+    /// #302 — accord live-quorum storage parity on sqlite (shares the
+    /// assertion body with memory + pg).
+    #[tokio::test]
+    async fn accord_live_quorum_storage_flow_sqlite() {
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        crate::federation::accord_quorum::test_fixtures::exercise_accord_storage(&backend, "sq")
+            .await;
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/tests/python/test_sqlite_engine.py
+++ b/tests/python/test_sqlite_engine.py
@@ -575,3 +575,67 @@ def test_nodes_stewarded_by_json_pyo3_299():
     finally:
         eng.close(force=True)
     ciris_persist.reset_engine()
+
+
+def test_accord_live_quorum_ffi_302():
+    """#302 — the accord live-quorum write-through FFI is bound and routes
+    JSON through the backend: M4 nonce gate (issue + fail-closed reject +
+    admit), proposal round-trip via the anchor index, and active-halt H2
+    set/clear semantics. The verify-before-mutation participation path needs
+    real hybrid signatures and is covered exhaustively by the Rust tests."""
+    import json
+    import os
+    import secrets
+    import tempfile
+
+    import pytest
+
+    ciris_persist.reset_engine()
+    seed = os.path.join(tempfile.mkdtemp(), "seed")
+    with open(seed, "wb") as fh:
+        fh.write(secrets.token_bytes(32))
+    alias = "n" + secrets.token_hex(6)
+    try:
+        eng = ciris_persist.Engine(
+            "sqlite::memory:", alias, local_key_id=alias, local_key_path=seed
+        )
+    except ValueError as exc:
+        if "sqlite" in str(exc) and "feature" in str(exc):
+            pytest.skip("wheel built without the sqlite feature")
+        raise
+    try:
+        # M4: nonce gate.
+        assert eng.accord_nonce_issued("fam", "n1") is False
+        proposal = {
+            "family_key_id": "fam",
+            "action": "fire",
+            "nonce": "n1",
+            "window_until": "2031-01-01T00:00:00Z",
+            "prior_family_digest": "pfd-abc",
+            "payload_sha256": "psh-def",
+        }
+        # Proposal before the nonce is issued → ValueError (M4 fail-closed).
+        with pytest.raises(ValueError):
+            eng.put_accord_proposal_json(
+                json.dumps({"proposal": proposal, "authority_signature": None})
+            )
+        eng.issue_accord_nonce("fam", "n1")
+        assert eng.accord_nonce_issued("fam", "n1") is True
+        # Now admitted; the anchor index returns it (verbatim round-trip).
+        eng.put_accord_proposal_json(
+            json.dumps({"proposal": proposal, "authority_signature": None})
+        )
+        rows = json.loads(eng.list_accord_proposals_by_anchor_json("fire", "pfd-abc"))
+        assert len(rows) == 1
+        assert rows[0]["proposal"]["nonce"] == "n1"
+
+        # H2 active halt: set, wrong-id resume no-ops, right-id clears.
+        eng.set_active_halt("fam", "halt-X")
+        assert json.loads(eng.get_active_halt_json("fam"))["active_halt_id"] == "halt-X"
+        eng.clear_active_halt("fam", "halt-WRONG")
+        assert eng.get_active_halt_json("fam") is not None
+        eng.clear_active_halt("fam", "halt-X")
+        assert eng.get_active_halt_json("fam") is None
+    finally:
+        eng.close(force=True)
+    ciris_persist.reset_engine()


### PR DESCRIPTION
Implements #302 — the durable storage half of the constitutional kill-switch's decimation-recovery live quorum. CIRISVerify ships the stateless machinery in `ciris_verify_core::accord_live_quorum` (CIRISVerify#150, re-pinned here **v8.1.0 → v8.2.0** — the tag that first ships #150); CIRISServer Phase-3 (#122) writes through.

**Division of labour:** persist STORES verbatim + dedups + verifies participations + holds nonce/halt state; the **server runs the tally** (`verify_fire_by_live_quorum` etc. re-verify at tally time).

## What landed
V091 migrations (pg + sqlite lockstep), the `accord_quorum` module, the `FederationDirectory` surface (12 methods × **3 backends** postgres/sqlite/memory), and pyo3 write-through:

| Table | Property |
|---|---|
| `accord_proposal` | stored **verbatim**; digest derived via verify-core (`AccordProposal::digest`), never caller-supplied; `(action, prior_family_digest)` coalescing index (H4) |
| `accord_participation` | **verify-before-mutation** (proposal exists + member ∈ caller standing roster (C3) + `AccordParticipation::verify` fail-closed); **M6 dedup by PINNED pubkey** (PK `(proposal_digest, pinned_pubkey)`); **C2** server-stamped `server_arrival_at` (`signed_at` advisory) |
| `accord_decision` | **immutable** frozen-L snapshot (M2) |
| `accord_active_halt` | H2 — clear only the matching halt (stale-halt resume no-ops) |
| `accord_issued_nonce` | M4 — `put_accord_proposal` fail-closed on an unissued nonce |

Anti-replay anchor = the **standing** roster `prior_family_digest` (C3), never the live set L.

## Deliberately NOT included
**Recovery (`verify_recovery_supersede`, H7)** — it bends entrenchment for the captured-roster case and can't go live until the Constitution sanctions it (**CIRISAccord#4**). Only `fire` / `roster_change` / `resume` objects are handled. verify-core ships the fn ungated (doc-level caution only), so persist withholds the path at the substrate.

## Validation
- Parity from **one** shared `exercise_accord_storage` body across memory + sqlite + postgres (pg gated on `CIRIS_PERSIST_TEST_PG_URL`), driving **real hybrid-signed participations** through verify-core's `AccordParticipation::verify`.
- Python FFI smoke (`test_accord_live_quorum_ffi_302`): M4 nonce gate, proposal round-trip, H2 halt.
- Full clippy (`-D warnings`) + fmt clean; 139-test federation sweep green.
- `Requires-Dist ciris-verify>=8.0.0,<9` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ