### PR TITLE
v11.2.0 — #304 wrap-once-to-the-identity (derived content-KEM) + verify v8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.2.0] — 2026-06-27
+
+### Added — #304: wrap-once-to-the-identity for the self-DEK cascade (derived content-KEM)
+
+CIRISServer 0.5.56+ **derives** a user's content-encryption keypair (X25519 +
+ML-KEM-768) deterministically from the FedID Ed25519 seed (CIRISVerify#151 /
+verify **v8.3.0**, re-pinned here). Consequence: every occurrence of one
+identity presents the **identical** enc pubkey.
+
+Two things confirmed/fixed:
+
+1. **The derived model is accepted** (it already was — documented + now
+   regression-tested): `federation_identity_occurrences` has no UNIQUE/CHECK on
+   the enc pubkeys, and `put_identity_occurrence` does not reject two occurrences
+   of one identity sharing the same `pubkey_x25519_base64` /
+   `pubkey_ml_kem_768_base64`. Duplicates admit.
+2. **Wrap-once optimization** (`rekey_for_newcomers`): the cascade wrapped the
+   DEK per-occurrence, so a derived-key identity with N occurrences ran the
+   expensive ML-KEM-768 encap N times over one pubkey. It now **memoizes the
+   wrap per distinct `(x25519, ml_kem)` pubkey pair** and reuses it for every
+   occurrence sharing that pubkey — any holder of the shared (derived) private
+   key opens it. Collapses N redundant encaps to one per derived identity. Grant
+   rows stay per-occurrence (the reader resolves by `occurrence_key_id`,
+   unchanged); non-derived (distinct) pubkeys are unaffected — one wrap each.
+
+Proven by `self_dek_wrap_once_for_derived_identity_pubkeys_304`: two occurrences
+sharing a derived pubkey get **byte-identical** grants (the wrap was reused),
+while a distinct-pubkey control gets a different wrap.
+
+The full "wrap once, stored once, new occurrence is a no-op rekey" shape would
+need a grant-keyed-by-identity model + reader change — deferred; per-occurrence
+grants with a deduped wrap is the low-risk win that keeps the at-rest reader
+untouched.
+
+### Changed — re-pin CIRISVerify v8.2.0 → v8.3.0
+
+All six pins → `v8.3.0` (ships #151, the self content-KEM derivation #304 rides).
+In-family minor; `Requires-Dist ciris-verify>=8.0.0,<9` unchanged.
+
 ## [11.1.0] — 2026-06-26
 
 ### Added — #302 (FSD-004): accord live-quorum storage substrate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.1.0"
+version = "11.2.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -490,14 +490,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -755,10 +755,10 @@ tokio-stream = "0.1"
 # key). Placed AFTER every platform-independent dep — see the v0.9.0
 # bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
 # feature implies `postgres` which depends on `openssl`. On iOS there is
 # no system libssl; vendored build-from-source handles it (ARM64 has no
@@ -769,7 +769,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.2.0", version = "8", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
 # unconditionally pulls postgres-native-tls → native-tls → openssl-sys
 # regardless of which backend feature is active. On desktop builds the

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10325,6 +10325,119 @@ mod tests {
         );
     }
 
+    /// #304 — the DERIVED content-KEM model: CIRISServer derives one
+    /// content-KEM keypair per identity (verify v8.3.0), so every occurrence
+    /// presents the IDENTICAL enc pubkey. Persist must (a) ACCEPT the
+    /// duplicate pubkeys across occurrences, and (b) wrap the self DEK ONCE
+    /// per distinct pubkey — proven here by byte-identical grants for the two
+    /// shared-pubkey occurrences, vs a distinct grant for a different-pubkey
+    /// control.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn self_dek_wrap_once_for_derived_identity_pubkeys_304() {
+        use crate::federation::types::{self, identity_type};
+        use crate::federation::BlobStorage;
+
+        let (signer, _alias) = self_login_signer();
+        let steward_derived = signer.derived_key_id();
+        let engine = Engine::with_signer(signer, "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        self_login_seed_key(&engine, &steward_derived, identity_type::STEWARD).await;
+
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let identity_key = format!("user-{suffix}");
+        self_login_seed_key(&engine, &identity_key, identity_type::USER).await;
+        let mk_keys = || {
+            use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+            let (_xp, x_pub, _mp, ml_pub) =
+                crate::federation::identity_aggregate::mint_content_kem_keypair().expect("mint");
+            crate::federation::EncryptionPubkeys {
+                x25519_base64: B64.encode(x_pub),
+                ml_kem_768_base64: B64.encode(ml_pub),
+            }
+        };
+        // The DERIVED identity keypair — shared across occurrences A/B/C.
+        let derived = mk_keys();
+        // A distinct (non-derived) control keypair for occurrence D.
+        let control = mk_keys();
+
+        let seed_occ = |occ: String, keys: crate::federation::EncryptionPubkeys| {
+            let identity_key = identity_key.clone();
+            let engine = &engine;
+            async move {
+                self_login_seed_key(engine, &occ, identity_type::AGENT).await;
+                engine
+                    .federation_directory()
+                    .put_identity_occurrence(crate::federation::SignedIdentityOccurrence {
+                        identity_occurrence: types::IdentityOccurrence {
+                            identity_key_id: identity_key,
+                            occurrence_key_id: occ,
+                            device_class: types::device_class::SERVER.into(),
+                            hardware_attestation: None,
+                            asserted_at: chrono::Utc::now(),
+                            valid_until: None,
+                            encryption_pubkeys: Some(keys),
+                            persist_row_hash: String::new(),
+                        },
+                    })
+                    .await
+                    .expect("put_identity_occurrence");
+            }
+        };
+
+        let occ_a = format!("a-{suffix}");
+        seed_occ(occ_a.clone(), derived.clone()).await;
+
+        // Encrypt a self blob (grants occurrence A + self-retention).
+        let cascade = engine
+            .put_blob_encrypted_self_family("self", &identity_key, b"derived-model", None)
+            .await
+            .expect("encrypt self blob");
+        let sha = cascade.at_rest_sha256;
+
+        // Add B + C sharing the DERIVED pubkey, and D with the control pubkey.
+        let occ_b = format!("b-{suffix}");
+        let occ_c = format!("c-{suffix}");
+        let occ_d = format!("d-{suffix}");
+        seed_occ(occ_b.clone(), derived.clone()).await; // accepted despite duplicate pubkey
+        seed_occ(occ_c.clone(), derived.clone()).await;
+        seed_occ(occ_d.clone(), control.clone()).await;
+        let rekey = engine
+            .rekey_self_occurrence_add(
+                &identity_key,
+                &[occ_b.clone(), occ_c.clone(), occ_d.clone()],
+            )
+            .await
+            .expect("rekey");
+        assert!(rekey.excluded.is_empty(), "all keyed, none fail-secure");
+
+        let grant = |r: &str| {
+            let sq = sq.clone();
+            let r = r.to_owned();
+            async move {
+                sq.get_at_rest_grant(&sha, &r)
+                    .await
+                    .expect("grant")
+                    .expect("exists")
+            }
+        };
+        let (gb, gc, gd) = (
+            grant(&occ_b).await,
+            grant(&occ_c).await,
+            grant(&occ_d).await,
+        );
+        // Wrap-once: B and C share the derived pubkey → byte-identical wrap.
+        assert_eq!(
+            gb.1, gc.1,
+            "#304: derived-pubkey occurrences share one wrap"
+        );
+        // Control: D's distinct pubkey → a different wrap (dedup is by pubkey,
+        // not blanket).
+        assert_ne!(gb.1, gd.1, "distinct pubkey ⇒ distinct wrap");
+    }
+
     /// transport_destination is idempotent on the composite PK + a
     /// removed row is gone (drop+re-register reachability model).
     #[cfg(feature = "sqlite")]

--- a/src/federation/at_rest_cascade.rs
+++ b/src/federation/at_rest_cascade.rs
@@ -644,10 +644,31 @@ pub mod orchestrate {
             let dek =
                 unwrap_dek_for_persist(&content_master, &self_grant.1).map_err(map_at_rest_err)?;
 
+            // #304 — wrap-once-to-the-identity: CIRISServer 0.5.56+ DERIVES a
+            // user's content-KEM keypair (x25519 + ML-KEM-768) from the FedID
+            // Ed25519 seed (CIRISVerify#151 / verify v8.3.0), so every
+            // occurrence of one identity presents the IDENTICAL enc pubkey. The
+            // wrap is recipient-determined by those pubkeys, so encap ONCE per
+            // distinct pubkey pair and reuse the wrap for every occurrence that
+            // shares it — any holder of the shared (derived) private key opens
+            // it. This collapses N redundant ML-KEM-768 encaps to one per
+            // derived identity; the grant rows stay per-occurrence (the reader
+            // resolves by occurrence_key_id, unchanged). Non-derived (distinct)
+            // pubkeys are unaffected — one wrap each, as before.
+            let mut wrap_cache: std::collections::HashMap<(String, String), String> =
+                std::collections::HashMap::new();
             for i in needs {
                 let (occ_key_id, keys) = &keyed[i];
-                let wrapped = wrap_dek_v2(&keys.x25519_base64, &keys.ml_kem_768_base64, &dek)
-                    .map_err(map_at_rest_err)?;
+                let cache_key = (keys.x25519_base64.clone(), keys.ml_kem_768_base64.clone());
+                let wrapped = match wrap_cache.get(&cache_key) {
+                    Some(w) => w.clone(),
+                    None => {
+                        let w = wrap_dek_v2(&keys.x25519_base64, &keys.ml_kem_768_base64, &dek)
+                            .map_err(map_at_rest_err)?;
+                        wrap_cache.insert(cache_key, w.clone());
+                        w
+                    }
+                };
                 backend
                     .put_at_rest_grant(sha, occ_key_id, WRAP_ALGORITHM_V2, &wrapped, cohort_scope)
                     .await?;


### PR DESCRIPTION
Closes #304 + re-pins verify to v8.3.0 (the tag that ships the derivation #304 rides).

## Context
CIRISServer 0.5.56+ **derives** a user's content-encryption keypair (X25519 + ML-KEM-768) from the FedID Ed25519 seed (CIRISVerify#151 / verify **v8.3.0**). So every occurrence of one identity presents the **identical** enc pubkey.

## What landed
1. **The derived model is accepted** (it already was — now documented + regression-tested). `federation_identity_occurrences` has no UNIQUE/CHECK on the enc pubkeys, and `put_identity_occurrence` doesn't reject two occurrences of one identity sharing the same `pubkey_x25519`/`pubkey_ml_kem`. Duplicates admit — the downstream is unblocked.
2. **Wrap-once optimization** in `rekey_for_newcomers`: the cascade wrapped the DEK **per-occurrence**, so a derived-key identity with N occurrences ran the expensive ML-KEM-768 encap N times over one pubkey. It now **memoizes the wrap per distinct `(x25519, ml_kem)` pubkey pair** and reuses it for every occurrence sharing it (any holder of the shared derived private key opens it). N redundant encaps → one per derived identity. Grant rows stay per-occurrence (reader resolves by `occurrence_key_id`, **unchanged**); distinct pubkeys are unaffected.

## Validation
`self_dek_wrap_once_for_derived_identity_pubkeys_304`: two occurrences sharing a derived pubkey get **byte-identical** grants (wrap reused); a distinct-pubkey control gets a different wrap. fmt + full clippy (`-D warnings`) + no-default/server builds + 31 cascade/self-login tests green.

## Scope note (answering #304's design question)
The full "wrap once, stored once, a new occurrence is a *no-op* rekey" shape needs a **grant-keyed-by-identity** model + at-rest reader change. Deferred — per-occurrence grants with a deduped wrap is the low-risk win that keeps the reader untouched and delivers the encap savings now. Happy to do the grant-by-identity model as a follow-up if you want the storage/portability win too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ