### PR TITLE
v11.7.0 — #320 audit: ABI-stable outbound_queue + signer capsules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,68 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.7.0] — 2026-07-01
+
+### Added — #320 audit: ABI-stable outbound_queue + signer capsules (close the remaining raw-Rust-type cross-cdylib surfaces)
+
+The #320 cohabitation audit (fixed the `FederationDirectory` vtable-skew that
+hung CIRISEdge) flagged two more `PyEngine` capsules that still hand a cohabiting
+Rust consumer a raw persist Rust type by-value across the cdylib boundary — the
+same structural class (#141 libsqlite3 SIGSEGV / #156 cross-tokio deadlock / #320
+directory vtable-skew: a type whose in-memory contract is not guaranteed stable
+across persist versions, passed static-vs-wheel). Both are now closed with
+ABI-stable C-vtable serialized-op capsules that dispatch INSIDE persist's `.so`,
+exactly mirroring `directory_capsule` (#322/#323) and reusing the existing
+`executor_capsule` (#157) for the spawn. The old capsules are **retained +
+deprecated** for the migration window; **CIRISEdge must adopt** (CIRISEdge#245
+extends).
+
+- **`outbound_queue_ops_capsule`** (`src/ffi/outbound_queue_capsule.rs`, name tag
+  `ciris_persist::outbound_queue_ops_v1`). The pre-audit `outbound_queue_capsule`
+  handed over a raw `BackendDispatch` enum; because
+  [`OutboundQueue`](crate::outbound::OutboundQueue) uses `-> impl Future + Send`
+  RPITIT methods it is **not object-safe**, so the consumer `match`ed the variant
+  and **static-dispatched** the trait method against ITS compiled view of
+  persist's `PostgresBackend` / `SqliteBackend` struct layout → layout skew across
+  versions → memory corruption. The new capsule serializes an `OutboundQueueOp`
+  (one variant per trait method — the full surface), runs it inside persist's
+  `.so` against persist's own compiled backend via a single generic dispatcher,
+  and returns a serialized `OutboundQueueOpResult`. Postgres and Sqlite dispatch
+  **identically** (no backend asymmetry). Gated on at least one backend feature
+  (a backend-less `server`-only build has no concrete queue to hand out); the
+  signer capsule below has no such dependency.
+
+- **`signer_ops_capsule`** (`src/ffi/signer_capsule.rs`, name tag
+  `ciris_persist::signer_ops_v1`) — **SECURITY-CRITICAL**, the highest-stakes
+  capsule in the crate. The pre-audit `keyring_signer_capsule` handed over raw
+  `Arc<dyn HardwareSigner>` + optional `Arc<dyn PqcSigner>` trait objects. A
+  `dyn` vtable's method-slot order is **not ABI-stable** across persist versions,
+  so a consumer built against an older persist could call `.sign()` through a slot
+  index that, in the wheel's vtable, resolves to a DIFFERENT method — or, across
+  the classical (`HardwareSigner`) vs PQC (`PqcSigner`) trait boundary, to the
+  wrong signer/algorithm entirely. Unlike the directory case (which merely hung),
+  a misdispatch here **signs**: it emits bytes computed with the wrong key or
+  under the wrong algorithm (Ed25519 where ML-DSA-65 was intended, or vice versa)
+  that still verify as a valid CIRIS signature — a silent forged-signature /
+  key-confusion bug. The new capsule serializes a `SignerOp`
+  (`Sign` / `PqcSign` / `PublicKey` / `PqcPublicKey` / `KeyId`) and dispatches the
+  exact signer + method INSIDE persist's `.so`, where persist's own code
+  statically maps each op to its trait method — the classical-vs-PQC and
+  method-slot selection can never be skewed by a consumer's stale layout. Results
+  are raw signature / public-key **bytes** (`Vec<u8>`); persist does NOT
+  round-trip `ciris_crypto` types across the ABI, and the consumer receives bytes
+  byte-identical to a direct in-`.so` call. An absent PQC signer is `Ok(None)`
+  inside the `Maybe*` result variants (not an error).
+
+Both capsule ops enums are append-only (same discipline as `DirectoryOp`); each
+carries `OUTBOUND_QUEUE_ABI_VERSION` / `SIGNER_ABI_VERSION` (both `1`) which
+consumers MUST check at capsule-receive time. All `unsafe` is confined to the two
+new modules with per-use safety contracts (directory_capsule audit style);
+`#![deny(unsafe_code)]` is untouched elsewhere. Five outbound types gained
+persist-internal serde derives (`OutboundStatus`, `AbandonedReason`,
+`OutboundFailureOutcome`, `OutboundFilter`, `OutboundRow`) so op args/results
+round-trip. Verify pins stay v8.3.0.
+
 ## [11.6.1] — 2026-07-01
 
 ### Added — #320 audit follow-up: two composite `DirectoryOp`s (verify + delegation graph) close the ABI-stable surface

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.6.1"
+version = "11.7.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -41,6 +41,39 @@ pub mod executor_capsule;
 // current packaging surface is the PyCapsule on PyEngine below.
 pub mod directory_capsule;
 
+// v11.7.0 (CIRISPersist#320 audit follow-up) — two more ABI-stable
+// dispatch capsules closing the remaining raw-Rust-type cross-cdylib
+// surfaces the #320 audit flagged:
+//
+// - `outbound_queue_capsule`: the pre-audit `outbound_queue_capsule`
+//   handed a consumer wheel a raw `BackendDispatch` enum; the consumer
+//   static-dispatched `OutboundQueue` (RPITIT / NOT object-safe) against
+//   ITS view of persist's backend struct layout → layout skew. The
+//   C-ABI serialized-op dispatcher runs the method inside persist's `.so`
+//   against persist's own compiled backend instead.
+//
+// - `signer_capsule` (SECURITY-CRITICAL): the pre-audit
+//   `keyring_signer_capsule` handed over raw `Arc<dyn HardwareSigner>` /
+//   `Arc<dyn PqcSigner>` trait objects; a consumer-side `dyn` vtable-order
+//   skew could dispatch `.sign()` to the wrong method/algorithm → a
+//   silent forged-signature / key-confusion bug. Dispatching inside
+//   persist's `.so` (persist's own vtable) eliminates that.
+//
+// Both reuse `executor_capsule` for the spawn. Same class as #156/#157
+// (cross-tokio), #141 (libsqlite3), and #320 (directory vtable-skew).
+//
+// `outbound_queue_capsule` references `crate::engine::BackendDispatch`,
+// whose variants are gated behind the `postgres`/`sqlite` features; with
+// no backend feature there is no concrete `OutboundQueue` to dispatch to,
+// so the module is gated on at least one backend being present (a
+// backend-less `server`-only build has nothing to hand out). The signer
+// capsule has no backend dependency, so it is available ungated like
+// `directory_capsule`.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub mod outbound_queue_capsule;
+
+pub mod signer_capsule;
+
 #[cfg(feature = "pyo3")]
 pub mod pyo3;
 

--- a/src/ffi/outbound_queue_capsule.rs
+++ b/src/ffi/outbound_queue_capsule.rs
@@ -1,0 +1,988 @@
+// This module's whole point is a C-ABI vtable that crosses the
+// cdylib boundary. Every safety boundary is documented at the
+// call site; the crate-wide #![deny(unsafe_code)] is overridden
+// here because there is no other way to implement an FFI ABI.
+// Audit-visible: every use of `unsafe` in this file is paired
+// with the contract that justifies it. Confined to this module
+// so release-wheel reviewers see one diff that owns the surface.
+#![allow(unsafe_code)]
+
+//! ABI-stable `OutboundQueue` dispatch capsule (CIRISPersist#320 audit).
+//!
+//! # Why this exists
+//!
+//! [`crate::outbound::OutboundQueue`] is a `Send + Sync` trait whose
+//! async methods return `-> impl Future + Send` (RPITIT) — it is
+//! therefore **NOT object-safe** (`Arc<dyn OutboundQueue>` will not
+//! compile). The pre-audit cross-module surface
+//! (`PyEngine::outbound_queue_capsule`) hands a consumer wheel
+//! (CIRISEdge) a raw [`crate::engine::BackendDispatch`] enum through a
+//! `PyCapsule`. The consumer then `match`es the variant and calls
+//! `OutboundQueue` methods on the concrete backend struct — dispatching
+//! **statically**, against the consumer's *own* compiled view of
+//! persist's backend struct layout.
+//!
+//! That is the same structural hazard as the
+//! [`crate::ffi::directory_capsule`] vtable-skew (#320): a Rust type
+//! whose in-memory contract is not guaranteed stable across persist
+//! versions is passed by-value across the static-vs-wheel boundary.
+//! Here it is worse in one dimension — the dispatch is not even through
+//! a `dyn` vtable but through the consumer's monomorphized copy of
+//! persist's `PostgresBackend` / `SqliteBackend` field layout. When
+//! CIRISEdge is built against persist v11.2.0's backend struct and then,
+//! at runtime, receives a `BackendDispatch` produced by a v11.7.0
+//! persist wheel whose struct fields moved, every field access / method
+//! call reinterprets memory at the wrong offset → corruption. Same class
+//! as the cross-tokio aliasing at CIRISPersist#156 (fixed by
+//! [`crate::ffi::executor_capsule`]) and the libsqlite3 cross-cdylib
+//! SIGSEGV at CIRISPersist#141.
+//!
+//! # The fix
+//!
+//! Cross the boundary with a **C-ABI vtable** ([`OutboundQueueVTable`])
+//! and a **uniform serialized bytes-in / bytes-out** op protocol. The
+//! consumer serializes an [`OutboundQueueOp`] (persist-owned,
+//! append-only enum), hands the bytes through
+//! [`OutboundQueueVTable::build_op`], which runs **inside persist's
+//! `.so`**. Persist deserializes the op, matches it to the concrete
+//! `OutboundQueue` method, and calls that method **against persist's own
+//! compiled backend** — the only layout that is guaranteed to match,
+//! because persist built it. Because `OutboundQueue` is not object-safe,
+//! the dispatch matches the [`crate::engine::BackendDispatch`] variant
+//! and calls the concrete backend's method through a single generic
+//! helper ([`dispatch_outbound_op`]) — Postgres and Sqlite behave
+//! identically (no backend asymmetry). The result is serialized to an
+//! [`OutboundQueueOpResult`] and handed back through a callback.
+//!
+//! Every method — regardless of heterogeneous argument/return types —
+//! flows through the one `bytes -> OutboundQueueOp -> dispatch ->
+//! OutboundQueueOpResult -> bytes` path, so there is exactly ONE stable
+//! ABI surface to audit, not one per trait method.
+//!
+//! # Spawn reuse
+//!
+//! `build_op` does not run the future itself; an `OutboundQueue` call is
+//! `async`. It returns a type-erased boxed future
+//! ([`crate::ffi::executor_capsule::TaskOpaque`]) that the consumer
+//! spawns through the EXISTING [`crate::ffi::executor_capsule`] — so the
+//! future is polled by persist's tokio worker pool, and no new
+//! runtime/spawn machinery is introduced here. The two capsules compose:
+//! `outbound_queue_ops_capsule` builds the op-future; `executor_capsule`
+//! spawns it.
+//!
+//! # The contract the consumer MUST honor
+//!
+//! Identical to [`crate::ffi::directory_capsule`]:
+//!
+//! - `result_cb` is invoked **exactly once**, from a persist worker
+//!   thread, with a pointer + length to the serialized
+//!   [`OutboundQueueOpResult`]. The bytes are valid ONLY during the
+//!   callback — the consumer MUST copy them before returning.
+//! - `result_ctx` is an opaque consumer pointer passed back verbatim; it
+//!   MUST remain valid until `result_cb` fires and be safe to use from
+//!   persist's worker thread (`result_cb` + `result_ctx` must be `Send`).
+//! - The spawned future obeys the [`crate::ffi::executor_capsule`]
+//!   tokio-primitive constraint: it must not touch the consumer crate's
+//!   tokio thread-locals. Its only async work is persist's own
+//!   `OutboundQueue` methods, which is always correct.
+//!
+//! # ABI version
+//!
+//! Consumers MUST verify [`OutboundQueueVTable::abi_version`] equals
+//! [`OUTBOUND_QUEUE_ABI_VERSION`] at capsule-receive time. Persist bumps
+//! the version on any breaking change to the vtable layout (NOT on
+//! append-only [`OutboundQueueOp`] growth — see that type's docs).
+//!
+//! # Error flattening
+//!
+//! [`crate::outbound::Error`] is not guaranteed serde-round-trippable,
+//! so every method failure is flattened to
+//! [`OutboundQueueOpResult::Err`]`(String)` carrying `Error::to_string()`.
+//! The consumer maps that back to a generic error on its side.
+
+use std::ffi::c_void;
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::BackendDispatch;
+use crate::outbound::{
+    OutboundFailureOutcome, OutboundFilter, OutboundQueue, OutboundRow, QueueId,
+};
+
+// Reuse the executor capsule's type-erased future pointer + the boxed
+// future shape it already knows how to spawn. The op-future produced
+// here is spawned by the consumer through `executor_capsule`, so the
+// two must agree on the exact boxed-future type.
+use crate::ffi::executor_capsule::TaskOpaque;
+
+/// The boxed-future shape [`crate::ffi::executor_capsule`] spawns. The
+/// pointer returned by [`OutboundQueueVTable::build_op`] is a
+/// `Box<BoxedFut>` cast to `*mut TaskOpaque`, byte-identical to what the
+/// executor capsule's `spawn` reconstructs.
+type BoxedFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// ABI version of [`OutboundQueueVTable`]. Bumped on any breaking change
+/// to the vtable's layout or function-pointer signatures.
+///
+/// INDEPENDENT of [`OutboundQueueOp`]'s wire growth: appending a new
+/// [`OutboundQueueOp`] variant does NOT bump this, because the vtable
+/// signature (`build_op` takes opaque bytes) is unchanged. Consumers
+/// MUST check the field at capsule-receive time:
+///
+/// ```ignore
+/// use ciris_persist::ffi::outbound_queue_capsule::{
+///     OutboundQueueHandle, OUTBOUND_QUEUE_ABI_VERSION,
+/// };
+///
+/// let handle: OutboundQueueHandle = unsafe { /* read from PyCapsule */ };
+/// assert_eq!(
+///     handle.vtable.abi_version,
+///     OUTBOUND_QUEUE_ABI_VERSION,
+///     "persist outbound_queue_ops_capsule ABI version mismatch — pin floor too low"
+/// );
+/// ```
+pub const OUTBOUND_QUEUE_ABI_VERSION: u32 = 1;
+
+/// An [`OutboundQueue`] operation, serialized by the consumer and
+/// dispatched inside persist's `.so`.
+///
+/// # APPEND-ONLY — the ABI depends on it
+///
+/// Same discipline as [`crate::ffi::directory_capsule::DirectoryOp`]:
+/// `serde_json`'s externally-tagged representation keys each variant by
+/// NAME, so the strict rule is auditability, not ordinal stability:
+///
+/// - **New operations MUST be added at the END.** Never insert in the
+///   middle, reorder, remove, rename, or change an existing variant's
+///   field set/types.
+/// - An older consumer never constructs the newer variants; a newer
+///   consumer talking to an older wheel that lacks a variant gets a
+///   clean deserialize failure → the wheel builds an
+///   [`OutboundQueueOpResult::Err`] rather than misdispatching.
+///
+/// Every argument type here derives `serde::{Serialize, Deserialize}`.
+/// One variant per [`OutboundQueue`] trait method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OutboundQueueOp {
+    /// [`OutboundQueue::enqueue_outbound`].
+    EnqueueOutbound {
+        /// Sender peer's `federation_keys.key_id`.
+        sender_key_id: String,
+        /// Destination peer's `federation_keys.key_id`.
+        destination_key_id: String,
+        /// CIRISEdge MessageType discriminant string.
+        message_type: String,
+        /// CIRISEdge wire-format version.
+        edge_schema_version: String,
+        /// Envelope bytes verbatim.
+        envelope_bytes: Vec<u8>,
+        /// Content hash for ACK matching (32 bytes).
+        body_sha256: [u8; 32],
+        /// Length in bytes of `envelope_bytes`.
+        body_size_bytes: i32,
+        /// Whether the message-type policy requires an ACK.
+        requires_ack: bool,
+        /// ACK timeout (required when `requires_ack`).
+        ack_timeout_seconds: Option<i64>,
+        /// Maximum transport attempts before abandon.
+        max_attempts: i32,
+        /// Time-to-live from enqueue.
+        ttl_seconds: i64,
+        /// Earliest time a dispatcher claim is allowed.
+        initial_next_attempt_after: chrono::DateTime<chrono::Utc>,
+    },
+    /// [`OutboundQueue::claim_pending_outbound`].
+    ClaimPendingOutbound {
+        /// Max rows to claim.
+        batch_size: i64,
+        /// Claim lease duration.
+        claim_duration_seconds: i64,
+        /// Worker identifier taking the claim.
+        claimed_by: String,
+    },
+    /// [`OutboundQueue::mark_transport_delivered`].
+    MarkTransportDelivered {
+        /// The claimed row's id.
+        queue_id: QueueId,
+        /// Transport identifier that delivered.
+        transport: String,
+    },
+    /// [`OutboundQueue::mark_transport_failed`].
+    MarkTransportFailed {
+        /// The claimed row's id.
+        queue_id: QueueId,
+        /// Transport error class.
+        error_class: String,
+        /// Transport error detail.
+        error_detail: String,
+        /// Transport identifier that failed.
+        transport: String,
+        /// Caller-supplied backoff target for the next attempt.
+        next_attempt_after: chrono::DateTime<chrono::Utc>,
+    },
+    /// [`OutboundQueue::mark_replay_resolved`].
+    MarkReplayResolved {
+        /// The row whose receiver-side replay reject means delivered.
+        queue_id: QueueId,
+    },
+    /// [`OutboundQueue::match_ack_to_outbound`].
+    MatchAckToOutbound {
+        /// The ACK envelope's `in_reply_to` (= our `body_sha256`).
+        in_reply_to_sha256: [u8; 32],
+    },
+    /// [`OutboundQueue::mark_ack_received`].
+    MarkAckReceived {
+        /// The matched `awaiting_ack` row.
+        queue_id: QueueId,
+        /// Receiver's ACK envelope verbatim.
+        ack_envelope_bytes: Vec<u8>,
+    },
+    /// [`OutboundQueue::sweep_ack_timeouts`].
+    SweepAckTimeouts {},
+    /// [`OutboundQueue::sweep_ttl_expired`].
+    SweepTtlExpired {},
+    /// [`OutboundQueue::sweep_expired_claims`].
+    SweepExpiredClaims {},
+    /// [`OutboundQueue::outbound_status`].
+    OutboundStatusOf {
+        /// The row to look up.
+        queue_id: QueueId,
+    },
+    /// [`OutboundQueue::list_outbound`].
+    ListOutbound {
+        /// Filter (all fields optional, combined with AND).
+        filter: OutboundFilter,
+        /// Page cap.
+        limit: i64,
+    },
+    /// [`OutboundQueue::cancel_outbound`].
+    CancelOutbound {
+        /// The row to operator-cancel.
+        queue_id: QueueId,
+    },
+    /// [`OutboundQueue::replay_abandoned`].
+    ReplayAbandoned {
+        /// The abandoned row to reset to `pending`.
+        queue_id: QueueId,
+    },
+}
+
+/// The mirror of each [`OutboundQueueOp`]'s return, plus the flattened
+/// error.
+///
+/// One `Ok*` variant per return SHAPE — identical shapes share a variant
+/// (all `()` returns collapse to [`OutboundQueueOpResult::Unit`]; the
+/// three `i64`-count sweeps to [`OutboundQueueOpResult::Count`]; the two
+/// `Vec<OutboundRow>` returns to [`OutboundQueueOpResult::Rows`]; the two
+/// `Option<OutboundRow>` returns to [`OutboundQueueOpResult::MaybeRow`]).
+///
+/// Same append-only discipline as [`OutboundQueueOp`].
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OutboundQueueOpResult {
+    /// Any method failure, flattened from `Error::to_string()`. The
+    /// structured [`crate::outbound::Error`] does not cross the ABI.
+    Err(String),
+    /// The `()` returns: `mark_transport_delivered`,
+    /// `mark_replay_resolved`, `mark_ack_received`, `cancel_outbound`,
+    /// `replay_abandoned`.
+    Unit,
+    /// `enqueue_outbound`.
+    Enqueued(QueueId),
+    /// `claim_pending_outbound`, `list_outbound`.
+    Rows(Vec<OutboundRow>),
+    /// `mark_transport_failed`.
+    FailureOutcome(OutboundFailureOutcome),
+    /// `match_ack_to_outbound`, `outbound_status`.
+    MaybeRow(Option<OutboundRow>),
+    /// `sweep_ack_timeouts`, `sweep_ttl_expired`, `sweep_expired_claims`.
+    Count(i64),
+}
+
+/// Run one [`OutboundQueueOp`] against a concrete backend `q` and wrap
+/// the outcome.
+///
+/// Generic over the concrete backend type `Q: OutboundQueue`. Because
+/// `OutboundQueue` is RPITIT / not object-safe, there is no
+/// `&dyn OutboundQueue` — [`dispatch_outbound_op`] selects `Q` by
+/// matching the [`BackendDispatch`] variant, then calls this ONE body.
+/// The body runs INSIDE persist's `.so`, against persist's own compiled
+/// backend method — the whole point of the #320 audit. A method `Err(e)`
+/// flattens to [`OutboundQueueOpResult::Err`]`(e.to_string())`.
+async fn run_outbound_op<Q: OutboundQueue>(q: &Q, op: OutboundQueueOp) -> OutboundQueueOpResult {
+    match op {
+        OutboundQueueOp::EnqueueOutbound {
+            sender_key_id,
+            destination_key_id,
+            message_type,
+            edge_schema_version,
+            envelope_bytes,
+            body_sha256,
+            body_size_bytes,
+            requires_ack,
+            ack_timeout_seconds,
+            max_attempts,
+            ttl_seconds,
+            initial_next_attempt_after,
+        } => match q
+            .enqueue_outbound(
+                &sender_key_id,
+                &destination_key_id,
+                &message_type,
+                &edge_schema_version,
+                &envelope_bytes,
+                &body_sha256,
+                body_size_bytes,
+                requires_ack,
+                ack_timeout_seconds,
+                max_attempts,
+                ttl_seconds,
+                initial_next_attempt_after,
+            )
+            .await
+        {
+            Ok(id) => OutboundQueueOpResult::Enqueued(id),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::ClaimPendingOutbound {
+            batch_size,
+            claim_duration_seconds,
+            claimed_by,
+        } => match q
+            .claim_pending_outbound(batch_size, claim_duration_seconds, &claimed_by)
+            .await
+        {
+            Ok(v) => OutboundQueueOpResult::Rows(v),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::MarkTransportDelivered {
+            queue_id,
+            transport,
+        } => match q.mark_transport_delivered(&queue_id, &transport).await {
+            Ok(()) => OutboundQueueOpResult::Unit,
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::MarkTransportFailed {
+            queue_id,
+            error_class,
+            error_detail,
+            transport,
+            next_attempt_after,
+        } => match q
+            .mark_transport_failed(
+                &queue_id,
+                &error_class,
+                &error_detail,
+                &transport,
+                next_attempt_after,
+            )
+            .await
+        {
+            Ok(o) => OutboundQueueOpResult::FailureOutcome(o),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::MarkReplayResolved { queue_id } => {
+            match q.mark_replay_resolved(&queue_id).await {
+                Ok(()) => OutboundQueueOpResult::Unit,
+                Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+            }
+        }
+        OutboundQueueOp::MatchAckToOutbound { in_reply_to_sha256 } => {
+            match q.match_ack_to_outbound(&in_reply_to_sha256).await {
+                Ok(v) => OutboundQueueOpResult::MaybeRow(v),
+                Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+            }
+        }
+        OutboundQueueOp::MarkAckReceived {
+            queue_id,
+            ack_envelope_bytes,
+        } => match q.mark_ack_received(&queue_id, &ack_envelope_bytes).await {
+            Ok(()) => OutboundQueueOpResult::Unit,
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::SweepAckTimeouts {} => match q.sweep_ack_timeouts().await {
+            Ok(n) => OutboundQueueOpResult::Count(n),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::SweepTtlExpired {} => match q.sweep_ttl_expired().await {
+            Ok(n) => OutboundQueueOpResult::Count(n),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::SweepExpiredClaims {} => match q.sweep_expired_claims().await {
+            Ok(n) => OutboundQueueOpResult::Count(n),
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::OutboundStatusOf { queue_id } => {
+            match q.outbound_status(&queue_id).await {
+                Ok(v) => OutboundQueueOpResult::MaybeRow(v),
+                Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+            }
+        }
+        OutboundQueueOp::ListOutbound { filter, limit } => {
+            match q.list_outbound(filter, limit).await {
+                Ok(v) => OutboundQueueOpResult::Rows(v),
+                Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+            }
+        }
+        OutboundQueueOp::CancelOutbound { queue_id } => match q.cancel_outbound(&queue_id).await {
+            Ok(()) => OutboundQueueOpResult::Unit,
+            Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+        },
+        OutboundQueueOp::ReplayAbandoned { queue_id } => {
+            match q.replay_abandoned(&queue_id).await {
+                Ok(()) => OutboundQueueOpResult::Unit,
+                Err(e) => OutboundQueueOpResult::Err(e.to_string()),
+            }
+        }
+    }
+}
+
+/// Run one [`OutboundQueueOp`] against the concrete backend held by
+/// `dispatch`.
+///
+/// Safe Rust — the body that runs INSIDE persist's `.so`. Both backend
+/// variants call the SAME generic [`run_outbound_op`], so Postgres and
+/// Sqlite behave identically (no backend asymmetry). This is the persist
+/// side of the #320-audit fix: the `OutboundQueue` method resolves
+/// against persist's own compiled backend, never a consumer's skewed
+/// monomorphization.
+pub async fn dispatch_outbound_op(
+    dispatch: &BackendDispatch,
+    op: OutboundQueueOp,
+) -> OutboundQueueOpResult {
+    match dispatch {
+        #[cfg(feature = "postgres")]
+        BackendDispatch::Postgres(b) => run_outbound_op(b.as_ref(), op).await,
+        #[cfg(feature = "sqlite")]
+        BackendDispatch::Sqlite(b) => run_outbound_op(b.as_ref(), op).await,
+    }
+}
+
+/// C-ABI callback the consumer supplies to receive the serialized
+/// [`OutboundQueueOpResult`]. Invoked exactly once, from a persist worker
+/// thread. The `(ptr, len)` bytes are valid ONLY during the call.
+pub type ResultCallback =
+    unsafe extern "C" fn(ctx: *mut c_void, result_ptr: *const u8, result_len: usize);
+
+/// C-ABI function-pointer table for the outbound-queue dispatcher.
+///
+/// `#[repr(C)]`; safe to stash in a static and hand its address across
+/// the cdylib boundary. The function pointers live inside persist's
+/// `.so`, so calling them transfers control into persist — where the
+/// concrete `OutboundQueue` method dispatch uses persist's own compiled
+/// backend.
+#[repr(C)]
+pub struct OutboundQueueVTable {
+    /// ABI version — see [`OUTBOUND_QUEUE_ABI_VERSION`]. Offset 0;
+    /// consumers read it via `&'static OutboundQueueVTable`.
+    pub abi_version: u32,
+    /// Reserved padding for natural 8-byte alignment. MUST be zero in v1.
+    pub _reserved: u32,
+    /// Deserialize the op from `op_ptr/op_len`, build the boxed
+    /// op-future, and return it as a `*mut TaskOpaque` for the consumer
+    /// to spawn via [`crate::ffi::executor_capsule`]. The future, when
+    /// polled, runs the op against the backend and calls
+    /// `result_cb(result_ctx, ...)` once with the serialized
+    /// [`OutboundQueueOpResult`].
+    ///
+    /// On a parse failure the returned future still fires `result_cb`
+    /// once — with a serialized [`OutboundQueueOpResult::Err`] — so the
+    /// consumer's completion path is uniform.
+    ///
+    /// # Safety
+    /// - `data` MUST be a value previously produced by
+    ///   [`build_persist_outbound_queue`] for this same vtable (a
+    ///   `Box::into_raw`'d `Box<BackendDispatch>`). Mismatched `data`
+    ///   ↔ `vtable` pairings are UB.
+    /// - `op_ptr` MUST point at `op_len` initialized, readable bytes for
+    ///   the duration of this call. They are parsed before the call
+    ///   returns; the consumer may free them afterward.
+    /// - `result_cb` + `result_ctx` MUST satisfy the module-level
+    ///   contract: `result_cb` is called exactly once from a persist
+    ///   worker thread, `result_ctx` stays valid until then, and the pair
+    ///   is `Send`.
+    /// - The returned `*mut TaskOpaque` MUST be spawned exactly once
+    ///   through persist's `executor_capsule` (or dropped by
+    ///   reconstructing `Box<Pin<Box<dyn Future<Output=()> + Send>>>`);
+    ///   any other use is UB.
+    pub build_op: unsafe extern "C" fn(
+        data: *mut c_void,
+        op_ptr: *const u8,
+        op_len: usize,
+        result_cb: ResultCallback,
+        result_ctx: *mut c_void,
+    ) -> *mut TaskOpaque,
+    /// Drop the handle — drops the inner [`BackendDispatch`] (and its
+    /// backend `Arc`). Called by the consumer when the capsule is dropped
+    /// (Python GC).
+    ///
+    /// # Safety
+    /// - `data` MUST be a value previously produced by
+    ///   [`build_persist_outbound_queue`] for this same vtable.
+    /// - MUST be called exactly once per capsule. Double-drop is UB.
+    pub drop: unsafe extern "C" fn(data: *mut c_void),
+}
+
+/// The capsule contents — opaque data pointer + vtable.
+///
+/// Consumers receive this via a `PyCapsule` whose pointer (after the
+/// name-tag check) IS a `*mut OutboundQueueHandle`. Treat the fields as
+/// opaque; invoke only through the vtable's function pointers.
+#[repr(C)]
+pub struct OutboundQueueHandle {
+    /// Opaque payload pointer: persist's vtable expects a
+    /// `Box::into_raw`'d `Box<BackendDispatch>`. Boxing gives a thin
+    /// pointer to the (owned) dispatch enum.
+    pub data: *mut c_void,
+    /// Reference to a static vtable inside `ciris_persist.abi3.so`.
+    pub vtable: &'static OutboundQueueVTable,
+}
+
+// SAFETY: `OutboundQueueHandle` is Send+Sync — the underlying
+// `BackendDispatch` is `Send + Sync` (an enum of `Arc<Backend>` where
+// the backends are `Send + Sync`), and the vtable is a 'static
+// reference. Consumers stash the capsule pointer in structures that
+// cross threads; marking these makes the expectation explicit, matching
+// `Directory` / `AsyncExecutor`.
+unsafe impl Send for OutboundQueueHandle {}
+unsafe impl Sync for OutboundQueueHandle {}
+
+/// Persist's outbound-queue vtable instance. Address-stable for the
+/// process lifetime — this is what a consumer's
+/// `OutboundQueueHandle.vtable` targets.
+pub static PERSIST_OUTBOUND_QUEUE_VTABLE: OutboundQueueVTable = OutboundQueueVTable {
+    abi_version: OUTBOUND_QUEUE_ABI_VERSION,
+    _reserved: 0,
+    build_op: persist_outbound_build_op,
+    drop: persist_outbound_drop,
+};
+
+/// Bundles the consumer-supplied completion callback and its opaque
+/// context so the pair can be captured into the boxed op-future (which
+/// persist spawns onto a worker thread). Marked `Send` because the
+/// `build_op` contract requires the consumer's `result_cb` +
+/// `result_ctx` pair to be `Send`.
+struct SendCompletion {
+    cb: ResultCallback,
+    ctx: *mut c_void,
+}
+// SAFETY: the `build_op` contract requires the consumer's
+// `result_cb` + `result_ctx` pair to be `Send` (used exactly once from a
+// persist worker thread). We hold the fn pointer + the raw ctx and hand
+// them back verbatim; we never deref the ctx here.
+unsafe impl Send for SendCompletion {}
+
+/// Implementation of [`OutboundQueueVTable::build_op`].
+///
+/// # Safety
+/// See [`OutboundQueueVTable::build_op`]. MUST be invoked only through
+/// the vtable function pointer, never directly from outside persist's
+/// `.so`.
+unsafe extern "C" fn persist_outbound_build_op(
+    data: *mut c_void,
+    op_ptr: *const u8,
+    op_len: usize,
+    result_cb: ResultCallback,
+    result_ctx: *mut c_void,
+) -> *mut TaskOpaque {
+    // SAFETY: per the vtable contract, `data` is a `Box::into_raw`'d
+    // `Box<BackendDispatch>` owned by the capsule. We borrow it (do NOT
+    // reconstruct the Box — that would drop the capsule's owned value)
+    // and clone the enum, which clones the inner backend `Arc` (bumping
+    // its refcount). The clone is ours to move into the future; the
+    // capsule keeps its own, freed later by `persist_outbound_drop`.
+    let dispatch: BackendDispatch = unsafe {
+        let boxed_ref: &BackendDispatch = &*(data as *const BackendDispatch);
+        boxed_ref.clone()
+    };
+
+    // SAFETY: per the vtable contract, `op_ptr`/`op_len` name `op_len`
+    // readable, initialized bytes valid for the duration of this call.
+    // `serde_json::from_slice` reads them synchronously here; nothing
+    // retains the borrow past this function.
+    let op_bytes: &[u8] = unsafe { std::slice::from_raw_parts(op_ptr, op_len) };
+    let parsed: Result<OutboundQueueOp, String> =
+        serde_json::from_slice::<OutboundQueueOp>(op_bytes).map_err(|e| e.to_string());
+
+    // Capture the consumer callback + context in a Send bundle so the
+    // future (spawned onto persist's worker pool) may hold it.
+    let completion = SendCompletion {
+        cb: result_cb,
+        ctx: result_ctx,
+    };
+
+    let fut: BoxedFut = Box::pin(async move {
+        // Keep the cloned dispatch + completion bundle alive across the
+        // await (owned, moved into the future — never the raw ptr).
+        let dispatch = dispatch;
+        let completion = completion;
+        let result: OutboundQueueOpResult = match parsed {
+            Ok(op) => dispatch_outbound_op(&dispatch, op).await,
+            Err(msg) => OutboundQueueOpResult::Err(format!("outbound op parse failure: {msg}")),
+        };
+        // Serialization of `OutboundQueueOpResult` cannot realistically
+        // fail (owned data, no non-string map keys). If it somehow did,
+        // fall back to a serialized Err so the consumer's completion path
+        // still fires with well-formed bytes.
+        let bytes = serde_json::to_vec(&result).unwrap_or_else(|e| {
+            serde_json::to_vec(&OutboundQueueOpResult::Err(format!(
+                "outbound op result serialize failure: {e}"
+            )))
+            .expect("Err(String) serialization is infallible")
+        });
+        // SAFETY: `completion.cb` + `completion.ctx` (= the consumer's
+        // `result_cb`/`result_ctx`) satisfy the vtable contract: valid,
+        // Send, called exactly once from this worker thread. `bytes`
+        // outlives the synchronous call (dropped only after the callback
+        // returns); the consumer copies before returning.
+        unsafe {
+            (completion.cb)(completion.ctx, bytes.as_ptr(), bytes.len());
+        }
+    });
+
+    // Double-box to a thin pointer, byte-identical to the shape
+    // `executor_capsule::persist_spawn` reconstructs.
+    let wrapped: Box<BoxedFut> = Box::new(fut);
+    Box::into_raw(wrapped) as *mut TaskOpaque
+}
+
+/// Implementation of [`OutboundQueueVTable::drop`].
+///
+/// # Safety
+/// See [`OutboundQueueVTable::drop`]. Single-drop only; double-drop is
+/// UB.
+unsafe extern "C" fn persist_outbound_drop(data: *mut c_void) {
+    // SAFETY: per the vtable contract, `data` was produced by
+    // `Box::into_raw(Box::new(dispatch))` in
+    // `build_persist_outbound_queue`. Reconstruct the Box to drop it (and
+    // the inner backend Arc).
+    let _boxed: Box<BackendDispatch> = unsafe { Box::from_raw(data as *mut BackendDispatch) };
+    // Drop runs here; if this was the last Arc, the backend refcount
+    // decrements on the persist side.
+}
+
+/// Construct an [`OutboundQueueHandle`] backed by `dispatch`. The
+/// returned value is what `outbound_queue_ops_capsule` wraps in a
+/// `PyCapsule`.
+///
+/// The [`BackendDispatch`] is boxed (`Box<BackendDispatch>`) to obtain a
+/// thin `*mut c_void` payload; the vtable's `build_op`/`drop` interpret
+/// `data` accordingly.
+pub fn build_persist_outbound_queue(dispatch: BackendDispatch) -> OutboundQueueHandle {
+    let boxed: Box<BackendDispatch> = Box::new(dispatch);
+    OutboundQueueHandle {
+        data: Box::into_raw(boxed) as *mut c_void,
+        vtable: &PERSIST_OUTBOUND_QUEUE_VTABLE,
+    }
+}
+
+/// Build a `PyCapsule` wrapping a fresh [`OutboundQueueHandle`] backed by
+/// `dispatch`, with a destructor that calls the vtable's `drop` at GC
+/// time (CIRISPersist#320 audit).
+///
+/// Confined to this module because the FFI capsule construction needs
+/// `unsafe` for `PyCapsule::new_with_value_and_destructor` — the same
+/// `#![deny(unsafe_code)]`-override rationale as
+/// [`crate::ffi::directory_capsule::build_capsule_with_destructor`].
+///
+/// The capsule payload pointer is a `Box::into_raw`'d
+/// `Box<OutboundQueueHandle>`. The destructor reconstructs the box and
+/// invokes `vtable.drop(data)` before deallocating the envelope.
+#[cfg(feature = "pyo3")]
+pub fn build_capsule_with_destructor<'py>(
+    py: pyo3::Python<'py>,
+    dispatch: BackendDispatch,
+) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyCapsule>> {
+    use pyo3::types::PyCapsule;
+    let handle = build_persist_outbound_queue(dispatch);
+    let boxed_handle: Box<OutboundQueueHandle> = Box::new(handle);
+    let raw: *mut OutboundQueueHandle = Box::into_raw(boxed_handle);
+    // SAFETY: `raw` was just produced by `Box::into_raw`; PyCapsule calls
+    // the destructor exactly once at GC. The destructor reconstructs the
+    // Box (recovering ownership) before invoking `vtable.drop` on the
+    // inner data pointer.
+    unsafe {
+        PyCapsule::new_with_value_and_destructor(
+            py,
+            raw as usize,
+            c"ciris_persist::outbound_queue_ops_v1",
+            |raw_usize, _ctx| {
+                let raw_ptr = raw_usize as *mut OutboundQueueHandle;
+                if raw_ptr.is_null() {
+                    return;
+                }
+                // SAFETY: `raw_ptr` is the pointer we `Box::into_raw`'d;
+                // the only path into this destructor is PyCapsule's
+                // single-fire GC.
+                let handle: Box<OutboundQueueHandle> = Box::from_raw(raw_ptr);
+                (handle.vtable.drop)(handle.data);
+                // Box deallocates the OutboundQueueHandle envelope here.
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "sqlite")]
+mod tests {
+    use super::*;
+    use crate::federation::types::{algorithm, identity_type, KeyRecord};
+    use crate::federation::{FederationDirectory, SignedKeyRecord};
+    use crate::store::backend::Backend;
+    use crate::store::sqlite::SqliteBackend;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    use ed25519_dalek::SigningKey;
+    use std::sync::mpsc;
+    use std::sync::Arc;
+
+    // ── shared helpers ─────────────────────────────────────────────
+
+    /// A minimal-but-valid `SignedKeyRecord` — the sqlite `put_public_key`
+    /// admission gate requires a real 32-byte Ed25519 pubkey + `hybrid`
+    /// algorithm, but does NOT verify a signature, so a deterministic seed
+    /// suffices to satisfy the `edge_outbound_queue` FK on
+    /// `federation_keys(key_id)`.
+    fn valid_key_record(key_id: &str, seed: u8) -> SignedKeyRecord {
+        let vk = SigningKey::from_bytes(&[seed; 32]).verifying_key();
+        let now = chrono::Utc::now();
+        SignedKeyRecord {
+            record: KeyRecord {
+                key_id: key_id.into(),
+                pubkey_ed25519_base64: B64.encode(vk.to_bytes()),
+                pubkey_ml_dsa_65_base64: None,
+                algorithm: algorithm::HYBRID.into(),
+                identity_type: identity_type::PRIMITIVE.into(),
+                identity_ref: key_id.into(),
+                valid_from: now,
+                valid_until: None,
+                registration_envelope: serde_json::json!({ "id": key_id }),
+                original_content_hash: "deadbeef".into(),
+                scrub_signature_classical: String::new(),
+                scrub_signature_pqc: None,
+                scrub_key_id: key_id.into(),
+                scrub_timestamp: now,
+                pqc_completed_at: None,
+                persist_row_hash: String::new(),
+                roles: Vec::new(),
+                attestation_evidence: None,
+            },
+        }
+    }
+
+    async fn sqlite_dispatch() -> BackendDispatch {
+        let backend = SqliteBackend::open_in_memory()
+            .await
+            .expect("open in-memory sqlite");
+        backend
+            .run_migrations()
+            .await
+            .expect("run migrations (creates edge_outbound_queue)");
+        // Seed the sender + destination federation_keys rows the outbound
+        // FK references (real backends enforce it; SQLite has FKs ON).
+        backend
+            .put_public_key(valid_key_record("sender-1", 1))
+            .await
+            .expect("register sender key");
+        backend
+            .put_public_key(valid_key_record("dest-1", 2))
+            .await
+            .expect("register destination key");
+        BackendDispatch::Sqlite(Arc::new(backend))
+    }
+
+    fn test_runtime() -> Arc<tokio::runtime::Runtime> {
+        Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("build tokio runtime"),
+        )
+    }
+
+    /// Drive one op through the C-ABI against a runtime Arc (the shape
+    /// the executor capsule consumes).
+    fn run_op(
+        rt: &Arc<tokio::runtime::Runtime>,
+        handle: &OutboundQueueHandle,
+        op: &OutboundQueueOp,
+    ) -> OutboundQueueOpResult {
+        let op_bytes = serde_json::to_vec(op).expect("serialize op");
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        let boxed_tx: Box<mpsc::Sender<Vec<u8>>> = Box::new(tx);
+        let ctx: *mut c_void = Box::into_raw(boxed_tx) as *mut c_void;
+
+        unsafe extern "C" fn cb(ctx: *mut c_void, ptr: *const u8, len: usize) {
+            // SAFETY: single-fire boxed Sender; readable (ptr,len) for the call.
+            let tx: Box<mpsc::Sender<Vec<u8>>> =
+                unsafe { Box::from_raw(ctx as *mut mpsc::Sender<Vec<u8>>) };
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+            let _ = tx.send(bytes);
+        }
+
+        // SAFETY: matched data/vtable; readable op bytes; Send valid ctx/cb.
+        let task_ptr = unsafe {
+            (handle.vtable.build_op)(handle.data, op_bytes.as_ptr(), op_bytes.len(), cb, ctx)
+        };
+        let executor = crate::ffi::executor_capsule::build_persist_executor(rt.clone());
+        // SAFETY: task from build_op; matched executor vtable; single spawn.
+        unsafe { (executor.vtable.spawn)(executor.data, task_ptr) };
+        let bytes = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("op result must arrive");
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (executor.vtable.drop)(executor.data) };
+        serde_json::from_slice(&bytes).expect("deserialize OutboundQueueOpResult")
+    }
+
+    #[test]
+    fn abi_version_pinned_at_1() {
+        assert_eq!(OUTBOUND_QUEUE_ABI_VERSION, 1);
+        assert_eq!(PERSIST_OUTBOUND_QUEUE_VTABLE.abi_version, 1);
+    }
+
+    #[test]
+    fn vtable_abi_version_at_offset_zero() {
+        // Consumers read `vtable.abi_version` via
+        // `&'static OutboundQueueVTable`, so the field MUST be at offset 0.
+        let v = &PERSIST_OUTBOUND_QUEUE_VTABLE;
+        let base = v as *const _ as usize;
+        let version_field = &v.abi_version as *const _ as usize;
+        assert_eq!(version_field, base, "abi_version must be at offset 0");
+    }
+
+    #[test]
+    fn enqueue_then_status_round_trips() {
+        let rt = test_runtime();
+        let dispatch = rt.block_on(sqlite_dispatch());
+        let handle = build_persist_outbound_queue(dispatch.clone());
+
+        let now = chrono::Utc::now();
+        let enqueue = OutboundQueueOp::EnqueueOutbound {
+            sender_key_id: "sender-1".into(),
+            destination_key_id: "dest-1".into(),
+            message_type: "AttestationGossip".into(),
+            edge_schema_version: "1.0.0".into(),
+            envelope_bytes: b"hello".to_vec(),
+            body_sha256: [7u8; 32],
+            body_size_bytes: 5,
+            requires_ack: false,
+            ack_timeout_seconds: None,
+            max_attempts: 3,
+            ttl_seconds: 3600,
+            initial_next_attempt_after: now,
+        };
+        let queue_id = match run_op(&rt, &handle, &enqueue) {
+            OutboundQueueOpResult::Enqueued(id) => id,
+            other => panic!("expected Enqueued, got {other:?}"),
+        };
+
+        // OutboundStatusOf via the capsule → MaybeRow(Some(row)).
+        let looked = run_op(
+            &rt,
+            &handle,
+            &OutboundQueueOp::OutboundStatusOf {
+                queue_id: queue_id.clone(),
+            },
+        );
+        let via_capsule = match looked {
+            OutboundQueueOpResult::MaybeRow(v) => v,
+            other => panic!("expected MaybeRow, got {other:?}"),
+        };
+
+        // Assert it matches calling the method directly on the backend.
+        let via_direct = rt
+            .block_on(dispatch_direct_status(&dispatch, &queue_id))
+            .expect("direct status");
+        assert_eq!(
+            via_capsule, via_direct,
+            "capsule result must equal direct call"
+        );
+        let row = via_capsule.expect("row present");
+        assert_eq!(row.queue_id, queue_id);
+        assert_eq!(row.envelope_bytes, b"hello");
+        assert_eq!(row.body_sha256, [7u8; 32]);
+
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (handle.vtable.drop)(handle.data) };
+    }
+
+    /// Direct `outbound_status` on the concrete backend — the ground
+    /// truth the capsule round-trip is compared against.
+    async fn dispatch_direct_status(
+        dispatch: &BackendDispatch,
+        queue_id: &QueueId,
+    ) -> Result<Option<OutboundRow>, crate::outbound::Error> {
+        match dispatch {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.outbound_status(queue_id).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.outbound_status(queue_id).await,
+        }
+    }
+
+    #[test]
+    fn unknown_queue_id_flattens_to_err_variant() {
+        // mark_transport_delivered on a non-existent/non-claimed row
+        // errors on both backends; proves the Err(String) flattening
+        // path across the ABI.
+        let rt = test_runtime();
+        let dispatch = rt.block_on(sqlite_dispatch());
+        let handle = build_persist_outbound_queue(dispatch.clone());
+
+        let res = run_op(
+            &rt,
+            &handle,
+            &OutboundQueueOp::MarkTransportDelivered {
+                queue_id: "no-such-queue-id".into(),
+                transport: "mock".into(),
+            },
+        );
+        assert!(
+            matches!(res, OutboundQueueOpResult::Err(_)),
+            "unknown queue_id ⇒ Err(String), got {res:?}"
+        );
+
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (handle.vtable.drop)(handle.data) };
+    }
+
+    #[test]
+    fn malformed_op_bytes_fire_err_callback() {
+        // A parse failure must STILL fire the callback with a serialized
+        // Err (uniform completion path), never leak the future.
+        let rt = test_runtime();
+        let dispatch = rt.block_on(sqlite_dispatch());
+        let handle = build_persist_outbound_queue(dispatch);
+
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        let ctx: *mut c_void = Box::into_raw(Box::new(tx)) as *mut c_void;
+        unsafe extern "C" fn cb(ctx: *mut c_void, ptr: *const u8, len: usize) {
+            // SAFETY: single-fire boxed Sender; readable (ptr,len).
+            let tx: Box<mpsc::Sender<Vec<u8>>> =
+                unsafe { Box::from_raw(ctx as *mut mpsc::Sender<Vec<u8>>) };
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+            let _ = tx.send(bytes);
+        }
+        let garbage = b"{not valid json";
+        // SAFETY: matched data/vtable; readable bytes; Send valid ctx/cb.
+        let task_ptr = unsafe {
+            (handle.vtable.build_op)(handle.data, garbage.as_ptr(), garbage.len(), cb, ctx)
+        };
+        let executor = crate::ffi::executor_capsule::build_persist_executor(rt.clone());
+        // SAFETY: task from build_op; matched executor vtable; single spawn.
+        unsafe { (executor.vtable.spawn)(executor.data, task_ptr) };
+        let bytes = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("parse-failure callback must still fire");
+        let res: OutboundQueueOpResult = serde_json::from_slice(&bytes).expect("deserialize");
+        assert!(matches!(res, OutboundQueueOpResult::Err(_)), "got {res:?}");
+
+        // SAFETY: single-drop, matched vtables.
+        unsafe { (executor.vtable.drop)(executor.data) };
+        unsafe { (handle.vtable.drop)(handle.data) };
+    }
+}

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -22146,6 +22146,21 @@ impl PyEngine {
     /// pattern the Option-B pub-fn (#95) uses.
     ///
     /// Name tag: `ciris_persist::outbound_queue`.
+    ///
+    /// # Deprecation (v11.7.0, CIRISPersist#320 audit)
+    ///
+    /// Structurally unsound under cdylib cohabitation — this hands the
+    /// consumer a raw `BackendDispatch` whose `OutboundQueue` methods the
+    /// consumer static-dispatches against ITS compiled view of persist's
+    /// `PostgresBackend` / `SqliteBackend` struct layout. When the wheel's
+    /// backend layout has moved relative to the consumer's build, every
+    /// field access / method call reinterprets memory at the wrong offset
+    /// → corruption. Same class as the directory vtable-skew (#320) and
+    /// the cross-tokio deadlock (#156). New consumers MUST migrate to
+    /// [`Self::outbound_queue_ops_capsule_py`]
+    /// (`outbound_queue_ops_capsule`), the ABI-stable C-vtable
+    /// serialized-op surface that dispatches the method INSIDE persist's
+    /// `.so`. Retained for the migration window (CIRISEdge#245 extends).
     #[pyo3(name = "outbound_queue_capsule")]
     fn outbound_queue_capsule_py<'py>(
         &self,
@@ -22161,6 +22176,44 @@ impl PyEngine {
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_capsule: {e}")))
     }
 
+    /// v11.7.0 (CIRISPersist#320 audit) — the ABI-stable replacement for
+    /// [`Self::outbound_queue_capsule_py`]. Returns a `PyCapsule` wrapping
+    /// an
+    /// [`OutboundQueueHandle`](crate::ffi::outbound_queue_capsule::OutboundQueueHandle)
+    /// — a C-ABI vtable + opaque data — instead of a raw `BackendDispatch`.
+    ///
+    /// The consumer never static-dispatches an `OutboundQueue` method
+    /// against persist's backend struct layout. Instead it serializes an
+    /// [`OutboundQueueOp`](crate::ffi::outbound_queue_capsule::OutboundQueueOp),
+    /// calls `vtable.build_op(...)` (which runs inside persist's `.so`, so
+    /// the concrete method dispatch uses persist's own compiled backend),
+    /// spawns the returned future via the `executor_capsule`, and receives
+    /// the serialized
+    /// [`OutboundQueueOpResult`](crate::ffi::outbound_queue_capsule::OutboundQueueOpResult)
+    /// through a callback. Postgres and Sqlite dispatch identically (no
+    /// backend asymmetry). This closes the cross-cdylib layout-skew class
+    /// the #320 audit flagged.
+    ///
+    /// Consumers MUST check `vtable.abi_version ==
+    /// OUTBOUND_QUEUE_ABI_VERSION` at receive time.
+    ///
+    /// Name tag: `ciris_persist::outbound_queue_ops_v1`.
+    #[pyo3(name = "outbound_queue_ops_capsule")]
+    fn outbound_queue_ops_capsule_py<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
+        let dispatch = match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
+        };
+        crate::ffi::outbound_queue_capsule::build_capsule_with_destructor(py, dispatch).map_err(
+            |e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_ops_capsule: {e}")),
+        )
+    }
+
     /// v2.7.0 (CIRISPersist#109) — cross-module accessor for the
     /// federation keyring signer parts. Returns a `PyCapsule` wrapping
     /// the same `KeyringSignerHandle` the Option-B pub-fn (#95)
@@ -22170,6 +22223,26 @@ impl PyEngine {
     /// (docs/COHABITATION.md rule 1).
     ///
     /// Name tag: `ciris_persist::keyring_signer`.
+    ///
+    /// # Deprecation (v11.7.0, CIRISPersist#320 audit) — SECURITY-CRITICAL
+    ///
+    /// Structurally unsound under cdylib cohabitation, with the highest
+    /// stakes of any capsule: this hands the consumer raw
+    /// `Arc<dyn HardwareSigner>` / `Arc<dyn PqcSigner>` trait objects. A
+    /// `dyn` vtable's method-slot order is NOT ABI-stable across persist
+    /// versions, so a consumer built against an older persist can call
+    /// `.sign()` through a slot index that, in the wheel's vtable, points
+    /// at a DIFFERENT method — or, across the classical-vs-PQC trait
+    /// boundary, at the wrong signer/algorithm entirely. The result is a
+    /// signature computed with the wrong key or algorithm that still
+    /// verifies as a valid CIRIS signature: a silent forged-signature /
+    /// key-confusion bug. New consumers MUST migrate to
+    /// [`Self::signer_ops_capsule_py`] (`signer_ops_capsule`), the
+    /// ABI-stable C-vtable serialized-op surface that dispatches the
+    /// exact signer + method INSIDE persist's `.so` (persist's own
+    /// vtable), where the classical-vs-PQC and method-slot selection can
+    /// never be skewed. Retained for the migration window (CIRISEdge#245
+    /// extends).
     #[pyo3(name = "keyring_signer_capsule")]
     fn keyring_signer_capsule_py<'py>(
         &self,
@@ -22182,6 +22255,43 @@ impl PyEngine {
         };
         pyo3::types::PyCapsule::new_with_value(py, handle, c"ciris_persist::keyring_signer")
             .map_err(|e| PyErr::new::<LensQueryError, _>(format!("keyring_signer_capsule: {e}")))
+    }
+
+    /// v11.7.0 (CIRISPersist#320 audit) — the **SECURITY-CRITICAL**
+    /// ABI-stable replacement for [`Self::keyring_signer_capsule_py`].
+    /// Returns a `PyCapsule` wrapping a
+    /// [`Signer`](crate::ffi::signer_capsule::Signer) — a C-ABI vtable +
+    /// opaque data — instead of raw `Arc<dyn HardwareSigner>` /
+    /// `Arc<dyn PqcSigner>` trait objects.
+    ///
+    /// The consumer never calls `.sign()` / `.public_key()` through its
+    /// own (possibly skewed) `dyn` vtable. Instead it serializes a
+    /// [`SignerOp`](crate::ffi::signer_capsule::SignerOp), calls
+    /// `vtable.build_op(...)` (which runs inside persist's `.so`, so the
+    /// classical-vs-PQC signer and the concrete method are selected by
+    /// persist's own statically-resolved code), spawns the returned future
+    /// via the `executor_capsule`, and receives the raw signature /
+    /// public-key **bytes** through a callback as a serialized
+    /// [`SignerOpResult`](crate::ffi::signer_capsule::SignerOpResult).
+    /// This eliminates the wrong-method / wrong-algorithm signing hazard
+    /// the old raw-`dyn` surface carried.
+    ///
+    /// Consumers MUST check `vtable.abi_version == SIGNER_ABI_VERSION` at
+    /// receive time.
+    ///
+    /// Name tag: `ciris_persist::signer_ops_v1`.
+    #[pyo3(name = "signer_ops_capsule")]
+    fn signer_ops_capsule_py<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
+        let handle = crate::signing::KeyringSignerHandle {
+            signer: self.signer.clone(),
+            pqc_signer: self.local_signer.as_ref().and_then(|ls| ls.pqc_signer()),
+            key_id: self.signer_key_id.clone(),
+        };
+        crate::ffi::signer_capsule::build_capsule_with_destructor(py, handle)
+            .map_err(|e| PyErr::new::<LensQueryError, _>(format!("signer_ops_capsule: {e}")))
     }
 
     /// v2.8.0 (CIRISPersist#111) — cross-cdylib accessor for the tokio

--- a/src/ffi/signer_capsule.rs
+++ b/src/ffi/signer_capsule.rs
@@ -1,0 +1,729 @@
+// This module's whole point is a C-ABI vtable that crosses the
+// cdylib boundary. Every safety boundary is documented at the
+// call site; the crate-wide #![deny(unsafe_code)] is overridden
+// here because there is no other way to implement an FFI ABI.
+// Audit-visible: every use of `unsafe` in this file is paired
+// with the contract that justifies it. Confined to this module
+// so release-wheel reviewers see one diff that owns the surface.
+#![allow(unsafe_code)]
+
+//! ABI-stable keyring-signer dispatch capsule — **SECURITY-CRITICAL**
+//! (CIRISPersist#320 audit).
+//!
+//! # Why this exists — and why it is the highest-stakes capsule
+//!
+//! [`crate::signing::KeyringSignerHandle`] carries raw trait objects:
+//! `signer: Arc<dyn ciris_keyring::HardwareSigner>` and
+//! `pqc_signer: Option<Arc<dyn ciris_keyring::PqcSigner>>`. The pre-audit
+//! cross-module surface (`PyEngine::keyring_signer_capsule`) hands a
+//! consumer wheel (CIRISEdge) these `Arc<dyn …>` values by-value through
+//! a `PyCapsule`. The consumer then calls `.sign(...)` / `.public_key()`
+//! on them.
+//!
+//! **A `dyn Trait` vtable is not ABI-stable.** Rust guarantees no stable
+//! slot order for a trait object's method pointers across compiler
+//! versions, crate versions, or builds. When CIRISEdge is compiled
+//! against persist v11.2.0's view of `HardwareSigner` and at runtime
+//! receives an `Arc<dyn HardwareSigner>` produced by a v11.7.0 persist
+//! wheel, the consumer computes the slot index for `sign` using **its
+//! own** statically-resolved vtable layout — but the fat pointer targets
+//! the wheel's vtable, whose slot at that index may be an entirely
+//! different method (e.g. `attestation`, `generate_key`, or
+//! `public_key`).
+//!
+//! For the directory capsule (#320) that class produced a hang. **Here
+//! the failure mode is worse: a misdispatch signs.** If the `sign` slot
+//! index resolves to a different signing method — or, across the classical
+//! (`HardwareSigner`) vs PQC (`PqcSigner`) trait boundary, to the wrong
+//! signer entirely — the process emits a signature computed over the
+//! wrong input, with the wrong key, or under the wrong algorithm
+//! (Ed25519 where ML-DSA-65 was intended, or vice versa). That is a
+//! silent forged-signature / key-confusion bug: bytes that verify as a
+//! valid CIRIS signature but were never authorized as such. Same
+//! structural class as the cross-tokio aliasing at CIRISPersist#156 and
+//! the libsqlite3 cross-cdylib SIGSEGV at CIRISPersist#141 — but with
+//! cryptographic-integrity stakes.
+//!
+//! # The fix
+//!
+//! Cross the boundary with a **C-ABI vtable** ([`SignerVTable`]) and a
+//! **uniform serialized bytes-in / bytes-out** op protocol. The consumer
+//! serializes a [`SignerOp`] (persist-owned, append-only enum), hands the
+//! bytes through [`SignerVTable::build_op`], which runs **inside persist's
+//! `.so`**. Persist deserializes the op and calls the concrete
+//! `HardwareSigner`/`PqcSigner` method **using persist's own compiled
+//! vtable** — the only vtable guaranteed to match the trait object's
+//! layout, because persist built both. Crucially, persist's own code
+//! statically resolves `Sign` → `HardwareSigner::sign` and `PqcSign` →
+//! `PqcSigner::sign`, so the classical-vs-PQC and method-slot selection
+//! can never be skewed by a consumer's stale layout. The result — raw
+//! signature / public-key **bytes** — is serialized to a
+//! [`SignerOpResult`] and handed back through a callback.
+//!
+//! Results are raw `Vec<u8>` — persist does NOT round-trip
+//! `ciris_crypto` signature/pubkey types across the ABI. The consumer
+//! receives the exact signature or public-key bytes the underlying signer
+//! produced, byte-identical to a direct in-`.so` call.
+//!
+//! # Spawn reuse
+//!
+//! `build_op` does not run the future itself; a signer call is `async`
+//! (HSM I/O on hardware paths). It returns a type-erased boxed future
+//! ([`crate::ffi::executor_capsule::TaskOpaque`]) that the consumer
+//! spawns through the EXISTING [`crate::ffi::executor_capsule`] — polled
+//! by persist's tokio worker pool. The two capsules compose:
+//! `signer_ops_capsule` builds the op-future; `executor_capsule` spawns
+//! it.
+//!
+//! # The contract the consumer MUST honor
+//!
+//! Identical to [`crate::ffi::directory_capsule`]:
+//!
+//! - `result_cb` is invoked **exactly once**, from a persist worker
+//!   thread, with a pointer + length to the serialized [`SignerOpResult`].
+//!   The bytes are valid ONLY during the callback — copy before
+//!   returning.
+//! - `result_ctx` is an opaque consumer pointer passed back verbatim; it
+//!   MUST remain valid until `result_cb` fires and be safe to use from
+//!   persist's worker thread (`result_cb` + `result_ctx` must be `Send`).
+//! - The spawned future obeys the [`crate::ffi::executor_capsule`]
+//!   tokio-primitive constraint: it must not touch the consumer crate's
+//!   tokio thread-locals. Its only async work is persist's own signer
+//!   methods, which is always correct.
+//!
+//! # ABI version
+//!
+//! Consumers MUST verify [`SignerVTable::abi_version`] equals
+//! [`SIGNER_ABI_VERSION`] at capsule-receive time. Persist bumps the
+//! version on any breaking change to the vtable layout (NOT on
+//! append-only [`SignerOp`] growth — see that type's docs).
+//!
+//! # Error flattening
+//!
+//! `ciris_keyring::KeyringError` is not guaranteed serde-round-trippable,
+//! so every signer failure is flattened to [`SignerOpResult::Err`]`(String)`
+//! carrying the error string. Absence of a PQC signer is NOT an error: it
+//! is represented as `Ok(None)` inside the PQC result variants (see
+//! [`SignerOp::PqcSign`] / [`SignerOp::PqcPublicKey`]).
+
+use std::ffi::c_void;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::signing::KeyringSignerHandle;
+use ciris_keyring::{HardwareSigner, PqcSigner};
+
+// Reuse the executor capsule's type-erased future pointer + the boxed
+// future shape it already knows how to spawn.
+use crate::ffi::executor_capsule::TaskOpaque;
+
+/// The boxed-future shape [`crate::ffi::executor_capsule`] spawns. The
+/// pointer returned by [`SignerVTable::build_op`] is a `Box<BoxedFut>`
+/// cast to `*mut TaskOpaque`, byte-identical to what the executor
+/// capsule's `spawn` reconstructs.
+type BoxedFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// ABI version of [`SignerVTable`]. Bumped on any breaking change to the
+/// vtable's layout or function-pointer signatures.
+///
+/// INDEPENDENT of [`SignerOp`]'s wire growth: appending a new
+/// [`SignerOp`] variant does NOT bump this. Consumers MUST check the
+/// field at capsule-receive time:
+///
+/// ```ignore
+/// use ciris_persist::ffi::signer_capsule::{Signer, SIGNER_ABI_VERSION};
+///
+/// let signer: Signer = unsafe { /* read from PyCapsule */ };
+/// assert_eq!(
+///     signer.vtable.abi_version,
+///     SIGNER_ABI_VERSION,
+///     "persist signer_ops_capsule ABI version mismatch — pin floor too low"
+/// );
+/// ```
+pub const SIGNER_ABI_VERSION: u32 = 1;
+
+/// A keyring-signer operation, serialized by the consumer and dispatched
+/// inside persist's `.so`.
+///
+/// # APPEND-ONLY — the ABI depends on it
+///
+/// Same discipline as [`crate::ffi::directory_capsule::DirectoryOp`]:
+///
+/// - **New operations MUST be added at the END.** Never insert in the
+///   middle, reorder, remove, rename, or change an existing variant's
+///   field set/types.
+/// - An older consumer never constructs the newer variants; a newer
+///   consumer talking to an older wheel that lacks a variant gets a clean
+///   deserialize failure → the wheel builds a [`SignerOpResult::Err`]
+///   rather than misdispatching.
+///
+/// The op NAME selects the signer + method **inside persist's `.so`**,
+/// where the classical-vs-PQC selection and the method-slot resolution
+/// are persist's own — never a consumer's skewed vtable layout. This is
+/// the property that makes wrong-algorithm signing impossible.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SignerOp {
+    /// Classical Ed25519 sign: `signer.sign(data).await`. Result:
+    /// [`SignerOpResult::Signature`] (64-byte Ed25519 signature bytes).
+    Sign {
+        /// The bytes to sign.
+        data: Vec<u8>,
+    },
+    /// PQC ML-DSA-65 sign: `pqc_signer.sign(data).await`. Result:
+    /// [`SignerOpResult::MaybeSignature`] — `Some(sig)` (3309-byte
+    /// ML-DSA-65 signature bytes) when a PQC signer is configured, `None`
+    /// when it is absent.
+    PqcSign {
+        /// The bytes to sign.
+        data: Vec<u8>,
+    },
+    /// Classical public key: `signer.public_key().await`. Result:
+    /// [`SignerOpResult::PublicKey`] (32-byte Ed25519 public key bytes).
+    PublicKey {},
+    /// PQC public key: `pqc_signer.public_key().await`. Result:
+    /// [`SignerOpResult::MaybePublicKey`] — `Some(pk)` (1952-byte
+    /// ML-DSA-65 public key bytes) when configured, `None` when absent.
+    PqcPublicKey {},
+    /// The signer's stable key id. Result: [`SignerOpResult::KeyId`].
+    KeyId {},
+}
+
+/// The mirror of each [`SignerOp`]'s return, plus the flattened error.
+///
+/// Results are raw bytes — persist does NOT round-trip `ciris_crypto`
+/// signature/pubkey types across the ABI. Same append-only discipline as
+/// [`SignerOp`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SignerOpResult {
+    /// Any signer failure, flattened from the keyring error string. The
+    /// structured `ciris_keyring::KeyringError` does not cross the ABI.
+    Err(String),
+    /// `Sign` — classical Ed25519 signature bytes.
+    Signature(Vec<u8>),
+    /// `PqcSign` — ML-DSA-65 signature bytes, or `None` if the host has
+    /// no PQC signer configured (NOT an error).
+    MaybeSignature(Option<Vec<u8>>),
+    /// `PublicKey` — classical Ed25519 public key bytes.
+    PublicKey(Vec<u8>),
+    /// `PqcPublicKey` — ML-DSA-65 public key bytes, or `None` if the host
+    /// has no PQC signer configured (NOT an error).
+    MaybePublicKey(Option<Vec<u8>>),
+    /// `KeyId` — the signer's stable identifier.
+    KeyId(String),
+}
+
+/// Run one [`SignerOp`] against `handle` and wrap the outcome.
+///
+/// Safe Rust — the body that runs INSIDE persist's `.so`, so every
+/// `handle.signer.sign(...)` / `handle.pqc_signer.…` call resolves
+/// through persist's own compiled `HardwareSigner`/`PqcSigner` vtable
+/// (the whole point of the #320 audit). Because persist's own code
+/// statically maps each op variant to the exact trait method, the
+/// classical-vs-PQC signer and the method slot can never be confused by a
+/// consumer's stale layout. A method `Err(e)` flattens to
+/// [`SignerOpResult::Err`]; an absent PQC signer flattens to `Ok(None)`.
+pub async fn dispatch_signer_op(handle: &KeyringSignerHandle, op: SignerOp) -> SignerOpResult {
+    match op {
+        SignerOp::Sign { data } => match handle.signer.sign(&data).await {
+            Ok(sig) => SignerOpResult::Signature(sig),
+            Err(e) => SignerOpResult::Err(e.to_string()),
+        },
+        SignerOp::PqcSign { data } => match handle.pqc_signer.as_ref() {
+            Some(pqc) => match pqc.sign(&data).await {
+                Ok(sig) => SignerOpResult::MaybeSignature(Some(sig)),
+                Err(e) => SignerOpResult::Err(e.to_string()),
+            },
+            None => SignerOpResult::MaybeSignature(None),
+        },
+        SignerOp::PublicKey {} => match handle.signer.public_key().await {
+            Ok(pk) => SignerOpResult::PublicKey(pk),
+            Err(e) => SignerOpResult::Err(e.to_string()),
+        },
+        SignerOp::PqcPublicKey {} => match handle.pqc_signer.as_ref() {
+            Some(pqc) => match pqc.public_key().await {
+                Ok(pk) => SignerOpResult::MaybePublicKey(Some(pk)),
+                Err(e) => SignerOpResult::Err(e.to_string()),
+            },
+            None => SignerOpResult::MaybePublicKey(None),
+        },
+        SignerOp::KeyId {} => SignerOpResult::KeyId(handle.key_id.clone()),
+    }
+}
+
+/// C-ABI callback the consumer supplies to receive the serialized
+/// [`SignerOpResult`]. Invoked exactly once, from a persist worker
+/// thread. The `(ptr, len)` bytes are valid ONLY during the call.
+pub type ResultCallback =
+    unsafe extern "C" fn(ctx: *mut c_void, result_ptr: *const u8, result_len: usize);
+
+/// C-ABI function-pointer table for the keyring-signer dispatcher.
+///
+/// `#[repr(C)]`; safe to stash in a static and hand its address across
+/// the cdylib boundary. The function pointers live inside persist's
+/// `.so`, so calling them transfers control into persist — where the
+/// concrete signer method dispatch uses persist's own (matching) vtable.
+#[repr(C)]
+pub struct SignerVTable {
+    /// ABI version — see [`SIGNER_ABI_VERSION`]. Offset 0; consumers read
+    /// it via `&'static SignerVTable`.
+    pub abi_version: u32,
+    /// Reserved padding for natural 8-byte alignment. MUST be zero in v1.
+    pub _reserved: u32,
+    /// Deserialize the op from `op_ptr/op_len`, build the boxed op-future,
+    /// and return it as a `*mut TaskOpaque` for the consumer to spawn via
+    /// [`crate::ffi::executor_capsule`]. The future, when polled, runs the
+    /// signer op and calls `result_cb(result_ctx, ...)` once with the
+    /// serialized [`SignerOpResult`].
+    ///
+    /// On a parse failure the returned future still fires `result_cb`
+    /// once — with a serialized [`SignerOpResult::Err`] — so the
+    /// consumer's completion path is uniform.
+    ///
+    /// # Safety
+    /// - `data` MUST be a value previously produced by
+    ///   [`build_persist_signer`] for this same vtable (a
+    ///   `Box::into_raw`'d `Box<KeyringSignerHandle>`). Mismatched `data`
+    ///   ↔ `vtable` pairings are UB.
+    /// - `op_ptr` MUST point at `op_len` initialized, readable bytes for
+    ///   the duration of this call. They are parsed before the call
+    ///   returns; the consumer may free them afterward.
+    /// - `result_cb` + `result_ctx` MUST satisfy the module-level
+    ///   contract: `result_cb` is called exactly once from a persist
+    ///   worker thread, `result_ctx` stays valid until then, and the pair
+    ///   is `Send`.
+    /// - The returned `*mut TaskOpaque` MUST be spawned exactly once
+    ///   through persist's `executor_capsule` (or dropped by
+    ///   reconstructing `Box<Pin<Box<dyn Future<Output=()> + Send>>>`);
+    ///   any other use is UB.
+    pub build_op: unsafe extern "C" fn(
+        data: *mut c_void,
+        op_ptr: *const u8,
+        op_len: usize,
+        result_cb: ResultCallback,
+        result_ctx: *mut c_void,
+    ) -> *mut TaskOpaque,
+    /// Drop the signer handle — drops the inner `Arc<dyn HardwareSigner>`
+    /// (and the optional `Arc<dyn PqcSigner>`). Called by the consumer
+    /// when the capsule is dropped (Python GC).
+    ///
+    /// # Safety
+    /// - `data` MUST be a value previously produced by
+    ///   [`build_persist_signer`] for this same vtable.
+    /// - MUST be called exactly once per capsule. Double-drop is UB.
+    pub drop: unsafe extern "C" fn(data: *mut c_void),
+}
+
+/// The capsule contents — opaque data pointer + vtable.
+///
+/// Consumers receive this via a `PyCapsule` whose pointer (after the
+/// name-tag check) IS a `*mut Signer`. Treat the fields as opaque; invoke
+/// only through the vtable's function pointers.
+#[repr(C)]
+pub struct Signer {
+    /// Opaque payload pointer: persist's vtable expects a
+    /// `Box::into_raw`'d `Box<KeyringSignerHandle>`. Boxing the handle
+    /// gives a thin `*mut c_void` to the struct (whose `Arc<dyn …>`
+    /// fields are themselves fat pointers).
+    pub data: *mut c_void,
+    /// Reference to a static vtable inside `ciris_persist.abi3.so`.
+    pub vtable: &'static SignerVTable,
+}
+
+// SAFETY: `Signer` is Send+Sync — the underlying `KeyringSignerHandle`
+// holds `Arc<dyn HardwareSigner>` / `Arc<dyn PqcSigner>`, both traits
+// `Send + Sync`, so the Arcs are `Send + Sync`; the vtable is a 'static
+// reference. Consumers stash the capsule pointer in structures that cross
+// threads; marking these makes the expectation explicit, matching
+// `Directory` / `AsyncExecutor`.
+unsafe impl Send for Signer {}
+unsafe impl Sync for Signer {}
+
+/// Persist's signer vtable instance. Address-stable for the process
+/// lifetime — this is what a consumer's `Signer.vtable` targets.
+pub static PERSIST_SIGNER_VTABLE: SignerVTable = SignerVTable {
+    abi_version: SIGNER_ABI_VERSION,
+    _reserved: 0,
+    build_op: persist_signer_build_op,
+    drop: persist_signer_drop,
+};
+
+/// Bundles the consumer-supplied completion callback and its opaque
+/// context so the pair can be captured into the boxed op-future. Marked
+/// `Send` because the `build_op` contract requires the consumer's
+/// `result_cb` + `result_ctx` pair to be `Send`.
+struct SendCompletion {
+    cb: ResultCallback,
+    ctx: *mut c_void,
+}
+// SAFETY: the `build_op` contract requires the consumer's
+// `result_cb` + `result_ctx` pair to be `Send` (used exactly once from a
+// persist worker thread). We hold the fn pointer + the raw ctx and hand
+// them back verbatim; we never deref the ctx here.
+unsafe impl Send for SendCompletion {}
+
+/// Implementation of [`SignerVTable::build_op`].
+///
+/// # Safety
+/// See [`SignerVTable::build_op`]. MUST be invoked only through the vtable
+/// function pointer, never directly from outside persist's `.so`.
+unsafe extern "C" fn persist_signer_build_op(
+    data: *mut c_void,
+    op_ptr: *const u8,
+    op_len: usize,
+    result_cb: ResultCallback,
+    result_ctx: *mut c_void,
+) -> *mut TaskOpaque {
+    // SAFETY: per the vtable contract, `data` is a `Box::into_raw`'d
+    // `Box<KeyringSignerHandle>` owned by the capsule. We borrow it (do
+    // NOT reconstruct the Box — that would drop the capsule's owned
+    // value) and clone the signer `Arc`s + key_id into a fresh owned
+    // handle, bumping the Arc refcounts. The clone is ours to move into
+    // the future; the capsule keeps its own, freed later by
+    // `persist_signer_drop`.
+    let handle: KeyringSignerHandle = unsafe {
+        let borrowed: &KeyringSignerHandle = &*(data as *const KeyringSignerHandle);
+        let signer: Arc<dyn HardwareSigner> = borrowed.signer.clone();
+        let pqc_signer: Option<Arc<dyn PqcSigner>> = borrowed.pqc_signer.clone();
+        let key_id: String = borrowed.key_id.clone();
+        KeyringSignerHandle {
+            signer,
+            pqc_signer,
+            key_id,
+        }
+    };
+
+    // SAFETY: per the vtable contract, `op_ptr`/`op_len` name `op_len`
+    // readable, initialized bytes valid for the duration of this call.
+    // `serde_json::from_slice` reads them synchronously here; nothing
+    // retains the borrow past this function.
+    let op_bytes: &[u8] = unsafe { std::slice::from_raw_parts(op_ptr, op_len) };
+    let parsed: Result<SignerOp, String> =
+        serde_json::from_slice::<SignerOp>(op_bytes).map_err(|e| e.to_string());
+
+    // Capture the consumer callback + context in a Send bundle so the
+    // future (spawned onto persist's worker pool) may hold it.
+    let completion = SendCompletion {
+        cb: result_cb,
+        ctx: result_ctx,
+    };
+
+    let fut: BoxedFut = Box::pin(async move {
+        // Keep the cloned handle + completion bundle alive across the
+        // await (owned, moved into the future — never the raw ptr).
+        let handle = handle;
+        let completion = completion;
+        let result: SignerOpResult = match parsed {
+            Ok(op) => dispatch_signer_op(&handle, op).await,
+            Err(msg) => SignerOpResult::Err(format!("signer op parse failure: {msg}")),
+        };
+        // Serialization of `SignerOpResult` cannot realistically fail
+        // (owned bytes/strings). If it somehow did, fall back to a
+        // serialized Err so the consumer's completion path still fires
+        // with well-formed bytes.
+        let bytes = serde_json::to_vec(&result).unwrap_or_else(|e| {
+            serde_json::to_vec(&SignerOpResult::Err(format!(
+                "signer op result serialize failure: {e}"
+            )))
+            .expect("Err(String) serialization is infallible")
+        });
+        // SAFETY: `completion.cb` + `completion.ctx` (= the consumer's
+        // `result_cb`/`result_ctx`) satisfy the vtable contract: valid,
+        // Send, called exactly once from this worker thread. `bytes`
+        // outlives the synchronous call (dropped only after the callback
+        // returns); the consumer copies before returning.
+        unsafe {
+            (completion.cb)(completion.ctx, bytes.as_ptr(), bytes.len());
+        }
+    });
+
+    // Double-box to a thin pointer, byte-identical to the shape
+    // `executor_capsule::persist_spawn` reconstructs.
+    let wrapped: Box<BoxedFut> = Box::new(fut);
+    Box::into_raw(wrapped) as *mut TaskOpaque
+}
+
+/// Implementation of [`SignerVTable::drop`].
+///
+/// # Safety
+/// See [`SignerVTable::drop`]. Single-drop only; double-drop is UB.
+unsafe extern "C" fn persist_signer_drop(data: *mut c_void) {
+    // SAFETY: per the vtable contract, `data` was produced by
+    // `Box::into_raw(Box::new(handle))` in `build_persist_signer`.
+    // Reconstruct the Box to drop it (and the inner signer Arcs).
+    let _boxed: Box<KeyringSignerHandle> =
+        unsafe { Box::from_raw(data as *mut KeyringSignerHandle) };
+    // Drop runs here; if these were the last Arcs, the signer refcounts
+    // decrement on the persist side.
+}
+
+/// Construct a [`Signer`] backed by `handle`. The returned value is what
+/// `signer_ops_capsule` wraps in a `PyCapsule`.
+///
+/// The [`KeyringSignerHandle`] is boxed (`Box<KeyringSignerHandle>`) to
+/// obtain a thin `*mut c_void` payload; the vtable's `build_op`/`drop`
+/// interpret `data` accordingly.
+pub fn build_persist_signer(handle: KeyringSignerHandle) -> Signer {
+    let boxed: Box<KeyringSignerHandle> = Box::new(handle);
+    Signer {
+        data: Box::into_raw(boxed) as *mut c_void,
+        vtable: &PERSIST_SIGNER_VTABLE,
+    }
+}
+
+/// Build a `PyCapsule` wrapping a fresh [`Signer`] backed by `handle`,
+/// with a destructor that calls the vtable's `drop` at GC time
+/// (CIRISPersist#320 audit).
+///
+/// Confined to this module because the FFI capsule construction needs
+/// `unsafe` for `PyCapsule::new_with_value_and_destructor` — the same
+/// `#![deny(unsafe_code)]`-override rationale as
+/// [`crate::ffi::directory_capsule::build_capsule_with_destructor`].
+///
+/// The capsule payload pointer is a `Box::into_raw`'d `Box<Signer>`. The
+/// destructor reconstructs the box and invokes `vtable.drop(data)` before
+/// deallocating the envelope.
+#[cfg(feature = "pyo3")]
+pub fn build_capsule_with_destructor<'py>(
+    py: pyo3::Python<'py>,
+    handle: KeyringSignerHandle,
+) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::types::PyCapsule>> {
+    use pyo3::types::PyCapsule;
+    let signer = build_persist_signer(handle);
+    let boxed_signer: Box<Signer> = Box::new(signer);
+    let raw: *mut Signer = Box::into_raw(boxed_signer);
+    // SAFETY: `raw` was just produced by `Box::into_raw`; PyCapsule calls
+    // the destructor exactly once at GC. The destructor reconstructs the
+    // Box (recovering ownership) before invoking `vtable.drop` on the
+    // inner data pointer.
+    unsafe {
+        PyCapsule::new_with_value_and_destructor(
+            py,
+            raw as usize,
+            c"ciris_persist::signer_ops_v1",
+            |raw_usize, _ctx| {
+                let raw_ptr = raw_usize as *mut Signer;
+                if raw_ptr.is_null() {
+                    return;
+                }
+                // SAFETY: `raw_ptr` is the pointer we `Box::into_raw`'d;
+                // the only path into this destructor is PyCapsule's
+                // single-fire GC.
+                let signer: Box<Signer> = Box::from_raw(raw_ptr);
+                (signer.vtable.drop)(signer.data);
+                // Box deallocates the Signer envelope here.
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signing::{LocalSigner, LocalSignerHardwareAdapter};
+    use ed25519_dalek::SigningKey;
+    use std::sync::mpsc;
+
+    // ── shared helpers ─────────────────────────────────────────────
+
+    /// A software Ed25519-only signer handle (no PQC), plus the raw seed
+    /// so tests can reproduce the direct signature.
+    fn ed25519_handle(seed: [u8; 32]) -> KeyringSignerHandle {
+        let local = Arc::new(LocalSigner::from_parts(
+            SigningKey::from_bytes(&seed),
+            "signer-test".into(),
+            None,
+            None,
+        ));
+        let signer: Arc<dyn HardwareSigner> = Arc::new(LocalSignerHardwareAdapter::new(local));
+        KeyringSignerHandle {
+            signer,
+            pqc_signer: None,
+            key_id: "signer-test".into(),
+        }
+    }
+
+    fn test_runtime() -> Arc<tokio::runtime::Runtime> {
+        Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .expect("build tokio runtime"),
+        )
+    }
+
+    /// Drive one op through the C-ABI against a runtime Arc (the shape
+    /// the executor capsule consumes).
+    fn run_op(rt: &Arc<tokio::runtime::Runtime>, signer: &Signer, op: &SignerOp) -> SignerOpResult {
+        let op_bytes = serde_json::to_vec(op).expect("serialize op");
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        let boxed_tx: Box<mpsc::Sender<Vec<u8>>> = Box::new(tx);
+        let ctx: *mut c_void = Box::into_raw(boxed_tx) as *mut c_void;
+
+        unsafe extern "C" fn cb(ctx: *mut c_void, ptr: *const u8, len: usize) {
+            // SAFETY: single-fire boxed Sender; readable (ptr,len) for the call.
+            let tx: Box<mpsc::Sender<Vec<u8>>> =
+                unsafe { Box::from_raw(ctx as *mut mpsc::Sender<Vec<u8>>) };
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+            let _ = tx.send(bytes);
+        }
+
+        // SAFETY: matched data/vtable; readable op bytes; Send valid ctx/cb.
+        let task_ptr = unsafe {
+            (signer.vtable.build_op)(signer.data, op_bytes.as_ptr(), op_bytes.len(), cb, ctx)
+        };
+        let executor = crate::ffi::executor_capsule::build_persist_executor(rt.clone());
+        // SAFETY: task from build_op; matched executor vtable; single spawn.
+        unsafe { (executor.vtable.spawn)(executor.data, task_ptr) };
+        let bytes = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("op result must arrive");
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (executor.vtable.drop)(executor.data) };
+        serde_json::from_slice(&bytes).expect("deserialize SignerOpResult")
+    }
+
+    #[test]
+    fn abi_version_pinned_at_1() {
+        assert_eq!(SIGNER_ABI_VERSION, 1);
+        assert_eq!(PERSIST_SIGNER_VTABLE.abi_version, 1);
+    }
+
+    #[test]
+    fn vtable_abi_version_at_offset_zero() {
+        // Consumers read `vtable.abi_version` via `&'static SignerVTable`,
+        // so the field MUST be at offset 0.
+        let v = &PERSIST_SIGNER_VTABLE;
+        let base = v as *const _ as usize;
+        let version_field = &v.abi_version as *const _ as usize;
+        assert_eq!(version_field, base, "abi_version must be at offset 0");
+    }
+
+    #[test]
+    fn sign_round_trips_byte_identical_to_direct() {
+        // SECURITY-CRITICAL round-trip: the capsule signature bytes MUST
+        // equal a direct `signer.sign` call — proving the sign ran in
+        // persist's `.so` against persist's own vtable (no algorithm/slot
+        // skew). Ed25519 is deterministic, so bytes are exactly equal.
+        let rt = test_runtime();
+        let handle = ed25519_handle([0x11u8; 32]);
+        // Keep a direct clone of the signer Arc for the ground-truth call.
+        let direct_signer: Arc<dyn HardwareSigner> = handle.signer.clone();
+        let signer = build_persist_signer(handle);
+
+        let msg = b"security-critical-sign".to_vec();
+        let res = run_op(&rt, &signer, &SignerOp::Sign { data: msg.clone() });
+        let via_capsule = match res {
+            SignerOpResult::Signature(sig) => sig,
+            other => panic!("expected Signature, got {other:?}"),
+        };
+        let via_direct = rt.block_on(direct_signer.sign(&msg)).expect("direct sign");
+        assert_eq!(
+            via_capsule, via_direct,
+            "capsule signature bytes must equal direct signer.sign bytes"
+        );
+        assert_eq!(via_capsule.len(), 64, "Ed25519 signature is 64 bytes");
+
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (signer.vtable.drop)(signer.data) };
+    }
+
+    #[test]
+    fn public_key_round_trips() {
+        let rt = test_runtime();
+        let handle = ed25519_handle([0x22u8; 32]);
+        let direct_signer: Arc<dyn HardwareSigner> = handle.signer.clone();
+        let signer = build_persist_signer(handle);
+
+        let res = run_op(&rt, &signer, &SignerOp::PublicKey {});
+        let via_capsule = match res {
+            SignerOpResult::PublicKey(pk) => pk,
+            other => panic!("expected PublicKey, got {other:?}"),
+        };
+        let via_direct = rt
+            .block_on(direct_signer.public_key())
+            .expect("direct public_key");
+        assert_eq!(via_capsule, via_direct);
+        assert_eq!(via_capsule.len(), 32, "Ed25519 public key is 32 bytes");
+
+        // And the key id round-trips too.
+        let key_id = run_op(&rt, &signer, &SignerOp::KeyId {});
+        assert!(
+            matches!(key_id, SignerOpResult::KeyId(ref s) if s == "signer-test"),
+            "got {key_id:?}"
+        );
+
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (signer.vtable.drop)(signer.data) };
+    }
+
+    #[test]
+    fn absent_pqc_returns_none_not_err() {
+        // The Ed25519-only handle has no PQC signer; PqcSign / PqcPublicKey
+        // MUST return Ok(None) inside the Maybe* variants — NOT a
+        // top-level Err (absence is a legitimate config, not a failure).
+        let rt = test_runtime();
+        let handle = ed25519_handle([0x33u8; 32]);
+        let signer = build_persist_signer(handle);
+
+        let sign = run_op(
+            &rt,
+            &signer,
+            &SignerOp::PqcSign {
+                data: b"whatever".to_vec(),
+            },
+        );
+        assert!(
+            matches!(sign, SignerOpResult::MaybeSignature(None)),
+            "absent PQC signer ⇒ MaybeSignature(None), got {sign:?}"
+        );
+
+        let pk = run_op(&rt, &signer, &SignerOp::PqcPublicKey {});
+        assert!(
+            matches!(pk, SignerOpResult::MaybePublicKey(None)),
+            "absent PQC signer ⇒ MaybePublicKey(None), got {pk:?}"
+        );
+
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (signer.vtable.drop)(signer.data) };
+    }
+
+    #[test]
+    fn malformed_op_bytes_fire_err_callback() {
+        // A parse failure must STILL fire the callback with a serialized
+        // Err (uniform completion path), never leak the future.
+        let rt = test_runtime();
+        let handle = ed25519_handle([0x44u8; 32]);
+        let signer = build_persist_signer(handle);
+
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        let ctx: *mut c_void = Box::into_raw(Box::new(tx)) as *mut c_void;
+        unsafe extern "C" fn cb(ctx: *mut c_void, ptr: *const u8, len: usize) {
+            // SAFETY: single-fire boxed Sender; readable (ptr,len).
+            let tx: Box<mpsc::Sender<Vec<u8>>> =
+                unsafe { Box::from_raw(ctx as *mut mpsc::Sender<Vec<u8>>) };
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+            let _ = tx.send(bytes);
+        }
+        let garbage = b"{not valid json";
+        // SAFETY: matched data/vtable; readable bytes; Send valid ctx/cb.
+        let task_ptr = unsafe {
+            (signer.vtable.build_op)(signer.data, garbage.as_ptr(), garbage.len(), cb, ctx)
+        };
+        let executor = crate::ffi::executor_capsule::build_persist_executor(rt.clone());
+        // SAFETY: task from build_op; matched executor vtable; single spawn.
+        unsafe { (executor.vtable.spawn)(executor.data, task_ptr) };
+        let bytes = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("parse-failure callback must still fire");
+        let res: SignerOpResult = serde_json::from_slice(&bytes).expect("deserialize");
+        assert!(matches!(res, SignerOpResult::Err(_)), "got {res:?}");
+
+        // SAFETY: single-drop, matched vtables.
+        unsafe { (executor.vtable.drop)(executor.data) };
+        unsafe { (signer.vtable.drop)(signer.data) };
+    }
+}

--- a/src/outbound/types.rs
+++ b/src/outbound/types.rs
@@ -1,6 +1,13 @@
 //! Outbound queue row + filter shapes (CIRISPersist#16).
 
 use chrono::{DateTime, Utc};
+// v11.7.0 (CIRISPersist#320 audit) — these types cross the ABI-stable
+// `outbound_queue_ops_capsule` boundary as serialized op args/results
+// (`src/ffi/outbound_queue_capsule.rs`). They are serialized inside
+// persist's `.so` and deserialized by the same persist code on the way
+// back, so the derives are a persist-internal wire contract, not a
+// cross-version-stable public schema.
+use serde::{Deserialize, Serialize};
 
 /// Server-generated outbound row identifier (UUID, hex+dashes).
 /// Returned to callers as `DurableHandle::queue_id`. Persist
@@ -12,7 +19,7 @@ pub type QueueId = String;
 /// values; schema CHECK enforces it. Two terminal states
 /// (`delivered`, `abandoned`); three working states (`pending`,
 /// `sending`, `awaiting_ack`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum OutboundStatus {
     /// Row is queued, eligible for `claim_pending_outbound`.
     Pending,
@@ -66,7 +73,7 @@ impl OutboundStatus {
 
 /// Why a row reached `Abandoned`. Mirrors the schema's
 /// `abandoned_reason` CHECK constraint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AbandonedReason {
     /// `attempt_count >= max_attempts` after a transport failure.
     MaxAttempts,
@@ -102,7 +109,7 @@ impl AbandonedReason {
 /// the row stays alive (attempt_count++, scheduled for next try);
 /// `Abandoned` when the failure pushed past `max_attempts` or
 /// `ttl_seconds`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OutboundFailureOutcome {
     /// The row survives this failure; will be re-claimed at
     /// `next_attempt_after`. `attempt` is the new attempt_count
@@ -118,7 +125,7 @@ pub enum OutboundFailureOutcome {
 
 /// Filter for `list_outbound`. All fields optional; combine with
 /// AND. Used by ops dashboards.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OutboundFilter {
     /// Restrict to rows with this status.
     pub status: Option<OutboundStatus>,
@@ -135,7 +142,7 @@ pub struct OutboundFilter {
 /// Row shape returned by `claim_pending_outbound`,
 /// `outbound_status`, `list_outbound`, `match_ack_to_outbound`. Maps
 /// 1:1 onto `cirislens.edge_outbound_queue` columns.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OutboundRow {
     /// Server-generated row identifier (UUID).
     pub queue_id: QueueId,


### PR DESCRIPTION
Completes the #320 cross-cdylib hardening (started in #320/#322/#323) with two more ABI-stable C-vtable dispatch capsules, closing the last two `PyEngine` surfaces that hand a cohabiting Rust consumer (CIRISEdge) a raw persist Rust type by-value across the cdylib boundary. Both mirror `directory_capsule` exactly and reuse the existing `executor_capsule` (#157) for the spawn.

## `outbound_queue_ops_capsule` (`src/ffi/outbound_queue_capsule.rs`)

The old `outbound_queue_capsule` handed over a raw `BackendDispatch` enum. Because `OutboundQueue` uses `-> impl Future + Send` RPITIT methods it is **not object-safe**, so the consumer `match`ed the variant and **static-dispatched** the trait method against ITS compiled view of persist's `PostgresBackend` / `SqliteBackend` struct layout → layout skew across versions → memory corruption. The new capsule serializes an `OutboundQueueOp` (one variant per trait method — the full surface), runs it inside persist's `.so` against persist's own compiled backend via a single generic dispatcher, and returns a serialized `OutboundQueueOpResult`. **Postgres and Sqlite dispatch identically** (no backend asymmetry).

## `signer_ops_capsule` (`src/ffi/signer_capsule.rs`) — SECURITY-CRITICAL

The old `keyring_signer_capsule` handed over raw `Arc<dyn HardwareSigner>` + optional `Arc<dyn PqcSigner>` trait objects. A `dyn` vtable's method-slot order is **not ABI-stable** across persist versions, so a consumer built against an older persist could call `.sign()` through a slot index that resolves, in the wheel's vtable, to a *different* method — or, across the classical (`HardwareSigner`) vs PQC (`PqcSigner`) boundary, to the wrong signer/algorithm entirely. Unlike the directory case (which merely hung), a misdispatch here **signs**: it emits bytes computed with the wrong key or under the wrong algorithm (Ed25519 where ML-DSA-65 was intended, or vice versa) that still verify as a valid CIRIS signature — a silent forged-signature / key-confusion bug. The new capsule serializes a `SignerOp` (`Sign` / `PqcSign` / `PublicKey` / `PqcPublicKey` / `KeyId`) and dispatches the exact signer + method inside persist's `.so` (persist's own vtable). Results are raw signature / public-key **bytes**; persist does NOT round-trip `ciris_crypto` types across the ABI. Absent PQC signer ⇒ `Ok(None)` inside the `Maybe*` variants (not an error).

## Compatibility

Old `outbound_queue_capsule` / `keyring_signer_capsule` are **retained + deprecated** (doc-comments name the layout/vtable-skew hazard and point to the new capsule). **CIRISEdge must adopt** — CIRISEdge#245 extends. Both ops enums are append-only; `OUTBOUND_QUEUE_ABI_VERSION` / `SIGNER_ABI_VERSION` both = `1`, checked by consumers at receive time. All `unsafe` confined to the two new modules with per-use safety contracts; `#![deny(unsafe_code)]` untouched elsewhere. Verify pins stay v8.3.0.

## Green gates

- `cargo test --lib --no-default-features --features "server sqlite"` — 1043 passed (incl. 24 capsule tests: 8 new outbound/signer)
- `cargo clippy --lib --tests --no-default-features --features "server sqlite"` — clean
- `RUSTFLAGS="-D warnings" cargo build --no-default-features --features server` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RWKf675EcbswPMuEqprUNQ
