### PR TITLE
ci: unstarve OpenSSL + wheel caches — bench.yml caches only target/criterion (#335)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -84,20 +84,27 @@ jobs:
         with:
           plat: linux-x86_64
 
-      - name: Cache cargo + criterion baseline
+      - name: Cache criterion baseline
         uses: actions/cache@v5
         with:
+          # CIRISPersist#335 — cache ONLY the criterion baseline, NOT the
+          # full compiled `target/`. The heavy dep artifacts (ML-DSA /
+          # ML-KEM / keyring / tokio-postgres graph) are already warmed by
+          # the GHCR `ciriscache` restore above (which lives OUTSIDE the
+          # 10 GB GitHub-cache budget), so caching all of `target/` here
+          # was ~3 GB of pure redundancy — and its two branch-scoped copies
+          # pushed the repo cache to 13.9 GB / 10 GB, LRU-evicting the small
+          # vcpkg-OpenSSL (28 MB) + wheel `target/` blobs and forcing a
+          # 382 s OpenSSL rebuild + cold wheel compiles every run. Scoping
+          # to `target/criterion` (the per-bench `base` snapshot the
+          # regression analysis compares against) drops this blob from ~3 GB
+          # to a few MB. Registry/git stay cached (cheap, high-value).
+          # Cargo.lock is gitignored (library convention), so the key hashes
+          # Cargo.toml — version bumps + new deps invalidate cleanly.
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          # Cargo.lock is gitignored (library convention), so the
-          # cache key hashes Cargo.toml — version bumps + new deps
-          # invalidate cleanly. The criterion target dir is
-          # included so subsequent runs see the previous baseline
-          # (criterion writes a per-bench `base` snapshot; the
-          # action's regression analysis works without it but is
-          # nicer with it).
+            target/criterion
           key: bench-${{ runner.os }}-${{ hashFiles('Cargo.toml') }}
           restore-keys: |
             bench-${{ runner.os }}-


### PR DESCRIPTION
Closes #335. CI-only, no version bump (same class as #332).

## Problem

After #332 made Windows the CI long pole (1503s), the anatomy showed **382s wasted** on `install OpenSSL via vcpkg` — a cache **miss** (`Cache not found for key: vcpkg-openssl-x64-windows-static-v1`), despite #327 adding that cache. Root cause: the repo GitHub Actions cache pool was **13.9 GB against the 10 GB limit**, so GitHub LRU-evicted the 28 MB OpenSSL blob (and the Windows wheel's `target/` cache) every run.

The bloat: `bench.yml`'s `actions/cache` saved the **full compiled `target/`** (~3 GB × branch-scoped copies) — but the job *also* restores the GHCR `ciriscache` (which lives **outside** the 10 GB budget) right above it, already warming the same verify→persist dep graph. Redundant, and budget-blowing.

## Fix

- **Prevent recurrence** (this PR): `bench.yml` caches only `target/criterion` (the regression baseline the criterion action diffs against), not full `target/`. Blob drops ~3 GB → a few MB. Registry/git stay cached.
- **Immediate relief** (done manually): deleted the dead `win7-buildstd-*` (orphaned by #332), the orphaned `v0-rust-bench-*` (old bench.yml revision), and the fat `bench-Linux-*` blobs → pool **13.9 GB → 3.2 GB**.

## Payoff

~7 GB headroom means the 28 MB OpenSSL blob + the Windows wheel `target/` cache survive between runs:
- **−382s** on Windows (OpenSSL restore instead of vcpkg rebuild)
- warmer `maturin build` (the wheel `target/` cache stops being evicted), chipping at the 1001s cold-compile half

No behavior change to benches themselves — the criterion baseline is still cached; only the redundant full-`target/` copy is dropped (the dep artifacts come from `ciriscache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)