### PR TITLE
#311: align CIRISCache key to the canonical cross-repo scheme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,18 +84,29 @@ jobs:
       # the link-time tss-esapi backend (#141); the TPM plugin is dlopen'd at
       # runtime and the keyring link-binds no libtss2 on any target.
       - uses: dtolnay/rust-toolchain@stable
-      # CIRISCache (CIRISPersist#285) — GHCR-backed cross-repo Rust cache,
-      # replacing Swatinem/rust-cache (unlimited GHCR storage, survives the
-      # tag-ref boundary, cross-repo-capable). Hardened continue-on-error so a
-      # cache miss/infra hiccup downgrades to a cold build, never failing the
-      # job; real test/lint/compile failures still fail as before. Explicit
-      # per-substrate key: every matrix leg runs on ubuntu-x86_64, so the
-      # default os-arch-rustc key would collide and the legs would clobber
-      # each other's cache.
+      # CIRISCache (CIRISPersist#311) — the CANONICAL cross-repo key
+      # (CIRISServer#99): ciris-substrate-v1-<PLAT>-release-rustc<RUSTC>-p<persist>-e<edge>-v<verify>,
+      # NO -<target> suffix (the suffix defeated CIRISServer's cross-repo
+      # restore). This host job is ubuntu-x86_64 ⇒ PLAT=linux-x86_64; persist
+      # e=none (no ciris-edge dep). The 6 substrate legs share this one
+      # per-platform key — they share the always-on ~/.cargo registry blob (the
+      # reliable cross-repo win); whole-dir target/ reuse is fingerprint-
+      # sensitive (feature flags differ per leg) and best-effort (#311 item 3),
+      # so only the `core` leg saves (below) to avoid 6-way save churn.
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #311)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          # `|| true` so a crate absent from Cargo.lock (persist has no
+          # ciris-edge) yields empty instead of grep's exit-1 aborting under
+          # `set -e -o pipefail`; ${X:-none} then fills the slot.
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          echo "CIRISCACHE_KEY=ciris-substrate-v1-linux-x86_64-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.substrate.name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
       # v2.0.1 — nextest, not cargo test: streams per-test PASS/FAIL/
       # SLOW lines so a hung test surfaces in the live log as "the
       # last RUN with no follow-up" instead of disappearing into a
@@ -181,14 +192,14 @@ jobs:
           source .venv/bin/activate
           pytest tests/python/ -v
 
-      # Save the warmed cache (main only; PRs restore but never save).
-      # Same explicit per-substrate key as the restore above so save/restore
-      # line up.
+      # Save the warmed cache (main only; PRs restore but never save). Only the
+      # `core` leg saves — all 6 legs share the one per-platform key, so saving
+      # from each would be a 6-way write of the same registry blob.
       - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && matrix.substrate.name == 'core'
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.substrate.name }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # NOTE: the prior `linux-aarch64-build` cross-compile job was removed
@@ -217,12 +228,19 @@ jobs:
       # `~/.cargo/bin/`. Disabling bin caching keeps the dtolnay-
       # installed cargo intact. Build cache (registry + target) is
       # unaffected. (v0.7.0/v0.7.1 main CI + v0.7.2 tag CI flakes.)
-      # CIRISCache (CIRISPersist#285) — GHCR-backed cross-repo Rust cache,
-      # replacing Swatinem/rust-cache. Single job → default key is fine.
-      # Hardened continue-on-error: a cache miss/infra hiccup downgrades to a
-      # cold build, never failing the job.
+      # CIRISCache (CIRISPersist#311) — canonical cross-repo key; this job runs
+      # on macos-14 (Apple silicon) ⇒ PLAT=macos-aarch64.
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #311)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          echo "CIRISCACHE_KEY=ciris-substrate-v1-macos-aarch64-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY }}
       - name: Repair toolchain if rustup-init shadow (cache-poison heal)
         # macOS runners can restore a `~/.cargo/bin/cargo` that IS the
         # rustup-init shim binary. The shim passes `cargo --version` through
@@ -256,6 +274,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
+          key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Mission category §4 + PLATFORM_ARCHITECTURE.md §3.1: iOS device +
@@ -304,14 +323,26 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      # CIRISCache (CIRISPersist#285) — replaces Swatinem/rust-cache. Explicit
-      # per-target key: both iOS legs run on macos-14, so the default
-      # os-arch-rustc key would collide; lock-hash busts on dependency
-      # changes. Hardened continue-on-error.
+      # CIRISCache (CIRISPersist#311) — canonical cross-repo key. The two iOS
+      # targets are distinct platform tokens, so no -<target> suffix is needed.
+      # iOS isn't in CIRISServer#99's <PLAT> table (no cross-repo sibling), so
+      # the fail-safe keeps the target triple as the token.
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #311)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          case "${{ matrix.target }}" in
+            aarch64-apple-ios)     PLAT="ios-aarch64" ;;
+            aarch64-apple-ios-sim) PLAT="ios-aarch64-sim" ;;
+            *) PLAT="${{ matrix.target }}" ;;
+          esac
+          echo "CIRISCACHE_KEY=ciris-substrate-v1-${PLAT}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
       - name: Repair toolchain if rustup-init shadow (cache-poison heal)
         # macOS runners can restore a `~/.cargo/bin/cargo` that IS the
         # rustup-init shim binary. The shim passes `cargo --version` through
@@ -408,13 +439,11 @@ jobs:
           path: dist/${{ matrix.dir }}/ciris_persist.abi3.so
 
       # Save the warmed cache (main only; PRs restore but never save).
-      # Same explicit per-target key as the restore above so save/restore
-      # line up.
       - uses: CIRISAI/CIRISCache/save@v1
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ci-perf — recombine the two parallel iOS target builds into the single
@@ -483,14 +512,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      # CIRISCache (CIRISPersist#285) — replaces Swatinem/rust-cache. Explicit
-      # per-ABI key: every Android leg runs on ubuntu-x86_64, so the default
-      # os-arch-rustc key would collide; lock-hash busts on dependency
-      # changes. Hardened continue-on-error.
+      # CIRISCache (CIRISPersist#311) — canonical cross-repo key; PLAT token is
+      # `android-<abi>` per CIRISServer#99's table (distinct per ABI, no
+      # -<target> suffix needed).
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #311)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          echo "CIRISCACHE_KEY=ciris-substrate-v1-android-${{ matrix.abi }}-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.abi }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
       - name: setup Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk
@@ -625,13 +660,11 @@ jobs:
           path: dist/${{ matrix.abi }}/
 
       # Save the warmed cache (main only; PRs restore but never save).
-      # Same explicit per-ABI key as the restore above so save/restore
-      # line up.
       - uses: CIRISAI/CIRISCache/save@v1
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
         with:
-          key: ciris-persist-build-${{ matrix.abi }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Downstream job: collect per-ABI artifacts into tarballs + wheels.
@@ -751,10 +784,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      # CIRISCache (CIRISPersist#285) — replaces Swatinem/rust-cache. Single
-      # job → default key is fine. Hardened continue-on-error.
+      # CIRISCache (CIRISPersist#311) — canonical cross-repo key; this job runs
+      # on ubuntu-latest ⇒ PLAT=linux-x86_64, the SAME key the linux-x86_64-test
+      # `core` leg saves. This job RESTORES it (registry-blob win) but does not
+      # save — `core` is the single linux-x86_64 saver, so the two don't race.
+      - name: Compute CIRISCache key (canonical, CIRISServer#99 / #311)
+        shell: bash
+        run: |
+          RUSTC=$(rustc -V | awk '{print $2}')
+          ver() { { grep -A1 "name = \"$1\"" Cargo.lock | grep -m1 '^version' | sed -E 's/.*"([^"]+)".*/\1/'; } || true; }
+          P=$(ver ciris-persist); E=$(ver ciris-edge); V=$(ver ciris-verify-core)
+          echo "CIRISCACHE_KEY=ciris-substrate-v1-linux-x86_64-release-rustc${RUSTC}-p${P:-none}-e${E:-none}-v${V:-none}" >> "$GITHUB_ENV"
       - uses: CIRISAI/CIRISCache/restore@v1
         continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY }}
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
       # v2.0 — clippy over the same widened feature set as the test
@@ -766,12 +810,9 @@ jobs:
           "postgres server pyo3 sqlite cirisaudit secrets cirisnode cirisgraph telemetry"
           -- -D warnings
 
-      # Save the warmed cache (main only; PRs restore but never save).
-      - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
-        continue-on-error: true
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # No save here — the linux-x86_64-test `core` leg is the single saver for
+      # the shared linux-x86_64 key (#311), so this restore-only job can't race
+      # it on GHCR.
 
   # Mission category §4 "Mission rejection": the clippy + fmt gate
   # plus a license-deny pass per CRATE_RECOMMENDATIONS §6.


### PR DESCRIPTION
Closes #311. CI-only — no version bump, no release.

CIRISServer#99 restores upstream substrate compiles via the canonical key `ciris-substrate-v1-<PLAT>-release-rustc<RUSTC>-p<persist>-e<edge>-v<verify>`. This repo used its own `ciris-persist-build-<matrix>-<lockhash>` namespace, so the downstream restore never hit it. Converts all **5 CIRISCache jobs** to the canonical scheme.

**Mirrors CIRISVerify (v7.5.1) which already did this** — including the two fixes the #99 snippet needed (flagged earlier): `|| true` so a Cargo.lock-absent crate yields empty instead of aborting under `set -e -o pipefail`, and an explicit `<PLAT>` `case` table instead of bash-3.2-unsafe `${,,}`.

| Job | PLAT token |
|---|---|
| `linux-x86_64-test`, `lint` | `linux-x86_64` |
| `darwin-aarch64-test` | `macos-aarch64` |
| `android-ndk` | `android-<abi>` |
| `ios-build` | `ios-aarch64[-sim]` (no #99 sibling → fail-safe) |

- **No `-<target>` suffix** (the suffix is exactly what defeated the cross-repo restore). For persist `e=none` (no `ciris-edge` dep).
- **Save-on-main confirmed** — every saver has `if: github.ref == refs/heads/main` + the top-level `permissions: packages: write`. The 6 linux-test legs share one per-platform key, so only the `core` leg saves (no 6-way churn) and `lint` is **restore-only** (`core` is the single `linux-x86_64` saver — they can't race on GHCR).
- **Caveat documented** (#311 item 3): whole-dir `target/` reuse across repos is fingerprint-sensitive (feature flags differ); the reliable cross-repo win is the `~/.cargo` registry/git layer — key alignment is the prerequisite either way.

Verified the key computes correctly on persist's Cargo.lock: `ciris-substrate-v1-linux-x86_64-release-rustc1.95.0-p11.2.0-enone-v8.3.0`. YAML validated. **First post-merge run is a one-time cold build** (key namespace change), then warm.

Happy to adjust the `<PLAT>` token table if CIRISServer wants ios/android spelled differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ