### PR TITLE
v11.4.0 — #308 (CC 4.4.3.2.8): affiliations as 4th rostered cohort_scope + crypto_tier resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.4.0] — 2026-06-27
+
+### Added — #308 (CC 4.4.3.2.8): `affiliations` as the 4th rostered `cohort_scope` + a `crypto_tier` resolver on the PyO3 surface
+
+CC 0.5.1 §4.4.3.2.8 makes `affiliations` the **fourth** rostered `cohort_scope`
+tier (alongside `self` / `family` / `community`), sharing the community
+machinery and resolving to the **CommunityDek** crypto tier. Previously every
+affiliations cohort op was rejected at the boundary with
+`ValueError: unknown cohort "affiliations" (...)`. Two asks landed:
+
+**(a) `affiliations` admitted as a rostered cohort + membership lifecycle.**
+`Cohort::Affiliations` (wire token `"affiliations"`) joins the
+`#[non_exhaustive]` `Cohort` enum. It shares the `community` machinery
+**exactly** — the same `federation_communities` storage, the same
+`active_community_members` / `add_community_member` /
+`put_community_membership_revocation` lifecycle, and the same per-`(group,
+epoch)` **CommunityDek** cascade. Critically, a member **removal bumps the
+CommunityDek epoch** (forward secrecy, CC 4.4.3.2.2), inherited for free because
+affiliations revocation rides the community revocation table (which bumps the
+epoch transactionally at write time). Every cohort-routing dispatch arm in the
+`FederationDirectory` trait (`active_members` / `lookup_group` / `groups_of` /
+`add_member` / `revoke_member` / `group_prior_envelope`) and the three backends
+(memory / sqlite / postgres) routes `Affiliations` through the identical
+community path — no PG/sqlite/memory asymmetry. Supersede/versioning records the
+`affiliations` chain under its own `cohort.as_str()` discriminator (keeping it
+separable from `community` though they share the live row), with new
+`supersede_affiliations` / `supersede_affiliations_with_quorum` trait wrappers.
+The new `Cohort::shares_community_machinery()` predicate is the single source of
+truth the two tiers fold through.
+
+**(b) `crypto_tier` resolver exposed on the Engine/PyO3 surface.** The internal
+`cohort_scope::crypto_tier(...)` mapping already resolved
+`affiliations → CommunityDek`; this exposes it from Python via the new
+`EngineCell.cohort_scope_crypto_tier(cohort_scope, cohort_subkind=None) -> str`
+method, returning the lowercase tier name
+(`"invisible_encrypted"` / `"community_dek"` / `"plaintext"`). It accepts any
+`cohort_scope` token (negative-default: unknown → `"plaintext"`) and needs no
+database round-trip, so `affiliations → community_dek` is checkable from Python.
+
+The FFI error token now reads `expected one of: self | family | community |
+affiliations`.
+
+**Out of scope (deferred):** the `compartments[]` / per-compartment-DEK /
+per-member-exclusion / disclosure limb of CC 4.4.3.2.8 is a separate larger
+Rust-lane item and is NOT in #308.
+
+Rust unit tests added (memory = fast, mirrored in sqlite + postgres):
+`Cohort::from_token("affiliations")` now `Ok`; a full affiliations
+add → active-members → revoke lifecycle with the epoch bump on revoke, asserted
+to read the SAME roster as `community`; and a `crypto_tier`-resolver test
+proving `affiliations → CommunityDek` is reachable.
+
+No version re-pin (CIRISVerify stays **v8.3.0**).
+
 ## [11.3.0] — 2026-06-27
 
 ### Added — #307 (CC 3.4.11): refuse `age_self_declared:level:*` (self rung carries a `{band}`, never a `{level}`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.3.0"
+version = "11.4.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/cohort.rs
+++ b/src/federation/cohort.rs
@@ -17,27 +17,39 @@
 //! (pg / sqlite / memory) is inherited for free and no backend override is
 //! needed.
 //!
-//! ## Cohort coverage (CIRISServer #249 Q1/Q4)
-//! `affiliations` / `species` / `biosphere` / `federation` are audience scopes
-//! with **no roster table** today, so they are NOT cohorts here. Whether
-//! `affiliations` should become a first-class rostered group (a managed set of
-//! org affiliations mirroring family/community) is an open CEG/constitution
-//! shape question (CIRISServer #249 Q1). [`Cohort`] is therefore
-//! `#[non_exhaustive]`: a future decision to add `affiliations` extends the
-//! enum without a breaking change, and this whole surface covers it the moment
-//! the roster table exists.
+//! ## Cohort coverage (CIRISServer #249 Q1/Q4; CC 4.4.3.2.8 / #308)
+//! As of v11.4.0 (CC 4.4.3.2.8, CIRISPersist#308) `affiliations` is the
+//! **fourth** rostered group. The Q1 "open shape question" resolved in its
+//! favor: `affiliations` shares the `community` machinery EXACTLY — the same
+//! `federation_communities` storage + `*_community_*` lifecycle, and the same
+//! [`CommunityDek`](crate::federation::types::cohort_scope::CryptoTier::CommunityDek)
+//! crypto tier with epoch-bump-on-removal forward secrecy (CC 4.4.3.2.2). It is
+//! distinguished only by its visibility-gradient position on the wire
+//! (`cohort_scope: "affiliations"`). `species` / `biosphere` / `federation`
+//! remain audience scopes with **no roster table**, so they are NOT cohorts.
+//! [`Cohort`] stays `#[non_exhaustive]` so any further tier joins later without
+//! a breaking change.
+//!
+//! The compartments[] / per-compartment-DEK / per-member-exclusion limb of
+//! CC 4.4.3.2.8 is a separate larger Rust-lane item and is NOT in #308.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::types;
 
-/// One of the three rostered-group kinds. Serializes to the wire scope token
-/// (`"self"` / `"family"` / `"community"`) so the cohort dispatch is portable
-/// over FFI / JSON.
+/// One of the four rostered-group kinds. Serializes to the wire scope token
+/// (`"self"` / `"family"` / `"community"` / `"affiliations"`) so the cohort
+/// dispatch is portable over FFI / JSON.
 ///
-/// `#[non_exhaustive]` — see the module docs (CIRISServer #249 Q1: `affiliations`
-/// may join later without breaking callers).
+/// `#[non_exhaustive]` — see the module docs. As of v11.4.0 (CC 4.4.3.2.8,
+/// CIRISPersist#308) `affiliations` is the **fourth** rostered tier, sharing
+/// the `community` machinery exactly (same `federation_communities` storage,
+/// same per-`(group, epoch)` [`CommunityDek`] cascade with epoch-bump-on-
+/// removal forward secrecy). The enum stays `#[non_exhaustive]` so any further
+/// tier joins later without breaking callers.
+///
+/// [`CommunityDek`]: crate::federation::types::cohort_scope::CryptoTier::CommunityDek
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Cohort {
@@ -52,25 +64,50 @@ pub enum Cohort {
     /// A `community` (`federation_communities`).
     #[serde(rename = "community")]
     Community,
+    /// An `affiliations` group (CC 4.4.3.2.8, CIRISPersist#308) — the fourth
+    /// rostered tier. Shares the `community` machinery EXACTLY: the same
+    /// `federation_communities` rows / `*_community_*` membership lifecycle and
+    /// the same [`CommunityDek`] crypto tier (epoch-bump-on-removal forward
+    /// secrecy). It differs from `community` only in its visibility-gradient
+    /// position on the wire (`cohort_scope: "affiliations"`).
+    ///
+    /// [`CommunityDek`]: crate::federation::types::cohort_scope::CryptoTier::CommunityDek
+    #[serde(rename = "affiliations")]
+    Affiliations,
 }
 
 impl Cohort {
-    /// The wire scope token (`"self"` / `"family"` / `"community"`).
+    /// The wire scope token (`"self"` / `"family"` / `"community"` /
+    /// `"affiliations"`).
     pub fn as_str(&self) -> &'static str {
         match self {
             Cohort::SelfId => "self",
             Cohort::Family => "family",
             Cohort::Community => "community",
+            Cohort::Affiliations => "affiliations",
         }
     }
 
+    /// `true` iff this cohort shares the `community` rostered machinery — the
+    /// `federation_communities` storage + the [`CommunityDek`] cascade. Both
+    /// `community` and `affiliations` (CC 4.4.3.2.8) resolve `true`; `self` and
+    /// `family` resolve `false`. The single predicate every community-routing
+    /// dispatch arm consults, so the two tiers never fork.
+    ///
+    /// [`CommunityDek`]: crate::federation::types::cohort_scope::CryptoTier::CommunityDek
+    pub fn shares_community_machinery(&self) -> bool {
+        matches!(self, Cohort::Community | Cohort::Affiliations)
+    }
+
     /// Parse the wire scope token. `Err` (the offending token) for anything
-    /// that is not a rostered cohort (e.g. `"affiliations"` today — Q1).
+    /// that is not a rostered cohort (e.g. `"species"` / `"federation"` — those
+    /// are audience scopes with no roster table).
     pub fn from_token(s: &str) -> Result<Cohort, String> {
         match s {
             "self" => Ok(Cohort::SelfId),
             "family" => Ok(Cohort::Family),
             "community" => Ok(Cohort::Community),
+            "affiliations" => Ok(Cohort::Affiliations),
             other => Err(other.to_string()),
         }
     }
@@ -218,20 +255,35 @@ mod tests {
 
     #[test]
     fn cohort_token_roundtrips_and_rejects_non_rostered() {
-        for c in [Cohort::SelfId, Cohort::Family, Cohort::Community] {
+        for c in [
+            Cohort::SelfId,
+            Cohort::Family,
+            Cohort::Community,
+            Cohort::Affiliations,
+        ] {
             assert_eq!(Cohort::from_token(c.as_str()), Ok(c));
         }
         // `self` serializes to the wire token, not the Rust ident.
         assert_eq!(Cohort::SelfId.as_str(), "self");
-        // audience scopes with no roster are not cohorts (Q1).
-        assert_eq!(
-            Cohort::from_token("affiliations"),
-            Err("affiliations".to_string())
-        );
+        // CC 4.4.3.2.8 / #308: `affiliations` is now an admitted rostered
+        // cohort (no longer rejected at the boundary).
+        assert_eq!(Cohort::from_token("affiliations"), Ok(Cohort::Affiliations));
+        assert_eq!(Cohort::Affiliations.as_str(), "affiliations");
+        // audience scopes with no roster table are still not cohorts.
         assert_eq!(
             Cohort::from_token("federation"),
             Err("federation".to_string())
         );
+        assert_eq!(Cohort::from_token("species"), Err("species".to_string()));
+    }
+
+    #[test]
+    fn affiliations_shares_community_machinery() {
+        // The single predicate every community-routing dispatch arm consults.
+        assert!(Cohort::Community.shares_community_machinery());
+        assert!(Cohort::Affiliations.shares_community_machinery());
+        assert!(!Cohort::Family.shares_community_machinery());
+        assert!(!Cohort::SelfId.shares_community_machinery());
     }
 
     #[test]
@@ -241,7 +293,13 @@ mod tests {
             serde_json::to_string(&Cohort::Community).unwrap(),
             "\"community\""
         );
+        assert_eq!(
+            serde_json::to_string(&Cohort::Affiliations).unwrap(),
+            "\"affiliations\""
+        );
         let c: Cohort = serde_json::from_str("\"family\"").unwrap();
         assert_eq!(c, Cohort::Family);
+        let a: Cohort = serde_json::from_str("\"affiliations\"").unwrap();
+        assert_eq!(a, Cohort::Affiliations);
     }
 }

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -1161,7 +1161,8 @@ pub trait FederationDirectory: Send + Sync {
                 .into_iter()
                 .map(cohort::RosterMember::from)
                 .collect(),
-            cohort::Cohort::Community => self
+            // CC 4.4.3.2.8 / #308: `affiliations` shares the community roster.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => self
                 .active_community_members(group_key_id)
                 .await?
                 .into_iter()
@@ -1221,7 +1222,8 @@ pub trait FederationDirectory: Send + Sync {
                 .lookup_family(group_key_id)
                 .await?
                 .map(cohort::GroupRef::from),
-            cohort::Cohort::Community => self
+            // CC 4.4.3.2.8 / #308: `affiliations` resolves via the community row.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => self
                 .lookup_community(group_key_id)
                 .await?
                 .map(cohort::GroupRef::from),
@@ -1256,7 +1258,8 @@ pub trait FederationDirectory: Send + Sync {
                 .into_iter()
                 .map(cohort::GroupRef::from)
                 .collect(),
-            cohort::Cohort::Community => self
+            // CC 4.4.3.2.8 / #308: `affiliations` shares the community reverse lookup.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => self
                 .list_communities_for_member_active(member_key_id)
                 .await?
                 .into_iter()
@@ -1307,7 +1310,8 @@ pub trait FederationDirectory: Send + Sync {
                 .await?,
                 hard_case::kind::FAMILY_MEMBERSHIP_CHANGE,
             ),
-            cohort::Cohort::Community => (
+            // CC 4.4.3.2.8 / #308: `affiliations` admits via the community roster.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => (
                 self.add_community_member(
                     group_key_id,
                     types::CommunityMember {
@@ -1374,7 +1378,10 @@ pub trait FederationDirectory: Send + Sync {
         // path, which carries its own events). `None` ⇒ no membership event.
         let change_kind = match cohort {
             cohort::Cohort::Family => Some(hard_case::kind::FAMILY_MEMBERSHIP_CHANGE),
-            cohort::Cohort::Community => Some(hard_case::kind::COMMUNITY_MEMBERSHIP_CHANGE),
+            // CC 4.4.3.2.8 / #308: `affiliations` shares the community event kind.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => {
+                Some(hard_case::kind::COMMUNITY_MEMBERSHIP_CHANGE)
+            }
             cohort::Cohort::SelfId => None,
         };
         match cohort {
@@ -1392,7 +1399,10 @@ pub trait FederationDirectory: Send + Sync {
                 })
                 .await?;
             }
-            cohort::Cohort::Community => {
+            // CC 4.4.3.2.8 / #308: `affiliations` removal rides the community
+            // revocation table — which bumps the CommunityDek epoch at write
+            // time (forward secrecy, CC 4.4.3.2.2), inherited for free.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => {
                 self.put_community_membership_revocation(
                     types::SignedCommunityMembershipRevocation {
                         community_membership_revocation: types::CommunityMembershipRevocation {
@@ -1547,6 +1557,24 @@ pub trait FederationDirectory: Send + Sync {
         let snapshot = serde_json::to_value(&new.community)
             .map_err(|e| Error::Backend(format!("supersede_community snapshot serialize: {e}")))?;
         self.supersede_group_row(cohort::Cohort::Community, snapshot, authorization)
+            .await
+    }
+
+    /// CC 4.4.3.2.8 / #308 — supersede an `affiliations` group. Identical to
+    /// [`Self::supersede_community`] (affiliations share the
+    /// `federation_communities` storage + the `Community` row type) but records
+    /// the version under the `affiliations` discriminator so the version chain
+    /// stays separable per tier.
+    async fn supersede_affiliations(
+        &self,
+        new: types::SignedCommunity,
+        authorization: Option<serde_json::Value>,
+    ) -> Result<u32, Error> {
+        check_consensus_protocol_form(&new.community.consensus_protocol)?;
+        let snapshot = serde_json::to_value(&new.community).map_err(|e| {
+            Error::Backend(format!("supersede_affiliations snapshot serialize: {e}"))
+        })?;
+        self.supersede_group_row(cohort::Cohort::Affiliations, snapshot, authorization)
             .await
     }
 
@@ -1708,7 +1736,9 @@ pub trait FederationDirectory: Send + Sync {
                     "consensus_protocol_entrenched": f.consensus_protocol_entrenched,
                 }))
             }
-            cohort::Cohort::Community => {
+            // CC 4.4.3.2.8 / #308: `affiliations` derives its prior envelope
+            // from the shared community row.
+            cohort::Cohort::Community | cohort::Cohort::Affiliations => {
                 let c = self.lookup_community(group_key_id).await?.ok_or_else(|| {
                     Error::InvalidArgument(format!("unknown community group {group_key_id:?}"))
                 })?;
@@ -1833,6 +1863,42 @@ pub trait FederationDirectory: Send + Sync {
             "quorum_signatures": signatures,
         });
         self.supersede_community(new, Some(authorization)).await
+    }
+
+    /// CC 4.4.3.2.8 / #308 — quorum-gated `affiliations` supersede. Mirror of
+    /// [`Self::supersede_community_with_quorum`]; the quorum is verified against
+    /// the shared community row and the new version is recorded under the
+    /// `affiliations` discriminator via [`Self::supersede_affiliations`].
+    async fn supersede_affiliations_with_quorum(
+        &self,
+        new: types::SignedCommunity,
+        change_envelope: serde_json::Value,
+        signatures: Vec<ciris_verify_core::threshold::ThresholdSignature>,
+    ) -> Result<u32, Error> {
+        let members: std::collections::BTreeSet<&str> = new
+            .community
+            .members
+            .iter()
+            .map(|m| m.key_id.as_str())
+            .collect();
+        assert_change_envelope_matches(
+            &new.community.community_key_id,
+            &members,
+            &new.community.consensus_protocol,
+            &change_envelope,
+        )?;
+        self.verify_membership_quorum(
+            cohort::Cohort::Affiliations,
+            &new.community.community_key_id,
+            &change_envelope,
+            &signatures,
+        )
+        .await?;
+        let authorization = serde_json::json!({
+            "change_envelope": change_envelope,
+            "quorum_signatures": signatures,
+        });
+        self.supersede_affiliations(new, Some(authorization)).await
     }
 
     /// #249 Cut B — the INBOUND delegation walk: every key that holds a

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -15868,12 +15868,38 @@ impl PyEngine {
     // ── #249 Cut G1 ── uniform cohort FFI (CIRISServer #249 §1/§2/§6) ──
     //
     // One cohort-parameterized surface (`cohort` ∈ {"self","family",
-    // "community"}) over the rostered-group read+write methods, so the
-    // KMP/Python consumers write rostered-group ops once instead of
-    // branching family-vs-community-vs-self. Each composes the
+    // "community","affiliations"}) over the rostered-group read+write methods,
+    // so the KMP/Python consumers write rostered-group ops once instead of
+    // branching family-vs-community-vs-self-vs-affiliations. Each composes the
     // [`crate::federation::cohort`] default methods (backend parity
     // inherited). A hardware-hybrid engine needs no extra signer here —
     // these are admission/read, not emit.
+
+    /// CC 4.4.3.2.8 / #308 — resolve a `cohort_scope` wire token to its at-rest
+    /// crypto tier, exposing [`crate::federation::types::cohort_scope::crypto_tier`]
+    /// on the Python surface. Returns the lowercase tier name:
+    /// `"invisible_encrypted"` (`self`/`family`), `"community_dek"`
+    /// (`community`/`affiliations`, unless `cohort_subkind == "infrastructure"`),
+    /// or `"plaintext"` (Commons / infrastructure / any unrecognized scope).
+    ///
+    /// Accepts ANY `cohort_scope` token (not just the rostered cohorts) — the
+    /// resolver is a closed-set negative-default dispatch, so unknown tokens
+    /// return `"plaintext"`. This makes `affiliations → community_dek`
+    /// (CC 4.4.3.2.8) checkable from Python without a database round-trip.
+    #[pyo3(signature = (cohort_scope, cohort_subkind=None))]
+    fn cohort_scope_crypto_tier(
+        &self,
+        cohort_scope: &str,
+        cohort_subkind: Option<&str>,
+    ) -> PyResult<String> {
+        use crate::federation::types::cohort_scope::{crypto_tier, CryptoTier};
+        let tier = match crypto_tier(cohort_scope, cohort_subkind) {
+            CryptoTier::InvisibleEncrypted => "invisible_encrypted",
+            CryptoTier::CommunityDek => "community_dek",
+            CryptoTier::Plaintext => "plaintext",
+        };
+        Ok(tier.to_string())
+    }
 
     /// #249 Cut G1 (§1) — active roster of `group_key_id` in `cohort`. Returns
     /// a JSON array of [`crate::federation::cohort::RosterMember`].
@@ -16205,8 +16231,10 @@ impl PyEngine {
             }),
             _ => None,
         };
+        // CC 4.4.3.2.8 / #308: `affiliations` decodes as a community row (shared
+        // `SignedCommunity` shape + `federation_communities` storage).
         let community: Option<crate::federation::SignedCommunity> = match cohort {
-            Cohort::Community => Some(crate::federation::SignedCommunity {
+            Cohort::Community | Cohort::Affiliations => Some(crate::federation::SignedCommunity {
                 community: serde_json::from_str(new_group_json)
                     .map_err(|e| PyValueError::new_err(format!("supersede community JSON: {e}")))?,
             }),
@@ -16235,6 +16263,13 @@ impl PyEngine {
                                 }
                                 Cohort::Community => {
                                     b.supersede_community(
+                                        community.clone().unwrap(),
+                                        authorization.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::Affiliations => {
+                                    b.supersede_affiliations(
                                         community.clone().unwrap(),
                                         authorization.clone(),
                                     )
@@ -16473,8 +16508,9 @@ impl PyEngine {
             }),
             _ => None,
         };
+        // CC 4.4.3.2.8 / #308: `affiliations` decodes as a community row.
         let community: Option<crate::federation::SignedCommunity> = match cohort {
-            Cohort::Community => Some(crate::federation::SignedCommunity {
+            Cohort::Community | Cohort::Affiliations => Some(crate::federation::SignedCommunity {
                 community: serde_json::from_str(new_group_json)
                     .map_err(|e| PyValueError::new_err(format!("supersede community JSON: {e}")))?,
             }),
@@ -16504,6 +16540,14 @@ impl PyEngine {
                                 }
                                 Cohort::Community => {
                                     b.supersede_community_with_quorum(
+                                        community.clone().unwrap(),
+                                        change_envelope.clone(),
+                                        signatures.clone(),
+                                    )
+                                    .await
+                                }
+                                Cohort::Affiliations => {
+                                    b.supersede_affiliations_with_quorum(
                                         community.clone().unwrap(),
                                         change_envelope.clone(),
                                         signatures.clone(),
@@ -23296,12 +23340,13 @@ fn base64_encode(bytes: &[u8]) -> String {
     B64.encode(bytes)
 }
 
-/// #249 Cut G1 — parse a cohort wire token (`"self"`/`"family"`/`"community"`)
-/// for the uniform cohort FFI. `ValueError` for a non-rostered scope.
+/// #249 Cut G1 / CC 4.4.3.2.8 #308 — parse a cohort wire token
+/// (`"self"`/`"family"`/`"community"`/`"affiliations"`) for the uniform cohort
+/// FFI. `ValueError` for a non-rostered scope.
 fn cohort_from_token(cohort: &str) -> PyResult<crate::federation::cohort::Cohort> {
     crate::federation::cohort::Cohort::from_token(cohort).map_err(|bad| {
         PyValueError::new_err(format!(
-            "unknown cohort {bad:?} (expected one of: self | family | community)"
+            "unknown cohort {bad:?} (expected one of: self | family | community | affiliations)"
         ))
     })
 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1712,13 +1712,16 @@ impl crate::federation::FederationDirectory for MemoryBackend {
     ) -> Result<u32, crate::federation::Error> {
         use crate::federation::cohort::{Cohort, GroupVersion};
         use crate::federation::Error;
+        // CC 4.4.3.2.8 / #308: `affiliations` keys its version history under its
+        // own discriminator while sharing the `federation_communities` storage.
         let cohort_str = match cohort {
-            Cohort::Family => "family".to_string(),
-            Cohort::Community => "community".to_string(),
             Cohort::SelfId => {
                 return Err(Error::InvalidArgument(
                     "supersede: the `self` cohort is not versioned".to_string(),
                 ))
+            }
+            Cohort::Family | Cohort::Community | Cohort::Affiliations => {
+                cohort.as_str().to_string()
             }
         };
         let now = chrono::Utc::now();
@@ -1766,7 +1769,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
                     .insert((cohort_str, key), next);
                 Ok(next)
             }
-            Cohort::Community => {
+            Cohort::Community | Cohort::Affiliations => {
                 let mut new_comm: crate::federation::Community =
                     serde_json::from_value(new_snapshot).map_err(|e| {
                         Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
@@ -1825,11 +1828,8 @@ impl crate::federation::FederationDirectory for MemoryBackend {
                 "list_group_versions: the `self` cohort is not versioned".to_string(),
             ));
         }
-        let cohort_str = if cohort == Cohort::Family {
-            "family".to_string()
-        } else {
-            "community".to_string()
-        };
+        // CC 4.4.3.2.8 / #308: `affiliations` reads its own history chain.
+        let cohort_str = cohort.as_str().to_string();
         let state = self.state.lock().expect("memory backend lock");
         let mut out: Vec<GroupVersion> = state
             .federation_group_versions
@@ -1845,7 +1845,8 @@ impl crate::federation::FederationDirectory for MemoryBackend {
                 .federation_families
                 .get(group_key_id)
                 .map(|f| serde_json::to_value(f).unwrap_or(serde_json::Value::Null)),
-            Cohort::Community => state
+            // CC 4.4.3.2.8 / #308: `affiliations` reads the shared community row.
+            Cohort::Community | Cohort::Affiliations => state
                 .federation_communities
                 .get(group_key_id)
                 .map(|c| serde_json::to_value(c).unwrap_or(serde_json::Value::Null)),
@@ -7366,6 +7367,130 @@ mod tests {
             .await
             .expect("non-future revocation accepted");
         assert_eq!(backend.community_dek_epoch("ob-owner"), 1);
+    }
+
+    /// CC 4.4.3.2.8 / #308 — the `affiliations` cohort runs the FULL membership
+    /// lifecycle (add → active-members → revoke) through the SAME community
+    /// machinery as `community`, including the epoch bump (forward secrecy) on
+    /// removal. Asserted via the uniform [`FederationDirectory`] cohort surface.
+    #[tokio::test]
+    async fn affiliations_cohort_membership_lifecycle_mirrors_community() {
+        use crate::federation::cohort::{Cohort, RevokeSpec, RosterMember};
+        use crate::federation::FederationDirectory;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await; // ob-owner (user), ob-node, ob-agent
+                                      // A second user-role key to add to the roster.
+        let mut joiner = fix_key("ob-joiner", "owner", "ob-joiner");
+        joiner.identity_type = crate::federation::types::identity_type::USER.into();
+        backend
+            .put_public_key(SignedKeyRecord { record: joiner })
+            .await
+            .unwrap();
+        // The affiliations group is a community row (shared storage), founded
+        // by the user-role member ob-owner.
+        let group = "aff-grp";
+        put_community_with(&backend, group, vec![member("ob-owner")], None)
+            .await
+            .expect("affiliations group (community row) created");
+
+        // ── add via the affiliations cohort ────────────────────────────────
+        let added = backend
+            .add_member(
+                Cohort::Affiliations,
+                group,
+                RosterMember {
+                    key_id: "ob-joiner".into(),
+                    joined_at: chrono::Utc::now(),
+                    role: Some("member".into()),
+                },
+            )
+            .await
+            .expect("affiliations add_member");
+        assert!(added, "genuine add returns true");
+
+        // active_members(affiliations) reads the shared community roster.
+        let active: Vec<String> = backend
+            .active_members(Cohort::Affiliations, group)
+            .await
+            .expect("affiliations active_members")
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(active.contains(&"ob-owner".to_string()));
+        assert!(
+            active.contains(&"ob-joiner".to_string()),
+            "added member visible via the affiliations cohort"
+        );
+        // Identical to reading via the `community` cohort (shared machinery).
+        let active_via_community: Vec<String> = backend
+            .active_members(Cohort::Community, group)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert_eq!(
+            active, active_via_community,
+            "affiliations and community read the SAME roster"
+        );
+
+        // ── revoke via the affiliations cohort → epoch bump (forward secrecy) ─
+        assert_eq!(backend.community_dek_epoch(group), 0, "epoch starts 0");
+        backend
+            .revoke_member(
+                Cohort::Affiliations,
+                group,
+                "ob-joiner",
+                RevokeSpec {
+                    effective_at: chrono::Utc::now(),
+                    reason: Some("left".into()),
+                    witness_set: vec![],
+                },
+            )
+            .await
+            .expect("affiliations revoke_member");
+        assert_eq!(
+            backend.community_dek_epoch(group),
+            1,
+            "affiliations removal bumps the CommunityDek epoch (CC 4.4.3.2.2 forward secrecy)"
+        );
+        let active_after: Vec<String> = backend
+            .active_members(Cohort::Affiliations, group)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(
+            !active_after.contains(&"ob-joiner".to_string()),
+            "revoked member dropped from the active affiliations roster"
+        );
+    }
+
+    /// CC 4.4.3.2.8 / #308 — `affiliations` resolves to the `CommunityDek`
+    /// crypto tier (the same tier as `community`), and the negative-default
+    /// holds: `self`/`family` → InvisibleEncrypted, an unknown scope →
+    /// Plaintext, infrastructure-subkind → Plaintext.
+    #[test]
+    fn affiliations_resolves_to_community_dek_tier() {
+        use crate::federation::types::cohort_scope::{crypto_tier, CryptoTier, AFFILIATIONS};
+        assert_eq!(
+            crypto_tier(AFFILIATIONS, None),
+            CryptoTier::CommunityDek,
+            "affiliations → CommunityDek (CC 4.4.3.2.8)"
+        );
+        // Same tier as community (shared machinery).
+        assert_eq!(crypto_tier("community", None), CryptoTier::CommunityDek);
+        // Infrastructure carve-out → Plaintext even for affiliations.
+        assert_eq!(
+            crypto_tier(AFFILIATIONS, Some("infrastructure")),
+            CryptoTier::Plaintext
+        );
+        // self/family → InvisibleEncrypted; unknown → Plaintext (negative default).
+        assert_eq!(crypto_tier("self", None), CryptoTier::InvisibleEncrypted);
+        assert_eq!(crypto_tier("family", None), CryptoTier::InvisibleEncrypted);
+        assert_eq!(crypto_tier("federation", None), CryptoTier::Plaintext);
+        assert_eq!(crypto_tier("nonsense-scope", None), CryptoTier::Plaintext);
     }
 
     // ── v3.1.0 (CIRISPersist#117) — peer-mutation surface ──────────

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -3062,8 +3062,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     "supersede: the `self` cohort is not versioned".to_string(),
                 ))
             }
-            Cohort::Family | Cohort::Community => {}
+            // CC 4.4.3.2.8 / #308: `affiliations` supersedes via the community
+            // storage path below, recorded under the `affiliations` discriminator.
+            Cohort::Family | Cohort::Community | Cohort::Affiliations => {}
         }
+        // The version-history discriminator: `cohort.as_str()` keeps the
+        // `affiliations` chain separable from `community` even though they
+        // share the `federation_communities` live row.
+        let cohort_discriminator = cohort.as_str();
         let now = chrono::Utc::now();
         let mut client = self
             .get_client()
@@ -3143,7 +3149,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     .map_err(|e| Error::Backend(format!("commit: {e}")))?;
                 next
             }
-            Cohort::Community => {
+            Cohort::Community | Cohort::Affiliations => {
                 let mut new_comm: crate::federation::Community =
                     serde_json::from_value(new_snapshot).map_err(|e| {
                         Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
@@ -3179,7 +3185,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     "INSERT INTO cirislens.federation_group_versions \
                         (cohort, group_key_id, version, snapshot, change_authorization, \
                          superseded_at, persist_row_hash) \
-                     VALUES ('community', $1, $2, $3, $4, $5, $6)",
+                     VALUES ($7, $1, $2, $3, $4, $5, $6)",
                     &[
                         &new_comm.community_key_id,
                         &prior_version,
@@ -3187,6 +3193,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                         &authorization,
                         &now,
                         &prior_comm.persist_row_hash,
+                        &cohort_discriminator,
                     ],
                 )
                 .await
@@ -3234,11 +3241,10 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 "list_group_versions: the `self` cohort is not versioned".to_string(),
             ));
         }
-        let cohort_str = if cohort == Cohort::Family {
-            "family"
-        } else {
-            "community"
-        };
+        // CC 4.4.3.2.8 / #308: `affiliations` filters its own history chain
+        // (`cohort.as_str()`), distinct from `community` though they share the
+        // live `federation_communities` row read below.
+        let cohort_str = cohort.as_str();
         let client = self
             .get_client()
             .await
@@ -17976,6 +17982,121 @@ mod tests {
             .await
             .expect("non-future revocation accepted");
         assert_eq!(backend.community_dek_current_epoch(&comm).await.unwrap(), 1);
+    }
+
+    /// CC 4.4.3.2.8 / #308 (PG parity): the `affiliations` cohort runs the full
+    /// membership lifecycle (add → active-members → revoke + epoch bump) through
+    /// the SAME community machinery on the Postgres backend.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn affiliations_cohort_membership_lifecycle_pg() {
+        use crate::federation::cohort::{Cohort, RevokeSpec, RosterMember};
+        use crate::federation::{BlobStorage, FederationDirectory};
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let now = chrono::Utc::now();
+        let suffix = uuid_like();
+        let coop = format!("aff-coop-{suffix}");
+        let alice = format!("aff-alice-{suffix}");
+        let carol = format!("aff-carol-{suffix}");
+        // Community key (infra-class) + two user-role human members.
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: fix_section_i_key(&coop, "acme", now, true),
+            })
+            .await
+            .unwrap();
+        for kid in [&alice, &carol] {
+            let mut k = fix_section_i_key(kid, "acme", now, true);
+            k.identity_type = crate::federation::types::identity_type::USER.into();
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord { record: k })
+                .await
+                .unwrap();
+        }
+        backend
+            .put_community(crate::federation::SignedCommunity {
+                community: crate::federation::Community {
+                    community_key_id: coop.clone(),
+                    community_name: "Affiliations Co-op".into(),
+                    members: vec![crate::federation::CommunityMember {
+                        key_id: alice.clone(),
+                        joined_at: now,
+                        role: None,
+                    }],
+                    founded_at: now,
+                    consensus_protocol: "majority".into(),
+                    policy_blob: Some(serde_json::json!({ "cohort_scope": "affiliations" })),
+                    persist_row_hash: String::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // add via the affiliations cohort.
+        let added = backend
+            .add_member(
+                Cohort::Affiliations,
+                &coop,
+                RosterMember {
+                    key_id: carol.clone(),
+                    joined_at: now,
+                    role: Some("member".into()),
+                },
+            )
+            .await
+            .expect("affiliations add_member");
+        assert!(added);
+
+        let active: Vec<String> = backend
+            .active_members(Cohort::Affiliations, &coop)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(active.contains(&carol));
+        // Shared roster: identical via the `community` cohort.
+        let via_community: Vec<String> = backend
+            .active_members(Cohort::Community, &coop)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert_eq!(active, via_community);
+
+        assert_eq!(backend.community_dek_current_epoch(&coop).await.unwrap(), 0);
+        backend
+            .revoke_member(
+                Cohort::Affiliations,
+                &coop,
+                &carol,
+                RevokeSpec {
+                    effective_at: chrono::Utc::now(),
+                    reason: Some("left".into()),
+                    witness_set: vec![],
+                },
+            )
+            .await
+            .expect("affiliations revoke_member");
+        assert_eq!(
+            backend.community_dek_current_epoch(&coop).await.unwrap(),
+            1,
+            "affiliations removal bumps the CommunityDek epoch (forward secrecy)"
+        );
+        let active_after: Vec<String> = backend
+            .active_members(Cohort::Affiliations, &coop)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(!active_after.contains(&carol));
     }
 
     /// SecReview F5 (PG parity): INSERT + hard_case + epoch-bump are ONE

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2701,9 +2701,10 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // Map a "group does not exist" sentinel back to a typed error.
         let not_found = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let nf = not_found.clone();
+        // CC 4.4.3.2.8 / #308: `affiliations` records its version history under
+        // its own `cohort.as_str()` discriminator while sharing the
+        // `federation_communities` storage path below.
         let cohort_str = match cohort {
-            Cohort::Family => "family",
-            Cohort::Community => "community",
             Cohort::SelfId => {
                 return Err(Error::InvalidArgument(
                     "supersede: the `self` cohort is not versioned (manage occurrences via \
@@ -2711,6 +2712,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         .to_string(),
                 ))
             }
+            Cohort::Family | Cohort::Community | Cohort::Affiliations => cohort.as_str(),
         };
 
         let new_version = match cohort {
@@ -2781,7 +2783,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     Ok(next)
                 })()
             }
-            Cohort::Community => {
+            Cohort::Community | Cohort::Affiliations => {
                 let mut new_comm: crate::federation::Community =
                     serde_json::from_value(new_snapshot).map_err(|e| {
                         Error::InvalidArgument(format!("supersede community snapshot decode: {e}"))
@@ -2822,7 +2824,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         "INSERT INTO federation_group_versions \
                             (cohort, group_key_id, version, snapshot, change_authorization, \
                              superseded_at, persist_row_hash) \
-                         VALUES ('community', ?1, ?2, ?3, ?4, ?5, ?6)",
+                         VALUES (?7, ?1, ?2, ?3, ?4, ?5, ?6)",
                         rusqlite::params![
                             new_comm.community_key_id,
                             prior_version,
@@ -2830,6 +2832,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                             auth_json,
                             now,
                             prior_comm.persist_row_hash,
+                            cohort_str,
                         ],
                     )?;
                     let next = prior_version + 1;
@@ -2881,11 +2884,9 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                 "list_group_versions: the `self` cohort is not versioned".to_string(),
             ));
         }
-        let cohort_str = if cohort == Cohort::Family {
-            "family"
-        } else {
-            "community"
-        };
+        // CC 4.4.3.2.8 / #308: `affiliations` reads its own history chain
+        // (`cohort.as_str()`) distinct from `community`.
+        let cohort_str = cohort.as_str();
         let conn = self.conn.clone();
         let key = group_key_id.to_owned();
         let cs = cohort_str.to_owned();
@@ -17833,6 +17834,86 @@ mod tests {
             backend.community_dek_current_epoch("comm").await.unwrap(),
             1
         );
+    }
+
+    /// CC 4.4.3.2.8 / #308 — the `affiliations` cohort runs the full membership
+    /// lifecycle (add → active-members → revoke + epoch bump) through the SAME
+    /// community machinery on the SQLite backend (pg/sqlite/memory parity).
+    #[tokio::test]
+    async fn affiliations_cohort_membership_lifecycle_sqlite() {
+        use crate::federation::cohort::{Cohort, RevokeSpec, RosterMember};
+        use crate::federation::{BlobStorage, FederationDirectory};
+        let backend = community_fixture(&[("alice", "alice-occ", true)], None).await;
+        // Register a fresh PRIMITIVE key to admit via the affiliations cohort.
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("carol", "carol", "carol"),
+            })
+            .await
+            .unwrap();
+
+        let added = backend
+            .add_member(
+                Cohort::Affiliations,
+                "comm",
+                RosterMember {
+                    key_id: "carol".into(),
+                    joined_at: chrono::Utc::now(),
+                    role: Some("member".into()),
+                },
+            )
+            .await
+            .expect("affiliations add_member");
+        assert!(added);
+
+        let active: Vec<String> = backend
+            .active_members(Cohort::Affiliations, "comm")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(active.contains(&"carol".to_string()));
+        // Shared roster: reading via `community` is identical.
+        let via_community: Vec<String> = backend
+            .active_members(Cohort::Community, "comm")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert_eq!(active, via_community);
+
+        assert_eq!(
+            backend.community_dek_current_epoch("comm").await.unwrap(),
+            0
+        );
+        backend
+            .revoke_member(
+                Cohort::Affiliations,
+                "comm",
+                "carol",
+                RevokeSpec {
+                    effective_at: chrono::Utc::now(),
+                    reason: Some("left".into()),
+                    witness_set: vec![],
+                },
+            )
+            .await
+            .expect("affiliations revoke_member");
+        assert_eq!(
+            backend.community_dek_current_epoch("comm").await.unwrap(),
+            1,
+            "affiliations removal bumps the CommunityDek epoch (forward secrecy)"
+        );
+        let active_after: Vec<String> = backend
+            .active_members(Cohort::Affiliations, "comm")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|m| m.key_id)
+            .collect();
+        assert!(!active_after.contains(&"carol".to_string()));
     }
 
     /// #249 Cut A — the JSON-shape contract the FFI active-variant


### PR DESCRIPTION
## #308 (CC 4.4.3.2.8) — `affiliations` as the 4th rostered `cohort_scope` + a `crypto_tier` resolver

CC 0.5.1 §4.4.3.2.8 makes `affiliations` the **fourth** rostered `cohort_scope`
tier (alongside `self` / `family` / `community`), sharing the community
machinery and resolving to the **CommunityDek** crypto tier. Previously every
affiliations cohort op was rejected at the boundary with
`ValueError: unknown cohort "affiliations" (...)`.

### (a) `affiliations` admitted as a rostered cohort + membership lifecycle
- `Cohort::Affiliations` (wire token `"affiliations"`) joins the
  `#[non_exhaustive]` `Cohort` enum.
- It shares the `community` machinery **exactly** — same `federation_communities`
  storage, same `active_community_members` / `add_community_member` /
  `put_community_membership_revocation` lifecycle, same per-`(group, epoch)`
  **CommunityDek** cascade.
- **Forward secrecy (CC 4.4.3.2.2):** a member removal bumps the CommunityDek
  epoch, inherited for free because affiliations revocation rides the community
  revocation table (which bumps the epoch transactionally at write time).
- Every `FederationDirectory` cohort dispatch arm (`active_members` /
  `lookup_group` / `groups_of` / `add_member` / `revoke_member` /
  `group_prior_envelope`) and all three backends (memory / sqlite / postgres)
  route `Affiliations` through the identical community path — **no
  PG/sqlite/memory asymmetry**.
- Supersede/versioning records the `affiliations` chain under its own
  `cohort.as_str()` discriminator (separable from `community` though they share
  the live row), via new `supersede_affiliations` /
  `supersede_affiliations_with_quorum` wrappers.
- New `Cohort::shares_community_machinery()` is the single fold predicate the two
  tiers share.

### (b) `crypto_tier` resolver exposed on the PyO3 surface
New `EngineCell.cohort_scope_crypto_tier(cohort_scope, cohort_subkind=None) -> str`
exposes the existing internal `cohort_scope::crypto_tier` mapping. Returns the
lowercase tier name (`"invisible_encrypted"` / `"community_dek"` / `"plaintext"`),
negative-default (unknown → `"plaintext"`), no DB round-trip — so
`affiliations → community_dek` is checkable from Python.

### Out of scope (deferred)
The `compartments[]` / per-compartment-DEK / per-member-exclusion / disclosure
limb of CC 4.4.3.2.8 is a separate larger Rust-lane item and is NOT in #308.

### Tests
Rust unit tests (memory = fast, mirrored in sqlite + postgres):
`from_token("affiliations")` now `Ok`; a full affiliations
add → active-members → revoke lifecycle with the epoch bump on revoke, asserted
to read the SAME roster as `community`; and a `crypto_tier`-resolver test
proving `affiliations → CommunityDek`.

### Verification
- `cargo test --lib --no-default-features --features "server sqlite"` — **1017 + 5 green**.
- `cargo clippy --lib --tests` clean across `server`, `server sqlite postgres`, and `pyo3 sqlite`.
- `RUSTFLAGS="-D warnings" cargo build --no-default-features --features server` clean (no-backend dead-code guard).

CIRISVerify stays **v8.3.0** (no re-pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ
