### PR TITLE
v11.5.0 — #307 gate-fix + #306 (CC 3.2): I1 age band + user-target steward-binding gate + minor liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,80 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.5.0] — 2026-06-27
+
+### Fixed — #307 (CC 3.4.11): `age_self_declared:level:*` refusal was a no-op on the real emit path (moved to the attestation_type gate)
+
+v11.3.0 added the `age_self_declared:level:*` refusal but placed it ONLY in
+`DimensionAdmissionPolicy::check`, which gates the `scores` envelope
+**`dimension`** field. Age tokens, however, travel as the **`attestation_type`**
+string (e.g. `attestation_type = "age_self_declared:level:adult"` with an empty
+envelope), and `DimensionAdmissionPolicy::check` fast-exits for any
+`attestation_type != scores` — so the v11.3.0 rule never fired on the real
+`emit_attestation_self` → put path. The rule is now ALSO placed in
+`check_reserved_prefix_admission` (the `attestation_type`-namespace gate, where
+the witness `age_assurance:` reservation already lives), near the top after the
+`capacity:` self-emission check. A row whose `attestation_type` equals
+`age_self_declared:level` or is prefixed `age_self_declared:level:` is rejected
+structurally (independent of emitter) with `Error::DimensionRejected` /
+`DimensionRejectionReason::SelfDeclaredLevelReserved`. The dimension-side rule is
+kept too (defense-in-depth for the scores+dimension shape). Backend-symmetric
+(memory / sqlite / postgres — the gate is shared). No re-pin.
+
+### Added — #306 (CC 3.2): I1 age band + user-target steward-binding gate + minor liveness
+
+Three closely-coupled CC 3.2 / CC 3.3.12 / CC 1.15.6 substrate additions
+(downstream conformance signals: `tests/test_360_steward_binding_admission.py`,
+`tests/test_361_minor_stewardship_liveness.py`).
+
+- **I1 age band** (new `src/federation/age.rs`). `age_band(directory, k) ->
+  AgeBand { Minor | Adult | Unknown }` resolves a key's verified age from its
+  incoming age attestations. **Witness `age_assurance:*` OUTRANKS self-declared
+  `age_self_declared:*`**; a self-declared **adult is ignored** (the one-way
+  ratchet — a subject may self-declare MINOR to lower its own access, never
+  self-graduate to adult). The most-recent live witness band wins outright;
+  else a live self-declared minor → `Minor`; else `Unknown`. Liveness here is
+  `expires_at`-only (richer supersede/withdraw liveness deferred to #309).
+  **Presumption of sovereignty** (CC 1.15.6): a key with no usable age proof
+  resolves to `Unknown`, which the steward-binding axis treats as NON-minor
+  (un-stewardable). The three-valued band is exposed verbatim so #309 can layer
+  a content-protective `unknown → minor` resolution on the CONTENT axis without
+  changing this primitive.
+
+- **CC 3.2 user-target steward-binding gate**
+  (`check_user_target_steward_binding_admission`, wired into all three backends'
+  `put_attestation` immediately after `check_node_agency_admission`). A
+  `delegates_to` whose target resolves to a `user`-role identity is admissible
+  ONLY as **minor-guardianship**: the target must be a PROVEN minor AND the
+  granter a PROVEN adult `user`. Every other user-target binding is refused with
+  the new `Error::UserTargetStewardBindingForbidden` (kind
+  `federation_user_target_steward_binding_forbidden`): an adult target →
+  `target_is_self_sovereign` (un-stewardable, CC 1.15.6); an Unknown-age target
+  → `target_age_unverified`; an unresolved granter → `granter_unresolved`; a
+  non-user / non-adult granter → `granter_not_adult_user`. Node/agent targets
+  are untouched (still governed by `check_node_agency_admission` only).
+
+- **Minor-stewardship liveness fail-secure** (`is_steward_bound`,
+  `steward_bindings_of`, and `steward_binding_chain` for invariant parity). The
+  bug: a `user`-role key self-anchored via clause (1)/(2), so a steward-less
+  minor could not be detected. Fix: clauses (1)/(2) confer steward-binding only
+  when `age_band(k) != Minor`. A PROVEN minor does NOT self-anchor — it must
+  rely on a LIVE adult-steward `delegates_to` (clause 3), so when that edge is
+  withdrawn `is_steward_bound(minor)` flips to **false** (fail-secure, identical
+  posture to a steward-less node/agent). An adult/Unknown user still
+  self-anchors (sovereign). **Node/agent keys are never `user`-role, so clauses
+  (1)/(2) never fired for them — the node/agent path and the
+  `UnstewardedCommunityMember` gate that consumes `is_steward_bound` behave
+  exactly as before** (control test preserved).
+
+- **FFI**: new `Engine.age_band_json(key_id) -> "minor" | "adult" | "unknown"`
+  (modeled on `is_steward_bound_json`), plus a crate-level `Engine::age_band`
+  wrapper.
+
+No version re-pin (CIRISVerify stays **v8.3.0**). The CIRISConformance
+`test_350` / `test_360` / `test_361` updates (the `xfail(strict)` flips) are a
+downstream follow-up owned by the conformance maintainer.
+
 ## [11.4.0] — 2026-06-27
 
 ### Added — #308 (CC 4.4.3.2.8): `affiliations` as the 4th rostered `cohort_scope` + a `crypto_tier` resolver on the PyO3 surface

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.4.0"
+version = "11.5.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3371,6 +3371,20 @@ impl Engine {
         }
     }
 
+    /// v11.5.0 (CIRISPersist#306, CC 3.3.12 / CC 1.15.6) — the **I1 age
+    /// band** of `key_id`, resolved from its incoming age attestations
+    /// (witness `age_assurance:*` OUTRANKS self-declared `age_self_declared:*`;
+    /// a self-declared adult is ignored — the one-way ratchet). A key with no
+    /// usable age proof resolves to [`crate::federation::age::AgeBand::Unknown`]
+    /// (presumption of sovereignty). See [`crate::federation::age::age_band`].
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn age_band(
+        &self,
+        key_id: &str,
+    ) -> Result<crate::federation::age::AgeBand, crate::federation::Error> {
+        crate::federation::age::age_band(&*self.federation_directory(), key_id).await
+    }
+
     // ── #249 Cut B ── CEG-native graph DX enumerators + community-roster
     //    grow, surfaced as Engine convenience wrappers over the
     //    `federation_directory()` reader + the admission free functions.

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -2134,18 +2134,29 @@ pub async fn is_steward_bound(
     directory: &dyn super::FederationDirectory,
     k: &str,
 ) -> Result<bool, Error> {
+    // v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — minor-stewardship
+    // liveness fix. A PROVEN minor user does NOT self-anchor via clauses
+    // (1)/(2): a minor MUST rely on a LIVE adult-steward edge (clause 3), so
+    // when that edge is withdrawn `is_steward_bound(minor)` fails secure
+    // (false). An adult/unknown user (self-sovereign — its own steward) still
+    // self-anchors. Node/agent keys are never `user`-role, so (1)/(2) never
+    // fired for them regardless and this gate cannot change their result.
+    let k_band = super::age::age_band(directory, k).await?;
+    let k_self_anchors = k_band != super::age::AgeBand::Minor;
     // (1) k's own identity_type set contains `user`.
-    if let Some(rec) = directory.lookup_public_key(k).await? {
-        if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
-            return Ok(true);
-        }
-    }
-    // (2) k is an occurrence of a human identity — resolve the identity key
-    //     and check ITS identity_type set for `user`.
-    if let Some(occ) = directory.lookup_identity_for_occurrence(k).await? {
-        if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
-            if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
+    if k_self_anchors {
+        if let Some(rec) = directory.lookup_public_key(k).await? {
+            if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
                 return Ok(true);
+            }
+        }
+        // (2) k is an occurrence of a human identity — resolve the identity
+        //     key and check ITS identity_type set for `user`.
+        if let Some(occ) = directory.lookup_identity_for_occurrence(k).await? {
+            if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
+                if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
+                    return Ok(true);
+                }
             }
         }
     }
@@ -2215,17 +2226,24 @@ pub async fn steward_bindings_of(
     k: &str,
 ) -> Result<Vec<String>, Error> {
     let mut out: std::collections::HashSet<String> = std::collections::HashSet::new();
-    // (1) k's own key is user-role.
-    if let Some(rec) = directory.lookup_public_key(k).await? {
-        if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
-            out.insert(k.to_owned());
+    // v11.5.0 (CIRISPersist#306) — mirror `is_steward_bound`'s minor gate so
+    // the invariant `is_steward_bound(k) ⟺ !steward_bindings_of(k).is_empty()`
+    // holds: a PROVEN minor user does NOT self-anchor (clauses 1/2 are
+    // suppressed); it must be carried by a live adult-steward edge (clause 3).
+    let k_self_anchors = super::age::age_band(directory, k).await? != super::age::AgeBand::Minor;
+    if k_self_anchors {
+        // (1) k's own key is user-role.
+        if let Some(rec) = directory.lookup_public_key(k).await? {
+            if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
+                out.insert(k.to_owned());
+            }
         }
-    }
-    // (2) k is an occurrence of a user-role identity.
-    if let Some(occ) = directory.lookup_identity_for_occurrence(k).await? {
-        if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
-            if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
-                out.insert(occ.identity_key_id);
+        // (2) k is an occurrence of a user-role identity.
+        if let Some(occ) = directory.lookup_identity_for_occurrence(k).await? {
+            if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
+                if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
+                    out.insert(occ.identity_key_id);
+                }
             }
         }
     }
@@ -2359,17 +2377,25 @@ pub async fn steward_binding_chain(
     directory: &dyn super::FederationDirectory,
     key_id: &str,
 ) -> Result<Vec<String>, Error> {
-    // (1) k's own key is user-role — k is the anchor.
-    if let Some(rec) = directory.lookup_public_key(key_id).await? {
-        if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
-            return Ok(vec![key_id.to_owned()]);
+    // v11.5.0 (CIRISPersist#306) — mirror `is_steward_bound`'s minor gate so
+    // `!steward_binding_chain(k).is_empty() ⟺ is_steward_bound(k)` holds: a
+    // PROVEN minor user does NOT self-anchor (clauses 1/2 suppressed); its
+    // chain must root in a live adult-steward edge (clause 3).
+    let k_self_anchors =
+        super::age::age_band(directory, key_id).await? != super::age::AgeBand::Minor;
+    if k_self_anchors {
+        // (1) k's own key is user-role — k is the anchor.
+        if let Some(rec) = directory.lookup_public_key(key_id).await? {
+            if identity_type::set_contains(&rec.identity_type, identity_type::USER) {
+                return Ok(vec![key_id.to_owned()]);
+            }
         }
-    }
-    // (2) k is an occurrence of a user-role identity — identity → k.
-    if let Some(occ) = directory.lookup_identity_for_occurrence(key_id).await? {
-        if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
-            if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
-                return Ok(vec![occ.identity_key_id, key_id.to_owned()]);
+        // (2) k is an occurrence of a user-role identity — identity → k.
+        if let Some(occ) = directory.lookup_identity_for_occurrence(key_id).await? {
+            if let Some(id_rec) = directory.lookup_public_key(&occ.identity_key_id).await? {
+                if identity_type::set_contains(&id_rec.identity_type, identity_type::USER) {
+                    return Ok(vec![occ.identity_key_id, key_id.to_owned()]);
+                }
             }
         }
     }
@@ -3038,6 +3064,101 @@ pub async fn check_node_agency_admission(
     })
 }
 
+/// v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — the **user-target
+/// steward-binding gate**: the companion to [`check_node_agency_admission`]
+/// for `delegates_to` rows whose TARGET resolves to a `user`-role identity.
+///
+/// The node/agency gate constrains node-targets; user-targets ("stewarding a
+/// person") were otherwise unguarded. CC 3.2 narrows the admissible
+/// user-target set to exactly **minor-guardianship**:
+///
+/// ```text
+/// admit_user_steward_binding(delegates_to S -> T):
+///   require  age_band(T) == minor                # ward is a proven minor
+///   require  user ∈ S.identity_type              # steward is a user
+///   require  age_band(S) == adult                # steward is a proven adult
+///   require  S == delegates_to.attesting_key_id  # steward signed it
+///   otherwise REJECT
+/// ```
+///
+/// A no-op (`Ok(())`) for any row that is NOT a
+/// [`attestation_type::DELEGATES_TO`], for an unresolved target (FK-rejected
+/// downstream), or for a target that is NOT a `user`-role identity
+/// (node/agent targets are governed by [`check_node_agency_admission`]). For
+/// a user target:
+///
+/// - target age band `!= Minor` ⇒ REJECT (`target_is_self_sovereign` when
+///   Adult — an adult is un-stewardable, CC 1.15.6; `target_age_unverified`
+///   when Unknown — the presumption of sovereignty: no stewardship over
+///   someone not PROVEN a minor);
+/// - target is a proven Minor but the granter does not resolve ⇒ REJECT
+///   (`granter_unresolved`);
+/// - granter is not a `user` OR not a proven adult ⇒ REJECT
+///   (`granter_not_adult_user` — a minor cannot be a guardian, a non-user
+///   cannot be a guardian);
+/// - else ADMIT (the legal minor-guardianship binding). `S ==
+///   attesting_key_id` is structural on the emit path, so no separate signer
+///   check is needed.
+///
+/// Verify-before-mutation (AV-9): wired into every backend's
+/// `put_attestation` immediately AFTER [`check_node_agency_admission`], so a
+/// rejected emission leaves no trace. Backend-agnostic — resolution uses the
+/// trait's own `lookup_public_key` + [`super::age::age_band`].
+pub async fn check_user_target_steward_binding_admission(
+    directory: &dyn super::FederationDirectory,
+    row: &super::Attestation,
+) -> Result<(), Error> {
+    use super::age::{age_band, AgeBand};
+    if row.attestation_type != attestation_type::DELEGATES_TO {
+        return Ok(());
+    }
+    // Resolve the target. An unresolved target is out of scope here (and
+    // FK-rejected downstream — it can never be persisted).
+    let Some(target) = directory.lookup_public_key(&row.attested_key_id).await? else {
+        return Ok(());
+    };
+    let target_set: std::collections::HashSet<&str> =
+        identity_type::parse_set(&target.identity_type)
+            .into_iter()
+            .collect();
+    // Only USER-role targets are governed by THIS rule; node/agent targets go
+    // through the node-agency gate.
+    if !target_set.contains(identity_type::USER) {
+        return Ok(());
+    }
+    // The target is a user. It must be a PROVEN minor to be stewardable.
+    let target_band = age_band(directory, &row.attested_key_id).await?;
+    if target_band != AgeBand::Minor {
+        let reason = match target_band {
+            AgeBand::Adult => "target_is_self_sovereign",
+            // Unknown (presumption of sovereignty).
+            _ => "target_age_unverified",
+        };
+        return Err(Error::UserTargetStewardBindingForbidden {
+            target_key_id: row.attested_key_id.clone(),
+            reason,
+        });
+    }
+    // Target is a proven minor — require the granter is a proven adult user.
+    let Some(granter) = directory.lookup_public_key(&row.attesting_key_id).await? else {
+        return Err(Error::UserTargetStewardBindingForbidden {
+            target_key_id: row.attested_key_id.clone(),
+            reason: "granter_unresolved",
+        });
+    };
+    let granter_is_adult_user =
+        identity_type::set_contains(&granter.identity_type, identity_type::USER)
+            && age_band(directory, &row.attesting_key_id).await? == AgeBand::Adult;
+    if !granter_is_adult_user {
+        return Err(Error::UserTargetStewardBindingForbidden {
+            target_key_id: row.attested_key_id.clone(),
+            reason: "granter_not_adult_user",
+        });
+    }
+    // Admit the minor-guardianship binding (S == attesting_key_id structural).
+    Ok(())
+}
+
 /// v10.3.0 (CIRISPersist#288, CC 3.4.1 / 3.4.3 / 3.4.5) — reserved-prefix
 /// admission on the **`attestation_type`** namespace, keyed on the attesting
 /// key's `identity_type`.
@@ -3077,6 +3198,23 @@ pub async fn check_reserved_prefix_admission(
         return Err(Error::CapacitySelfEmissionRejected {
             key_id: row.attesting_key_id.clone(),
             attestation_type: at.to_owned(),
+        });
+    }
+
+    // CC 3.4.11 (CIRISPersist#307) — the self-declared age rung carries a
+    // `{band}`, NEVER a `{level}`; a `{level}` token belongs to the
+    // witness `age_assurance:` rung. Age tokens travel as the
+    // `attestation_type` string (NOT the `scores` envelope `dimension`), so
+    // the v11.3.0 rule placed only in `DimensionAdmissionPolicy::check`
+    // (which fast-exits for any `attestation_type != scores`) was a no-op on
+    // the real emit path. Gate it HERE, on the `attestation_type` namespace,
+    // independent of emitter (no identity_type rescues the shape). The
+    // dimension-side rule is kept too (defense-in-depth for the
+    // scores+dimension shape).
+    if at == "age_self_declared:level" || at.starts_with("age_self_declared:level:") {
+        return Err(Error::DimensionRejected {
+            dimension: at.to_owned(),
+            reason: DimensionRejectionReason::SelfDeclaredLevelReserved.as_str(),
         });
     }
 

--- a/src/federation/age.rs
+++ b/src/federation/age.rs
@@ -1,0 +1,127 @@
+//! v11.5.0 (CIRISPersist#306, CC 3.3.12 / CC 1.15.6) — the **I1 age band**:
+//! the substrate primitive that resolves a key's verified age band from its
+//! incoming age attestations, so the CC 3.2 user-target steward-binding gate
+//! and the minor-stewardship liveness predicate can be machine-checked.
+//!
+//! Age tokens travel as the **`attestation_type`** string (NOT the `scores`
+//! envelope `dimension`):
+//!
+//! - `age_assurance:*` — the **witness** rung (provider/government). The
+//!   `attestation_type` is reserved to a `witness`-role emitter at admission
+//!   (see [`super::admission::check_reserved_prefix_admission`]). Authoritative.
+//! - `age_self_declared:*` — the **self** rung (subject-signed onboarding
+//!   "state your band"). A self-declared **adult is IGNORED** here — the
+//!   one-way ratchet: a subject may self-declare MINOR to LOWER its own
+//!   access, but may NEVER self-graduate to adult. Only a self-declared minor
+//!   counts.
+//!
+//! **Resolution** (witness OUTRANKS self):
+//!   1. the band of the most-recent live **witness**-rung age attestation
+//!      that parses to a recognized band (Adult / Minor), if any; ELSE
+//!   2. [`AgeBand::Minor`] if any live **self**-rung attestation declares
+//!      minor; ELSE
+//!   3. [`AgeBand::Unknown`] (no usable age token — the
+//!      presumption-of-sovereignty default: a person with no age proof is
+//!      NOT treated as a stewardable minor; CC 1.15.6).
+//!
+//! **Liveness** here is `expires_at`-only (skip rows with `expires_at <=
+//! now`). Richer supersede/withdraw liveness for age is deferred to #309 — do
+//! NOT build it. The three-valued band is exposed verbatim over FFI so #309
+//! can layer a content-protective `unknown → minor` resolution on the CONTENT
+//! axis without changing THIS primitive (the steward-binding axis keeps
+//! `unknown` = non-minor = self-sovereign).
+
+use super::{Error, FederationDirectory};
+
+/// The I1 age band of a key (CC 3.3.12). Three-valued: a person with no
+/// usable age attestation resolves to [`AgeBand::Unknown`], which the
+/// steward-binding gate treats as NON-minor (un-stewardable —
+/// presumption-of-sovereignty, CC 1.15.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgeBand {
+    /// A proven under-18 (a live witness `age_assurance:*:minor` OR a live
+    /// self-declared `age_self_declared:*:minor`).
+    Minor,
+    /// A proven over-18 (a live witness `age_assurance:*:adult`). A
+    /// self-declared adult does NOT confer this (the one-way ratchet).
+    Adult,
+    /// No usable age proof — treated as non-minor / self-sovereign on the
+    /// steward-binding axis.
+    Unknown,
+}
+
+impl AgeBand {
+    /// The stable FFI/telemetry string token (`"minor"` / `"adult"` /
+    /// `"unknown"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgeBand::Minor => "minor",
+            AgeBand::Adult => "adult",
+            AgeBand::Unknown => "unknown",
+        }
+    }
+}
+
+/// Parse an age **band** out of an age `attestation_type` token. Splits on
+/// `':'` and recognizes exactly `adult` → [`AgeBand::Adult`] and `minor` →
+/// [`AgeBand::Minor`] as a segment; returns `None` if neither is present.
+///
+/// Deliberately small + #309-extensible: #309 will add the 4-band
+/// `under_13` / `13_15` / `16_17` → all map to [`AgeBand::Minor`]. For now we
+/// recognize only the coarse `adult` / `minor` tokens both rungs use.
+fn parse_age_band_token(attestation_type: &str) -> Option<AgeBand> {
+    let mut found_adult = false;
+    let mut found_minor = false;
+    for seg in attestation_type.split(':') {
+        match seg {
+            "adult" => found_adult = true,
+            "minor" => found_minor = true,
+            _ => {}
+        }
+    }
+    // Defensive: a malformed token carrying both → no clean band.
+    match (found_adult, found_minor) {
+        (true, false) => Some(AgeBand::Adult),
+        (false, true) => Some(AgeBand::Minor),
+        _ => None,
+    }
+}
+
+/// Resolve the [`AgeBand`] of key `k` from its INCOMING age attestations
+/// (attestations ABOUT `k`, i.e. `attested_key_id == k`). See the
+/// module docs for the witness-outranks-self resolution + the
+/// presumption-of-sovereignty `Unknown` default.
+pub async fn age_band(directory: &dyn FederationDirectory, k: &str) -> Result<AgeBand, Error> {
+    let now = chrono::Utc::now();
+    // `list_attestations_for(k)` is ordered asserted_at DESC, so the first
+    // matching witness row is the most recent.
+    let mut self_says_minor = false;
+    for r in directory.list_attestations_for(k).await? {
+        // Liveness: an expired age attestation confers nothing (#309 will add
+        // richer supersede/withdraw liveness; expires_at only here).
+        if let Some(exp) = r.expires_at {
+            if exp <= now {
+                continue;
+            }
+        }
+        let at = r.attestation_type.as_str();
+        if at.starts_with("age_assurance:") {
+            // Witness rung — authoritative. The most recent one that parses
+            // to a recognized band wins outright.
+            if let Some(band) = parse_age_band_token(at) {
+                return Ok(band);
+            }
+        } else if at.starts_with("age_self_declared:") {
+            // Self rung — one-way ratchet: only a self-declared MINOR counts
+            // (a self-declared adult is ignored). Remember it but keep
+            // scanning for an authoritative witness row.
+            if parse_age_band_token(at) == Some(AgeBand::Minor) {
+                self_says_minor = true;
+            }
+        }
+    }
+    if self_says_minor {
+        return Ok(AgeBand::Minor);
+    }
+    Ok(AgeBand::Unknown)
+}

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -34,6 +34,7 @@
 
 pub mod accord_quorum;
 pub mod admission;
+pub mod age;
 pub mod at_rest_cascade;
 #[cfg(feature = "cirisaudit")]
 pub mod backfill;
@@ -3633,6 +3634,47 @@ pub enum Error {
         member_role: &'static str,
     },
 
+    /// v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — a `delegates_to`
+    /// whose TARGET (`attested_key_id`) resolves to a `user`-role identity was
+    /// REFUSED by the CC 3.2 user-target steward-binding gate. "Stewarding a
+    /// person" is admissible only as **minor-guardianship**; the admissible
+    /// set is exactly: target is a PROVEN minor AND the granter
+    /// (`attesting_key_id`) is a PROVEN adult `user`. Every other user-target
+    /// binding is refused:
+    ///
+    /// - `target_is_self_sovereign` — the target is a proven ADULT user. An
+    ///   adult is un-stewardable (CC 1.15.6, no-slavery / self-sovereignty);
+    ///   rejected unconditionally.
+    /// - `target_age_unverified` — the target has no usable age proof
+    ///   ([`crate::federation::age::AgeBand::Unknown`]). The
+    ///   presumption-of-sovereignty default: you may not acquire stewardship
+    ///   over someone unless they are PROVEN a minor.
+    /// - `granter_unresolved` — the granter key does not resolve.
+    /// - `granter_not_adult_user` — the granter is not a `user`, or not a
+    ///   proven adult (a minor cannot be a guardian; a non-user cannot be a
+    ///   guardian).
+    ///
+    /// `node`/`agent`-target bindings are governed by
+    /// [`admission::check_node_agency_admission`] and are NOT affected by this
+    /// rule. The row is NOT stored (verify-before-mutation, AV-9). Stable
+    /// `kind()` token `federation_user_target_steward_binding_forbidden`. See
+    /// [`admission::check_user_target_steward_binding_admission`].
+    #[error(
+        "delegates_to to user-role target {target_key_id:?} refused ({reason}): a user-target \
+         steward-binding is admissible only as minor-guardianship — the target MUST be a proven \
+         minor and the granter a proven adult user (CC 3.2 / CC 1.15.6 — an adult is \
+         un-stewardable; presumption of sovereignty for an unverified age)"
+    )]
+    UserTargetStewardBindingForbidden {
+        /// The `attested_key_id` (target) that resolved to a `user`-role
+        /// identity and failed the minor-guardianship predicate.
+        target_key_id: String,
+        /// Which leg of the predicate failed (`target_is_self_sovereign` /
+        /// `target_age_unverified` / `granter_unresolved` /
+        /// `granter_not_adult_user`).
+        reason: &'static str,
+    },
+
     /// v8.2.0 (CEG 1.0-RC11 §19.1 / CIRISPersist#228 item 1 / #229 item 1)
     /// — a WholenessWitness was REJECTED at the verify-before-persist
     /// gate: the §19.0 PQC-mandatory hard cut (classical-only / missing
@@ -3698,6 +3740,9 @@ impl Error {
             Error::DelegatedScopeUnauthorized { .. } => "federation_delegated_scope_unauthorized",
             Error::NodeAgencyForbidden { .. } => "federation_node_agency_forbidden",
             Error::UnstewardedCommunityMember { .. } => "federation_unstewarded_community_member",
+            Error::UserTargetStewardBindingForbidden { .. } => {
+                "federation_user_target_steward_binding_forbidden"
+            }
             Error::FederationTierUnverified { .. } => "federation_federation_tier_unverified",
             Error::WitnessAdmit(e) => e.kind(),
             Error::Backend(_) => "federation_backend",

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7057,6 +7057,53 @@ impl PyEngine {
         })
     }
 
+    /// v11.5.0 (CIRISPersist#306, CC 3.3.12 / CC 1.15.6) — the **I1 age band**
+    /// of `key_id`, resolved from its incoming age attestations (witness
+    /// `age_assurance:*` OUTRANKS self-declared `age_self_declared:*`; a
+    /// self-declared adult is ignored — the one-way ratchet). Returns one of
+    /// `"minor"` / `"adult"` / `"unknown"` (a key with no usable age proof
+    /// resolves to `"unknown"` — presumption of sovereignty). Wraps
+    /// [`age_band`](crate::federation::age::age_band). The three-valued band
+    /// is exposed verbatim so a consumer (#309) can layer a content-protective
+    /// `unknown → minor` resolution on the CONTENT axis without changing this
+    /// primitive.
+    fn age_band_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            py.detach(move || {
+                let band = match &self.backend {
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::age::age_band(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::age::age_band(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(band.as_str())
+                    .map_err(|e| PyValueError::new_err(format!("age_band serialize: {e}")))
+            })
+        })
+    }
+
     /// #249 Cut A — the **duty-holders** of a bare community-scoped action
     /// (a `moderation:*` / `reconsideration:*` over `community_id` with no
     /// content subject) for `duty` (`moderate` / `takedown` / `review`): the
@@ -23432,6 +23479,13 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // failure (non-infra membership is an authority act that must root
         // in an owner); ValueError (4xx).
         crate::federation::Error::UnstewardedCommunityMember { .. } => PyValueError::new_err(kind),
+        // v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — a refused
+        // user-target steward-binding (target is a self-sovereign adult / its
+        // age is unverified / the granter is not a proven adult user) is a
+        // caller-side authorization failure; ValueError (4xx).
+        crate::federation::Error::UserTargetStewardBindingForbidden { .. } => {
+            PyValueError::new_err(kind)
+        }
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — a federation-tier
         // attestation rejected at the bulk ingest gate (missing ML-DSA-65
         // half / tampered signature / canonicalizer mismatch /

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1305,6 +1305,14 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // emission leaves no trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — the user-target
+        // steward-binding gate: a `delegates_to` onto a `user`-role target is
+        // admissible ONLY as minor-guardianship (proven-minor target +
+        // proven-adult-user granter). Backend-symmetric with SQLite +
+        // Postgres; verify-before-mutation.
+        crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
+            .await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace, keyed on the attesting
         // key's identity_type. Backend-symmetric with SQLite + Postgres.
@@ -9215,5 +9223,421 @@ mod tests {
         check_reserved_prefix_admission(&backend, &row("delegates_to", "rp-agent", "rp-accord"))
             .await
             .expect("delegates_to is not a reserved type");
+
+        // #307 (CC 3.4.11) — the age_self_declared:level:* refusal lives on
+        // the attestation_TYPE gate (the REAL emit path), not just the
+        // dimension gate. age tokens travel as the attestation_type string.
+        for at in ["age_self_declared:level:adult", "age_self_declared:level"] {
+            let e = check_reserved_prefix_admission(&backend, &row(at, "rp-agent", "rp-agent"))
+                .await
+                .expect_err("age_self_declared:level:* must be refused on the type gate");
+            assert_eq!(
+                e.kind(),
+                "federation_dimension_rejected",
+                "{at:?} should refuse with DimensionRejected",
+            );
+            match e {
+                crate::federation::Error::DimensionRejected { reason, .. } => assert_eq!(
+                    reason,
+                    crate::federation::admission::DimensionRejectionReason::SelfDeclaredLevelReserved
+                        .as_str(),
+                ),
+                other => panic!("expected DimensionRejected, got {other:?}"),
+            }
+        }
+        // The `{band}` self rung still admits; a witness `age_assurance:*`
+        // token also fast-exits this gate (its emitter rule is identity-gated
+        // and not exercised here for an unregistered attester — use a
+        // registered witness-free shape that simply isn't level-reserved).
+        check_reserved_prefix_admission(
+            &backend,
+            &row("age_self_declared:band:adult", "rp-agent", "rp-agent"),
+        )
+        .await
+        .expect("age_self_declared:band:* is admitted (subject-signed self rung)");
+    }
+
+    // ── v11.5.0 (CIRISPersist#306, CC 3.2 / CC 3.3.12 / CC 1.15.6) ──────────
+    //    I1 age band + user-target steward-binding gate + minor liveness.
+
+    /// Register a key with a chosen `identity_type` (e.g. `user` / `witness` /
+    /// `agent` / `node`).
+    async fn put_typed_key(backend: &MemoryBackend, key_id: &str, it: &str) {
+        let mut rec = fix_key(key_id, "ref", key_id);
+        rec.identity_type = it.to_owned();
+        backend
+            .put_public_key(SignedKeyRecord { record: rec })
+            .await
+            .unwrap();
+    }
+
+    /// Build a live age attestation ABOUT `subject` (attested_key_id ==
+    /// subject) from `emitter`, carrying the given age `attestation_type`
+    /// token + empty envelope. Properly hybrid-signed (CC 5.3.2.4.3.1).
+    fn fix_age_attestation(id: &str, emitter: &str, subject: &str, token: &str) -> Attestation {
+        let mut a = fix_attestation(id, emitter, subject, emitter);
+        a.attestation_type = token.to_owned();
+        a.attestation_envelope = serde_json::json!({ "id": id });
+        a.expires_at = None;
+        resign_fix(&mut a);
+        a
+    }
+
+    /// age_band resolution: witness adult OUTRANKS self minor; self minor
+    /// alone → Minor; self adult alone → Unknown (ratchet ignores self-adult);
+    /// witness minor → Minor; no attestation → Unknown; expired witness
+    /// attestation ignored.
+    #[tokio::test]
+    async fn age_band_resolution_witness_outranks_self_and_ratchets() {
+        use crate::federation::age::{age_band, AgeBand};
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "ab-witness", "witness").await;
+        put_typed_key(&backend, "ab-subj", "user").await;
+
+        // No attestation → Unknown (presumption of sovereignty).
+        assert_eq!(
+            age_band(&backend, "ab-subj").await.unwrap(),
+            AgeBand::Unknown
+        );
+
+        // Self-declared adult alone → Unknown (the one-way ratchet ignores a
+        // self-declared adult).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "ab-self-adult",
+                    "ab-subj",
+                    "ab-subj",
+                    "age_self_declared:band:adult",
+                ),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            age_band(&backend, "ab-subj").await.unwrap(),
+            AgeBand::Unknown,
+            "a self-declared adult must NOT graduate the subject to Adult",
+        );
+
+        // Add a self-declared MINOR → Minor (a subject may ratchet DOWN).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "ab-self-minor",
+                    "ab-subj",
+                    "ab-subj",
+                    "age_self_declared:band:minor",
+                ),
+            })
+            .await
+            .unwrap();
+        assert_eq!(age_band(&backend, "ab-subj").await.unwrap(), AgeBand::Minor);
+
+        // A witness ADULT attestation OUTRANKS the self-declared minor → Adult.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "ab-witness-adult",
+                    "ab-witness",
+                    "ab-subj",
+                    "age_assurance:provider:adult:v1",
+                ),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            age_band(&backend, "ab-subj").await.unwrap(),
+            AgeBand::Adult,
+            "the witness rung must outrank a self-declared minor",
+        );
+    }
+
+    /// age_band: a witness MINOR resolves Minor; an EXPIRED witness adult is
+    /// ignored (liveness = expires_at only).
+    #[tokio::test]
+    async fn age_band_witness_minor_and_expired_witness_ignored() {
+        use crate::federation::age::{age_band, AgeBand};
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "abe-witness", "witness").await;
+        put_typed_key(&backend, "abe-subj", "user").await;
+
+        // Witness minor → Minor.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "abe-w-minor",
+                    "abe-witness",
+                    "abe-subj",
+                    "age_assurance:provider:minor:v1",
+                ),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            age_band(&backend, "abe-subj").await.unwrap(),
+            AgeBand::Minor
+        );
+
+        // An EXPIRED witness adult is ignored — Minor still wins (it is live).
+        let mut expired = fix_age_attestation(
+            "abe-w-adult-exp",
+            "abe-witness",
+            "abe-subj",
+            "age_assurance:provider:adult:v1",
+        );
+        expired.expires_at = Some("2020-01-01T00:00:00Z".parse().unwrap());
+        resign_fix(&mut expired);
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: expired,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            age_band(&backend, "abe-subj").await.unwrap(),
+            AgeBand::Minor,
+            "an expired witness adult must be ignored (liveness = expires_at)",
+        );
+    }
+
+    /// CC 3.2 user-target gate decision table, exercised through the REAL
+    /// `put_attestation` admission path on the memory backend.
+    #[tokio::test]
+    async fn user_target_steward_binding_gate_decision_table() {
+        use crate::federation::types::delegation_scope as ds;
+        let backend = MemoryBackend::new();
+        // S = adult-user steward; the witness that attests adulthood.
+        put_typed_key(&backend, "ut-witness", "witness").await;
+        put_typed_key(&backend, "ut-S", "user").await;
+        // Adult target A (witness-attested adult), unknown-age user U,
+        // minor target M (witness-attested minor), node N.
+        put_typed_key(&backend, "ut-A", "user").await;
+        put_typed_key(&backend, "ut-U", "user").await;
+        put_typed_key(&backend, "ut-M", "user").await;
+        put_typed_key(&backend, "ut-N", "node").await;
+
+        // Witness-attest S and A as adults; M as a minor.
+        for (id, subj, token) in [
+            ("uw-S", "ut-S", "age_assurance:provider:adult:v1"),
+            ("uw-A", "ut-A", "age_assurance:provider:adult:v1"),
+            ("uw-M", "ut-M", "age_assurance:provider:minor:v1"),
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: fix_age_attestation(id, "ut-witness", subj, token),
+                })
+                .await
+                .unwrap();
+        }
+
+        let deleg =
+            |id: &str, s: &str, t: &str| fix_node_delegates_to(id, s, t, s, &[ds::INFRA_SERVE]);
+
+        // S(adult user) → A(adult user) : REJECTED (target_is_self_sovereign).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: deleg("utd-A", "ut-S", "ut-A"),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_user_target_steward_binding_forbidden");
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(reason, "target_is_self_sovereign");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden, got {other:?}"),
+        }
+
+        // S(adult) → U(no age = Unknown) : REJECTED (target_age_unverified).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: deleg("utd-U", "ut-S", "ut-U"),
+            })
+            .await
+            .unwrap_err();
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(reason, "target_age_unverified");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden, got {other:?}"),
+        }
+
+        // S(adult user) → M(witness minor) : ADMITTED (legal guardianship).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: deleg("utd-M", "ut-S", "ut-M"),
+            })
+            .await
+            .expect("adult-user steward → witness-minor ward is admitted");
+        // (The granter-not-adult-user leg + node-target no-op are covered by
+        // `user_target_gate_granter_must_be_adult_and_nodes_unaffected`.)
+    }
+
+    /// CC 3.2 user-target gate: a non-adult (Unknown-age) granter cannot
+    /// steward even a proven minor (granter_not_adult_user); a node/agent
+    /// target is unaffected by this gate (goes through node-agency only).
+    #[tokio::test]
+    async fn user_target_gate_granter_must_be_adult_and_nodes_unaffected() {
+        use crate::federation::types::delegation_scope as ds;
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "ug-witness", "witness").await;
+        put_typed_key(&backend, "ug-U", "user").await; // unknown-age user (granter)
+        put_typed_key(&backend, "ug-M", "user").await; // witness-minor ward
+        put_typed_key(&backend, "ug-N", "node").await; // node target
+
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "ugw-M",
+                    "ug-witness",
+                    "ug-M",
+                    "age_assurance:provider:minor:v1",
+                ),
+            })
+            .await
+            .unwrap();
+
+        // U(unknown-age user) → M(minor) : REJECTED (granter not proven adult).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ugd-UM",
+                    "ug-U",
+                    "ug-M",
+                    "ug-U",
+                    &[ds::INFRA_SERVE],
+                ),
+            })
+            .await
+            .unwrap_err();
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(reason, "granter_not_adult_user");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden, got {other:?}"),
+        }
+
+        // U(unknown-age user) → N(node) : the user-target gate is a no-op for a
+        // node target (infra:* scope clears the node-agency gate) → ADMITTED.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ugd-UN",
+                    "ug-U",
+                    "ug-N",
+                    "ug-U",
+                    &[ds::INFRA_SERVE],
+                ),
+            })
+            .await
+            .expect("a node target is governed by the node-agency gate, not the user-target gate");
+    }
+
+    /// Minor-stewardship liveness fail-secure (CC 3.2): a minor user bound by
+    /// an adult (live edge) is steward-bound; after the granter withdraws it,
+    /// is_steward_bound flips to false (the minor does NOT self-anchor). A
+    /// node is unchanged; an adult user self-anchors with no edge.
+    #[tokio::test]
+    async fn minor_stewardship_liveness_fails_secure_nodes_and_adults_unchanged() {
+        use crate::federation::admission::{is_steward_bound, steward_bindings_of};
+        use crate::federation::types::delegation_scope as ds;
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "ml-witness", "witness").await;
+        put_typed_key(&backend, "ml-S", "user").await; // adult-user steward
+        put_typed_key(&backend, "ml-M", "user").await; // minor-user ward
+        put_typed_key(&backend, "ml-A", "user").await; // adult-user (self-sovereign)
+        put_typed_key(&backend, "ml-N", "node").await; // node control
+
+        // Attest S and A as adults, M as a minor.
+        for (id, subj, token) in [
+            ("mlw-S", "ml-S", "age_assurance:provider:adult:v1"),
+            ("mlw-A", "ml-A", "age_assurance:provider:adult:v1"),
+            ("mlw-M", "ml-M", "age_assurance:provider:minor:v1"),
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: fix_age_attestation(id, "ml-witness", subj, token),
+                })
+                .await
+                .unwrap();
+        }
+
+        // An adult user with no edge self-anchors (sovereign — its own steward).
+        assert!(
+            is_steward_bound(&backend, "ml-A").await.unwrap(),
+            "an adult user is its own steward anchor",
+        );
+
+        // A steward-less minor does NOT self-anchor (fail-secure).
+        assert!(
+            !is_steward_bound(&backend, "ml-M").await.unwrap(),
+            "a steward-less minor must NOT self-anchor (CC 3.2 fail-secure)",
+        );
+
+        // Bind the minor to the adult steward (live edge) → steward-bound.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ml-bind",
+                    "ml-S",
+                    "ml-M",
+                    "ml-S",
+                    &[ds::INFRA_SERVE],
+                ),
+            })
+            .await
+            .expect("adult-user steward → minor ward admitted");
+        assert!(is_steward_bound(&backend, "ml-M").await.unwrap());
+        assert_eq!(
+            steward_bindings_of(&backend, "ml-M").await.unwrap(),
+            vec!["ml-S".to_string()],
+            "while bound, the minor is anchored only to the adult steward (NOT self)",
+        );
+
+        // The adult withdraws the binding → the minor fails secure again.
+        let mut w = fix_attestation("ml-withdraw", "ml-S", "ml-M", "ml-S");
+        w.attestation_type = crate::federation::types::attestation_type::WITHDRAWS.into();
+        w.attestation_envelope = serde_json::json!({ "id": "ml-withdraw" });
+        resign_fix(&mut w);
+        backend
+            .put_attestation(SignedAttestation { attestation: w })
+            .await
+            .unwrap();
+        assert!(
+            !is_steward_bound(&backend, "ml-M").await.unwrap(),
+            "a minor whose only adult steward was withdrawn must be steward-less (fail-secure)",
+        );
+        assert!(steward_bindings_of(&backend, "ml-M")
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Control: a node bound then withdrawn is unchanged (bound→true,
+        // withdrawn→false) — the node path never used clauses (1)/(2).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ml-nbind",
+                    "ml-S",
+                    "ml-N",
+                    "ml-S",
+                    &[ds::INFRA_SERVE],
+                ),
+            })
+            .await
+            .unwrap();
+        assert!(is_steward_bound(&backend, "ml-N").await.unwrap());
+        let mut wn = fix_attestation("ml-nwithdraw", "ml-S", "ml-N", "ml-S");
+        wn.attestation_type = crate::federation::types::attestation_type::WITHDRAWS.into();
+        wn.attestation_envelope = serde_json::json!({ "id": "ml-nwithdraw" });
+        resign_fix(&mut wn);
+        backend
+            .put_attestation(SignedAttestation { attestation: wn })
+            .await
+            .unwrap();
+        assert!(
+            !is_steward_bound(&backend, "ml-N").await.unwrap(),
+            "the node/agent fail-secure path is unchanged by the minor gate",
+        );
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2479,6 +2479,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         // no trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — the user-target
+        // steward-binding gate: a `delegates_to` onto a `user`-role target is
+        // admissible ONLY as minor-guardianship (proven-minor target +
+        // proven-adult-user granter). Backend-symmetric with memory + SQLite;
+        // verify-before-mutation.
+        crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
+            .await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace (accord:* → accord_holder;
         // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2166,6 +2166,14 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // trace.
         crate::federation::admission::check_node_agency_admission(self, &row).await?;
 
+        // v11.5.0 (CIRISPersist#306, CC 3.2 / CC 1.15.6) — the user-target
+        // steward-binding gate: a `delegates_to` onto a `user`-role target is
+        // admissible ONLY as minor-guardianship (proven-minor target +
+        // proven-adult-user granter). Backend-symmetric with memory + Postgres;
+        // verify-before-mutation.
+        crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
+            .await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace (accord:* → accord_holder;
         // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →
@@ -25181,6 +25189,113 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    /// v11.5.0 (CIRISPersist#306, CC 3.2 / CC 3.3.12 / CC 1.15.6) — sqlite
+    /// parity for the I1 age band, the user-target steward-binding gate, and
+    /// the minor-stewardship liveness fail-secure.
+    #[tokio::test]
+    async fn user_target_gate_and_minor_liveness_sqlite() {
+        use crate::federation::admission::{is_steward_bound, steward_bindings_of};
+        use crate::federation::age::{age_band, AgeBand};
+        use crate::federation::types::{attestation_type, delegation_scope as ds, identity_type};
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        for (k, ity) in [
+            ("sl-witness", identity_type::WITNESS),
+            ("sl-S", identity_type::USER), // adult-user steward
+            ("sl-A", identity_type::USER), // self-sovereign adult user
+            ("sl-M", identity_type::USER), // minor-user ward
+            ("sl-N", identity_type::NODE), // node control
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key_with_identity_type(k, k, k, ity),
+                })
+                .await
+                .unwrap();
+        }
+
+        // Age-attest S + A as adults (witness rung), M as a minor.
+        let age = |emitter: &str, subj: &str, token: &str| {
+            let mut a = topo_attestation(
+                emitter,
+                subj,
+                token,
+                None,
+                None,
+                &[],
+                None,
+                chrono::Utc::now(),
+            );
+            a.attestation_envelope = serde_json::json!({ "id": token });
+            resign_fed(&mut a);
+            a
+        };
+        for (subj, token) in [
+            ("sl-S", "age_assurance:provider:adult:v1"),
+            ("sl-A", "age_assurance:provider:adult:v1"),
+            ("sl-M", "age_assurance:provider:minor:v1"),
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: age("sl-witness", subj, token),
+                })
+                .await
+                .unwrap();
+        }
+        assert_eq!(age_band(&backend, "sl-A").await.unwrap(), AgeBand::Adult);
+        assert_eq!(age_band(&backend, "sl-M").await.unwrap(), AgeBand::Minor);
+
+        // user-target gate: S(adult) → A(adult user) REJECTED (self-sovereign).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: node_delegates_to_sqlite("sl-S", "sl-A", &[ds::INFRA_SERVE]),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_user_target_steward_binding_forbidden");
+
+        // A steward-less minor does NOT self-anchor (fail-secure).
+        assert!(!is_steward_bound(&backend, "sl-M").await.unwrap());
+        // An adult user self-anchors with no edge.
+        assert!(is_steward_bound(&backend, "sl-A").await.unwrap());
+
+        // S(adult) → M(minor) ADMITTED; minor becomes steward-bound to S only.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: node_delegates_to_sqlite("sl-S", "sl-M", &[ds::INFRA_SERVE]),
+            })
+            .await
+            .expect("adult-user steward → minor ward admitted");
+        assert!(is_steward_bound(&backend, "sl-M").await.unwrap());
+        assert_eq!(
+            steward_bindings_of(&backend, "sl-M").await.unwrap(),
+            vec!["sl-S".to_string()],
+        );
+
+        // S withdraws → the minor fails secure (false).
+        let mut w = topo_attestation(
+            "sl-S",
+            "sl-M",
+            attestation_type::WITHDRAWS,
+            None,
+            None,
+            &[],
+            None,
+            chrono::Utc::now(),
+        );
+        w.attestation_envelope = serde_json::json!({ "id": "sl-withdraw" });
+        resign_fed(&mut w);
+        backend
+            .put_attestation(SignedAttestation { attestation: w })
+            .await
+            .unwrap();
+        assert!(
+            !is_steward_bound(&backend, "sl-M").await.unwrap(),
+            "a minor whose only adult steward was withdrawn must fail secure",
+        );
     }
 
     /// SecReview F3: a WITHDRAWN `delegates_to(user → node)` no longer


### PR DESCRIPTION
## v11.5.0 — #307 gate-placement fix + #306 (CC 3.2) age band + user-target steward-binding gate + minor liveness

### #307 (CC 3.4.11) — the `age_self_declared:level:*` refusal was a no-op on the real emit path

v11.3.0 shipped a rule refusing `age_self_declared:level:*` but placed it ONLY in `DimensionAdmissionPolicy::check`, which gates the `scores` envelope **`dimension`** field and fast-exits for any `attestation_type != scores`. Age tokens travel as the **`attestation_type`** string (e.g. `attestation_type = "age_self_declared:level:adult"`, empty envelope), so the rule never fired on `emit_attestation_self` → put. Fixed by adding the refusal to `check_reserved_prefix_admission` (the `attestation_type`-namespace gate, where the witness `age_assurance:` reservation lives), after the `capacity:` self-emission check. The dimension-side rule is kept for defense-in-depth. Backend-symmetric.

### #306 (CC 3.2 / CC 3.3.12 / CC 1.15.6)

- **I1 age band** (new `src/federation/age.rs`): `age_band() -> AgeBand { Minor | Adult | Unknown }`. Witness `age_assurance:*` OUTRANKS self-declared `age_self_declared:*`; a self-declared adult is ignored (one-way ratchet); no usable proof → `Unknown` (presumption of sovereignty). `expires_at`-only liveness (#309 extends).
- **CC 3.2 user-target gate** (`check_user_target_steward_binding_admission`, wired into all three backends after `check_node_agency_admission`): a `delegates_to` onto a `user`-role target is admissible ONLY as minor-guardianship (proven-minor target + proven-adult-user granter). All else → new `Error::UserTargetStewardBindingForbidden` (`target_is_self_sovereign` / `target_age_unverified` / `granter_unresolved` / `granter_not_adult_user`). Node/agent targets unaffected.
- **Minor-stewardship liveness fail-secure**: `is_steward_bound` / `steward_bindings_of` / `steward_binding_chain` clauses (1)/(2) confer steward-binding only when `age_band(k) != Minor`. A proven minor must rely on a live adult-steward edge; when withdrawn it fails secure. Node/agent path (and the `UnstewardedCommunityMember` gate) unchanged — control test preserved.
- **FFI**: `Engine.age_band_json -> "minor"/"adult"/"unknown"` + crate-level `Engine::age_band`.

### Verification
- `cargo test --lib --no-default-features --features server` — 623 passed; sqlite leg — 1019 passed.
- `cargo clippy --lib --tests` clean across `server` / `server sqlite` / `server postgres` / `server sqlite postgres pyo3`.
- `RUSTFLAGS="-D warnings" cargo build --no-default-features --features server` clean (no-backend dead-code trap).

CIRISVerify stays **v8.3.0** (no re-pin). The CIRISConformance `test_350` / `test_360` / `test_361` `xfail(strict)` flips are a downstream follow-up owned by the conformance maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ
