### PR TITLE
v11.3.0 — #307 (CC 3.4.11): refuse age_self_declared:level:* (self rung carries {band}, never {level})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.3.0] — 2026-06-27
+
+### Added — #307 (CC 3.4.11): refuse `age_self_declared:level:*` (self rung carries a `{band}`, never a `{level}`)
+
+Conformance gap closure on the CC 0.5.1 floor (`tests/test_350_age_assurance_reservation.py`,
+the lone `xfail(strict)`). The age-assurance reservation has two rungs:
+
+- **witness rung** — `age_assurance:level:adult` / `age_assurance:provider:adult:v1`,
+  emittable only by a key with `identity_type="witness"` (a registered
+  age-assurance provider). Already gated via `default_reserved_prefix_rules`
+  (`age_assurance:` → witness).
+- **self rung** — `age_self_declared:band:adult`, subject-signed.
+
+The gap: the self rung's discriminator is `{band}`, **never** `{level}` — the
+`{level}` token belongs to the witness rung. `age_self_declared:level:adult`
+was previously **admitted**; it is now **refused structurally**, independent of
+emitter (no `identity_type` rescues the shape — even a witness must use the
+`age_assurance:` prefix to carry a level). A subject self-asserting a `level`
+is claiming the witness rung's authority on its own signature.
+
+- New `DimensionAdmissionPolicy::check` rule (**Layer 1c**), placed after the
+  reserved-prefix emitter loop and before the morally-charged-stem scan: a `dim`
+  equal to `age_self_declared:level` or prefixed `age_self_declared:level:` is
+  rejected with new reason token `self_declared_level_reserved`
+  (`Error::DimensionRejected` / `DimensionRejectionReason::SelfDeclaredLevelReserved`).
+- The rule lives in the single shared policy that **all three backends**
+  (memory / sqlite / postgres) call at the dimension gate, so it fires
+  identically on every `emit_attestation_self` → put path — no PG/sqlite
+  asymmetry, no new wiring.
+
+No version re-pin (CIRISVerify stays **v8.3.0**).
+
 ## [11.2.0] — 2026-06-27
 
 ### Added — #304: wrap-once-to-the-identity for the self-DEK cascade (derived content-KEM)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.2.0"
+version = "11.3.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -217,6 +217,13 @@ pub enum DimensionRejectionReason {
     /// requires a `<namespace-prefix>:<scoped-leaf>` value;
     /// emptiness is malformed.
     EmptyOrMissingDimension,
+    /// CC 3.4.11 — the self-declared age rung carries a `{band}`
+    /// (`age_self_declared:band:*`), never a `{level}`. The `{level}`
+    /// token is reserved to the witness-attested `age_assurance:` rung,
+    /// so a `level` discriminator on the self-declared prefix is a
+    /// subject claiming the witness rung's authority on its own
+    /// signature. Refused structurally, independent of emitter.
+    SelfDeclaredLevelReserved,
 }
 
 impl DimensionRejectionReason {
@@ -227,6 +234,7 @@ impl DimensionRejectionReason {
             Self::MorallyChargedStem => "morally_charged_stem",
             Self::MissingVersionSegment => "missing_version_segment",
             Self::EmptyOrMissingDimension => "empty_or_missing_dimension",
+            Self::SelfDeclaredLevelReserved => "self_declared_level_reserved",
         }
     }
 }
@@ -493,6 +501,23 @@ impl DimensionAdmissionPolicy {
                 // Match satisfied — stop scanning further rules.
                 break;
             }
+        }
+
+        // Layer 1c — CC 3.4.11 token-structure rule for the self-declared
+        // age rung. The self rung carries a `{band}`
+        // (`age_self_declared:band:adult`), NEVER a `{level}`; the `{level}`
+        // discriminator is reserved to the witness-attested `age_assurance:`
+        // rung (`age_assurance:level:adult`). A subject self-asserting a
+        // `level` is claiming the witness rung's authority on its own
+        // signature, so the shape is refused structurally — independent of
+        // emitter (even a witness must use the `age_assurance:` prefix to
+        // carry a level). Mirrors the witness-rung positive gate in
+        // `default_reserved_prefix_rules` (`age_assurance:` → witness).
+        if dim == "age_self_declared:level" || dim.starts_with("age_self_declared:level:") {
+            return Err(Error::DimensionRejected {
+                dimension: dim.to_string(),
+                reason: DimensionRejectionReason::SelfDeclaredLevelReserved.as_str(),
+            });
         }
 
         // Layer 2a — the morally-charged-stem deny-list.
@@ -3633,6 +3658,45 @@ mod tests {
             attestation_type::SCORES,
             Some("age_assurance:thirteen_plus:v1"),
             identity_type::WITNESS,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn self_declared_age_rung_refuses_level_token() {
+        // CC 3.4.11 (CIRISPersist#307): the self-declared rung carries a
+        // `{band}`, never a `{level}`. `age_self_declared:level:*` is reserved
+        // to the witness `age_assurance:` rung and must be refused structurally
+        // — independent of emitter (no identity_type rescues the shape).
+        let p = default_policy();
+        for emitter in [
+            identity_type::AGENT,
+            identity_type::WITNESS,
+            identity_type::SUBSTRATE_PERSIST,
+        ] {
+            for dim in ["age_self_declared:level:adult", "age_self_declared:level"] {
+                let err = p
+                    .check(attestation_type::SCORES, Some(dim), emitter)
+                    .expect_err(&format!("{dim:?} must be refused for emitter {emitter:?}"));
+                match err {
+                    Error::DimensionRejected { reason, .. } => assert_eq!(
+                        reason,
+                        DimensionRejectionReason::SelfDeclaredLevelReserved.as_str(),
+                        "{dim:?} should refuse with self_declared_level_reserved",
+                    ),
+                    other => panic!("expected DimensionRejected, got {other:?}"),
+                }
+            }
+        }
+        // The `{band}` shape is NOT caught by the level rule — a versioned
+        // band self-assertion admits (subject-signed). (The bare
+        // `age_self_declared:band:adult` form the conformance suite uses is
+        // admitted on the production path; here it would trip the orthogonal
+        // version-segment rule, so the versioned form isolates the level gate.)
+        p.check(
+            attestation_type::SCORES,
+            Some("age_self_declared:band:adult:v1"),
+            identity_type::AGENT,
         )
         .unwrap();
     }


### PR DESCRIPTION
Closes #307. Conformance gap on the CC 0.5.1 floor (`tests/test_350_age_assurance_reservation.py`, the lone `xfail(strict)`).

## The contract
The age-assurance reservation has two rungs:
- **witness rung** — `age_assurance:level:adult` / `age_assurance:provider:adult:v1`, emittable only by `identity_type="witness"`. Already gated (`default_reserved_prefix_rules`: `age_assurance:` → witness).
- **self rung** — `age_self_declared:band:adult`, subject-signed.

The self rung's discriminator is `{band}`, **never** `{level}`. `age_self_declared:level:adult` was previously **admitted**; it now must be **refused** — the `{level}` token belongs to the witness rung, so a subject self-asserting a `level` is claiming the witness rung's authority on its own signature.

## Change
- New **Layer 1c** rule in `DimensionAdmissionPolicy::check`, after the reserved-prefix emitter loop and before the morally-charged-stem scan: `dim == "age_self_declared:level"` or `starts_with "age_self_declared:level:"` → `Error::DimensionRejected` with new reason `DimensionRejectionReason::SelfDeclaredLevelReserved` (`"self_declared_level_reserved"`). Refused **structurally** — independent of emitter (no `identity_type` rescues it; even a witness must use `age_assurance:` to carry a level).
- The rule lives in the **single shared policy** all three backends (memory/sqlite/postgres) call at the dimension gate → fires identically on every `emit_attestation_self` → put path. **No PG/sqlite asymmetry, no new wiring.**
- Unit test `self_declared_age_rung_refuses_level_token`: both shapes (`:level:adult`, `:level`) × three emitters (agent/witness/substrate) all refused with the new reason; versioned-band form still admits.

## Versioning
v11.2.0 → **v11.3.0** (minor — new admission gate + new `DimensionRejectionReason` variant). CIRISVerify stays **v8.3.0** (no re-pin). 43/43 admission tests green; no-backend build clean under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ
