### PR TITLE
ci: rolling phead cache blob — version bump restores most-recent persist build (incremental compile)

### DIFF
--- a/.github/actions/ciriscache/action.yml
+++ b/.github/actions/ciriscache/action.yml
@@ -32,14 +32,31 @@ runs:
         V=$(grep -m1 'tag = "v' Cargo.toml | sed -E 's/.*tag = "v([0-9.]+)".*/\1/')
         BASE="ciris-substrate-v1-${{ inputs.plat }}-release-rustc${RUSTC}"
         echo "CIRISCACHE_KEY=${BASE}-p${P:-none}-enone-v${V:-none}" >> "$GITHUB_ENV"
+        # CIRISPersist#320-followup — a ROLLING "most-recent persist build" key.
+        # The versioned key above misses on every version bump (p11.6.0 →
+        # p11.6.1 never existed), so before this only the verify layer restored
+        # and persist's OWN deps (pyo3/rusqlite/tokio-postgres/candle…) — which
+        # the verify blob does NOT hold — recompiled from scratch every release.
+        # `phead` is version-INDEPENDENT (still pinned on plat+rustc+verify so
+        # it's ABI-compatible) and overwritten each build, so a version bump
+        # restores the last persist `target/` (verify + all persist deps +
+        # persist crate) and cargo recompiles only CHANGED files. The versioned
+        # blob still exists for edge's cross-repo exact-pin.
+        echo "CIRISCACHE_KEY_HEAD=${BASE}-phead-enone-v${V:-none}" >> "$GITHUB_ENV"
         echo "CIRISCACHE_KEY_VERIFY=${BASE}-pnone-enone-v${V:-none}" >> "$GITHUB_ENV"
         echo "CIRISCache: persist=${BASE}-p${P:-none}-enone-v${V:-none}"
+        echo "CIRISCache: head   =${BASE}-phead-enone-v${V:-none}"
         echo "CIRISCache: verify =${BASE}-pnone-enone-v${V:-none}"
-    - uses: CIRISAI/CIRISCache/restore@v1   # layer 1 (widest): verify upstream
+    # Widest → narrowest; each overlays the previous (later wins on overlap).
+    - uses: CIRISAI/CIRISCache/restore@v1   # layer 1 (widest): verify upstream (first-ever-build fallback)
       continue-on-error: true
       with:
         key: ${{ env.CIRISCACHE_KEY_VERIFY }}
-    - uses: CIRISAI/CIRISCache/restore@v1   # layer 2 (narrowest, wins): persist's own
+    - uses: CIRISAI/CIRISCache/restore@v1   # layer 2: most-recent persist build (the cross-version warm target/)
+      continue-on-error: true
+      with:
+        key: ${{ env.CIRISCACHE_KEY_HEAD }}
+    - uses: CIRISAI/CIRISCache/restore@v1   # layer 3 (narrowest, wins): this exact version (same-version re-run)
       continue-on-error: true
       with:
         key: ${{ env.CIRISCACHE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,14 @@ jobs:
         with:
           key: ${{ env.CIRISCACHE_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      # …and the rolling `phead` blob (most-recent persist build) for
+      # cross-version incremental restore (see the ciriscache composite).
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main' && matrix.substrate.name == 'core'
+        continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY_HEAD }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # NOTE: the prior `linux-aarch64-build` cross-compile job was removed
   # in v0.1.15. Its purpose ("prove the crate cross-compiles to arm64
@@ -251,6 +259,15 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ env.CIRISCACHE_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # …and the rolling `phead` blob (most-recent persist build) so the NEXT
+      # version's build restores this warm target/ and recompiles only changed
+      # files instead of rebuilding persist's deps from the verify baseline.
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY_HEAD }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Mission category §4 + PLATFORM_ARCHITECTURE.md §3.1: iOS device +
@@ -410,6 +427,15 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ env.CIRISCACHE_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # …and the rolling `phead` blob (most-recent persist build) so the NEXT
+      # version's build restores this warm target/ and recompiles only changed
+      # files instead of rebuilding persist's deps from the verify baseline.
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY_HEAD }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ci-perf — recombine the two parallel iOS target builds into the single
@@ -624,6 +650,15 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ env.CIRISCACHE_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # …and the rolling `phead` blob (most-recent persist build) so the NEXT
+      # version's build restores this warm target/ and recompiles only changed
+      # files instead of rebuilding persist's deps from the verify baseline.
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: github.ref == 'refs/heads/main'
+        continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY_HEAD }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # Downstream job: collect per-ABI artifacts into tarballs + wheels.
@@ -1194,6 +1229,15 @@ jobs:
         continue-on-error: true
         with:
           key: ${{ env.CIRISCACHE_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # …and the rolling `phead` blob (most-recent persist build) for
+      # cross-version incremental restore (see the ciriscache composite).
+      - name: Save CIRISCache phead blob
+        if: github.ref == 'refs/heads/main' && (matrix.label == 'linux-aarch64' || matrix.label == 'windows-x86_64')
+        uses: CIRISAI/CIRISCache/save@v1
+        continue-on-error: true
+        with:
+          key: ${{ env.CIRISCACHE_KEY_HEAD }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # v0.1.12 — publish abi3 wheel to PyPI on every tag push.


### PR DESCRIPTION
Fixes the persist=miss-on-version-bump pattern found in the CI wall-time analysis. The persist blob was saved only under the exact `p<version>` key → every release missed it → persist's own deps (pyo3/rusqlite/tokio-postgres/candle) recompiled cold from the verify baseline every time.

**Fix (additive):** a rolling version-independent `phead` blob = the most-recent persist build. Composite restores **verify → phead → p<version>** (widest→narrowest). A version bump now restores `phead`'s full warm `target/` (verify + all persist deps + persist crate) → cargo recompiles only changed files. Versioned blob retained for edge's cross-repo exact-pin. Saves main-only (5 sites, each paired).

Benefit kicks in on the 2nd main build after merge (first build seeds `phead`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ