### PR TITLE
v11.9.0 — #337: CC 0.7 wire-vocabulary range-steward surface (ratify 0x0005_0001 + WIRE_VOCABULARY_KINDS.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.9.0] — 2026-07-01
+
+### Added — #337: CC 0.7 wire-vocabulary range-steward surface (ratify `0x0005_0001` + publish `WIRE_VOCABULARY_KINDS.md`)
+
+Discharges CIRISPersist's CC 0.7 §3.3 range-steward duty for the Tier-2 range
+`0x0005_0000..=0x0005_FFFF` ("persist-tier telemetry") assigned in
+`CIRISConstitution/manifests/WIRE_VOCABULARY.md` v1.0.1 §3.1.
+
+- **`WIRE_VOCABULARY_KINDS.md`** (repo root) — the authoritative `kind →
+  semantics` table for persist's range.
+- **`src/wire_vocabulary.rs`** (new module, re-exported at the crate root):
+  - `TRACE_BATCH_KIND = 0x0005_0001` — ratifies the §3.3 migrant of the retired
+    `MessageType::AccordEventsBatch`. Payload = canonical JSON of
+    `schema::BatchEnvelope` (the bytes the HTTP ingest posts /
+    `receive_and_persist` consumes). Reconciles CIRISServer/lens-core's
+    provisional `ACCORD_EVENTS_KIND` — they repin onto this constant.
+  - `trace_batch_payload_bytes(&BatchEnvelope)` — the produce half of the §3.3
+    shared canonicalization; `BatchEnvelope::from_json` is the
+    verify-before-persist receive half.
+  - `PERSIST_KIND_RANGE` + `is_persist_kind()` — the §3.1 range membership test.
+  - `WIRE_VOCABULARY_HASH` — pins the §4 vocabulary hash
+    `c6bd6aa4…9346c`, byte-identical to `CIRISEdge::WIRE_VOCABULARY_HASH`
+    (CIRISEdge#241) and the CIRISRegistry artifact copy (verified: it is the
+    SHA-256 of the manifest's canonical bytes). A pin test guards drift.
+
+**DSAR stays Tier-1** (not migrated): §3.3 keeps `DSARRequest`/`DSARResponse`
+closed because erasure is rights-bearing and rides Durable+requires-ack, which
+the opaque channels cannot express. The DSAR sub-range is documented as
+reserved-not-allocated.
+
+**No `send_trace_batch(edge, …)` wrapper here by design:** persist sits *below*
+edge (edge links persist), so wrapping `edge.send_opaque_event` in persist would
+invert the dependency. Persist owns the shared definition (kind + schema +
+canonicalization); the emitter (CIRISAgent#904) and receiver (CIRISServer/
+lens-core) — which depend on both — compose it with edge's generic opaque send.
+
+Verify pin unchanged at v8.3.0. No behavior change to any existing path — purely
+additive public surface + a governance doc.
+
 ## [11.8.2] — 2026-07-01
 
 ### Added — #333: 6 peer-mutation DirectoryOp variants complete the ops-proxy surface (CIRISEdge#245)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.8.2"
+version = "11.9.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/WIRE_VOCABULARY_KINDS.md
+++ b/WIRE_VOCABULARY_KINDS.md
@@ -1,0 +1,97 @@
+# CIRISPersist Wire Vocabulary — Tier-2 `kind` allocations
+
+**Range steward:** CIRISPersist
+**Reserved range (§3.1):** `0x0005_0000..=0x0005_FFFF` — "persist-tier telemetry"
+**Wire authority:** `CIRISConstitution/manifests/WIRE_VOCABULARY.md` v1.0.1
+(artifact steward CIRISRegistry), CC 0.7.
+**Pinned vocabulary hash (§4):** `c6bd6aa44111b226a6f204801b1afaa7153fb43296652c1f7cbc23228ac9346c`
+— exported as `ciris_persist::WIRE_VOCABULARY_HASH`, byte-identical to
+`CIRISEdge::WIRE_VOCABULARY_HASH` (CIRISEdge#241) and the artifact-steward copy.
+
+---
+
+## What this document is
+
+The CC 0.7 wire vocabulary is **two-tier** (RFC 8126 registration policy).
+Tier 1 is the closed `MessageType` set carrying the ethical primitives, owned
+by CIRISEdge and amended only through CC §4.5.1. Tier 2 is three opaque
+channels — `OpaqueRequest` / `OpaqueResponse` / `OpaqueEvent` — each carrying a
+`kind: u32` drawn from a per-repo reserved range. Edge treats the `payload` as
+opaque bytes and enforces only the outer envelope signature + the global body
+caps; **the range steward owns the inner schema, its canonicalization, and the
+convenience surface** (§3.3), documented here.
+
+§3.1 assigns CIRISPersist the range above. This file is the authoritative
+`kind → semantics` table for it. Edge does not know or enforce what a persist
+`kind` means; a peer that receives a persist-range `kind` it does not implement
+returns `OpaqueResponse { status: 501 }` — never a silent drop.
+
+Allocating a new `kind` inside this range is a steward action (RFC 8126 Private
+Use): no CC amendment, just an entry below + the matching constant in
+`src/wire_vocabulary.rs`.
+
+---
+
+## Allocations
+
+| `kind` | Name | Channel | Payload | Status |
+|---|---|---|---|---|
+| `0x0005_0001` | accord trace-events batch | `OpaqueEvent` | canonical JSON of `ciris_persist::schema::BatchEnvelope` | **Ratified** (v11.9.0) |
+| `0x0005_0002..=0x0005_00FF` | — | — | reserved for future persist telemetry | Unallocated |
+| DSAR (`0x0005_0100..=0x0005_01FF`) | data-subject access/erasure | — | — | **Reserved, not allocated** (see below) |
+| `0x0005_0200..=0x0005_FFFF` | — | — | unallocated | — |
+
+### `0x0005_0001` — accord trace-events batch
+
+The §3.3 migrant of the retired `MessageType::AccordEventsBatch`.
+
+- **Channel:** `OpaqueEvent { kind: 0x0005_0001, payload }` — Durable,
+  fire-and-forget (no ack). Trace/telemetry: hash-chain verify + scrub +
+  persist happen inside lens/persist; edge is agnostic.
+- **Payload:** the canonical JSON bytes of a `BatchEnvelope` — exactly the
+  bytes the HTTP ingest path posts and `Engine::receive_and_persist` consumes.
+  No `serde_json::Value` anywhere in the type (MISSION.md §3 anti-pattern #1);
+  every field is typed, so the bytes parse losslessly.
+- **Schema owner:** `ciris_persist::schema::BatchEnvelope` (this repo,
+  `src/schema/envelope.rs`).
+- **Canonicalization (produce):** `ciris_persist::trace_batch_payload_bytes(&BatchEnvelope)`.
+- **Verify-before-persist (receive):** `BatchEnvelope::from_json(&payload)` —
+  all schema-version / trace-level / required-field / `MAX_DATA_DEPTH` gates
+  fire there and return typed errors before anything is persisted.
+- **Constant:** `ciris_persist::TRACE_BATCH_KIND`.
+- **Body cap:** the global `MAX_BODY_BYTES` (8 MiB, §3.2); no smaller per-kind
+  sub-cap declared.
+
+**Consumers:**
+- *Receiver* — CIRISServer / lens-core relay repins its provisional
+  `ACCORD_EVENTS_KIND = 0x0005_0001` onto `ciris_persist::TRACE_BATCH_KIND`.
+- *Emitter* — CIRISAgent#904 (pending) produces the payload via
+  `trace_batch_payload_bytes` and sends it over edge's generic
+  `send_opaque_event(TRACE_BATCH_KIND, bytes)`.
+
+### DSAR — reserved, **not** allocated
+
+The §3.1 range scope names "trace batches, **DSAR**", but §3.3 resolves that
+`DSARRequest` / `DSARResponse` **stay Tier-1** and do not migrate:
+data-subject access/erasure is rights-bearing (consent-weight, adjacent to
+`Withdraws`) **and** rides Durable + requires-ack — the erasure-completion
+receipt the three opaque channels cannot express (§3 delivery-expressiveness
+limit). No DSAR `kind` is allocated here. The sub-range is held reserved so
+that, should a durable ack-bearing opaque channel ever be added and DSAR be
+revisited, its allocation lands in a stable place.
+
+---
+
+## Why persist exposes no `send_trace_batch` wrapper
+
+§3.3's worked example — `CIRISAgent::send_inline_text(text)` wrapping
+`edge.send_opaque_event(kind, app_canonicalize(text))` — works because
+CIRISAgent sits *above* CIRISEdge. **CIRISPersist sits below edge** (edge links
+persist; the reverse would be a dependency cycle), so a `send_trace_batch(edge,
+…)` wrapper cannot live in this repo. Persist therefore owns and exports the
+*shared definition* — the ratified `kind`, the `BatchEnvelope` schema, and the
+`trace_batch_payload_bytes` / `from_json` canonicalization pair — and the
+emitter/receiver tiers (which depend on both persist and edge) compose it with
+edge's generic `send_opaque_event` / `subscribe_opaque`. "App owns meaning" is
+honored on the wire and in the stewardship graph; the only thing that never
+exists is a transport-tier typed struct for this migrant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub mod tickets;
 pub mod verify;
 #[cfg(feature = "cirislens_wa_cert")]
 pub mod wa_cert;
+pub mod wire_vocabulary;
 pub mod witness;
 
 /// v4.12.1 (CIRISPersist#189) — verify-style embedded version literal for
@@ -169,6 +170,15 @@ pub use engine::AuditDispatch;
 #[cfg(all(feature = "cirisnode", any(feature = "postgres", feature = "sqlite")))]
 pub use engine::NodeCoreDispatch;
 pub use engine::{BackendDispatch, Engine, EngineError};
+// v11.9.0 (CIRISPersist#337) — CC 0.7 wire-vocabulary range-steward surface
+// at the crate root so consumers `use ciris_persist::{TRACE_BATCH_KIND,
+// WIRE_VOCABULARY_HASH}` alongside `Engine`. CIRISServer/lens-core repins its
+// provisional `ACCORD_EVENTS_KIND` onto `TRACE_BATCH_KIND`; CIRISAgent#904
+// (emitter) shares `trace_batch_payload_bytes`. See `WIRE_VOCABULARY_KINDS.md`.
+pub use wire_vocabulary::{
+    is_persist_kind, trace_batch_payload_bytes, PERSIST_KIND_RANGE, TRACE_BATCH_KIND,
+    WIRE_VOCABULARY_HASH,
+};
 // v2.13.0 (CIRISPersist#113) — Engine detection-events read + subscribe
 // facade. Re-export the filter / row types + the derived Error at the
 // crate root so consumers can `use ciris_persist::{Engine,

--- a/src/wire_vocabulary.rs
+++ b/src/wire_vocabulary.rs
@@ -1,0 +1,160 @@
+//! CC 0.7 wire-vocabulary — CIRISPersist's Tier-2 range-steward surface.
+//!
+//! The federation wire vocabulary is a hash-pinned constitutional artifact
+//! (`CIRISConstitution/manifests/WIRE_VOCABULARY.md` v1.0.1, artifact
+//! steward CIRISRegistry). It is **two-tier** (RFC 8126 registration-policy
+//! vocabulary):
+//!
+//! - **Tier 1** — the closed `MessageType` set carrying the ethical
+//!   primitives (attestations, votes, key registration, …). Adding one is a
+//!   CC §4.5.1 amendment. CIRISEdge owns this; persist does not.
+//! - **Tier 2** — three opaque channels (`OpaqueRequest` / `OpaqueResponse`
+//!   / `OpaqueEvent`) carrying a `kind: u32` from a per-repo reserved range
+//!   (§3.1). Edge treats the payload as opaque bytes; the *range steward*
+//!   owns the inner schema, canonicalization, and convenience surface (§3.3)
+//!   and documents `kind → semantics` in a `WIRE_VOCABULARY_KINDS.md`.
+//!
+//! §3.1 assigns CIRISPersist the range [`PERSIST_KIND_RANGE`]
+//! (`0x0005_0000..=0x0005_FFFF`, "persist-tier telemetry"). This module is
+//! persist's §3.3 range-steward surface: the ratified [`TRACE_BATCH_KIND`],
+//! the shared payload canonicalization ([`trace_batch_payload_bytes`] /
+//! [`BatchEnvelope::from_json`]), and the pinned [`WIRE_VOCABULARY_HASH`].
+//! The human-readable allocation table lives in `WIRE_VOCABULARY_KINDS.md`
+//! at the repo root.
+//!
+//! **Dependency direction (why there is no `send_trace_batch` here).** §3.3's
+//! worked example — `CIRISAgent::send_inline_text(text)` as a thin wrapper
+//! over `edge.send_opaque_event(kind, app_canonicalize(text))` — works
+//! because CIRISAgent sits *above* CIRISEdge. CIRISPersist sits *below* edge
+//! (edge links persist, not the reverse), so a `send_trace_batch(edge, …)`
+//! wrapper cannot live here without inverting the dependency. Persist instead
+//! exports the ratified `kind` + the schema + the canonicalization helper —
+//! the single shared definition — and the emitter tier (CIRISAgent#904) and
+//! receiver tier (CIRISServer/lens-core) compose it with edge's *generic*
+//! `send_opaque_event` / `subscribe_opaque`.
+
+use crate::schema::BatchEnvelope;
+
+/// The CC 0.7 wire-vocabulary hash — SHA-256 of the canonical bytes of
+/// `WIRE_VOCABULARY.md` v1.0.1 (§4). Every ratifying repo pins this identical
+/// value; a mismatch at cohabitation is a substrate-tier build failure, not a
+/// warning. Byte-identical to `CIRISEdge::WIRE_VOCABULARY_HASH` (CIRISEdge#241)
+/// and the artifact-steward copy in CIRISRegistry.
+///
+/// sha256 = c6bd6aa44111b226a6f204801b1afaa7153fb43296652c1f7cbc23228ac9346c
+pub const WIRE_VOCABULARY_HASH: [u8; 32] = [
+    0xc6, 0xbd, 0x6a, 0xa4, 0x41, 0x11, 0xb2, 0x26, 0xa6, 0xf2, 0x04, 0x80, 0x1b, 0x1a, 0xfa, 0xa7,
+    0x15, 0x3f, 0xb4, 0x32, 0x96, 0x65, 0x2c, 0x1f, 0x7c, 0xbc, 0x23, 0x22, 0x8a, 0xc9, 0x34, 0x6c,
+];
+
+/// CIRISPersist's reserved Tier-2 `kind` range (§3.1): the 16-bit sub-range
+/// `0x0005_0000..=0x0005_FFFF`, "persist-tier telemetry". Every persist-owned
+/// `kind` MUST fall inside this range; [`is_persist_kind`] enforces it.
+pub const PERSIST_KIND_RANGE: std::ops::RangeInclusive<u32> = 0x0005_0000..=0x0005_FFFF;
+
+/// Ratified `kind` for the **accord trace-events batch** (the §3.3 migrant of
+/// the retired `MessageType::AccordEventsBatch`). Carried as an
+/// `OpaqueEvent { kind: TRACE_BATCH_KIND, payload }` where `payload` is the
+/// canonical JSON bytes of a [`BatchEnvelope`] — exactly the bytes the HTTP
+/// ingest path posts and `Engine::receive_and_persist` consumes.
+///
+/// - Produce the payload with [`trace_batch_payload_bytes`].
+/// - Verify-before-persist on receive with [`BatchEnvelope::from_json`]
+///   (all schema-version / trace-level / required-field / depth gates fire
+///   there; hash-chain verify + scrub + persist run inside lens/persist —
+///   edge is agnostic).
+///
+/// Consumers pin THIS constant rather than a local literal: CIRISServer's
+/// lens-core relay repins its provisional `ACCORD_EVENTS_KIND` here, and
+/// CIRISAgent#904 (emitter) shares the same definition.
+pub const TRACE_BATCH_KIND: u32 = 0x0005_0001;
+
+/// `true` iff `kind` falls in persist's reserved Tier-2 range (§3.1). A peer
+/// that receives a persist-range `kind` it does not implement returns
+/// `OpaqueResponse { status: 501 }` (never a silent drop) — that dispatch is
+/// edge's, but the range membership test is persist's to define.
+#[must_use]
+pub fn is_persist_kind(kind: u32) -> bool {
+    PERSIST_KIND_RANGE.contains(&kind)
+}
+
+/// Produce the opaque-event **payload bytes** for a trace-events batch: the
+/// canonical JSON serialization of `envelope`. This is the range steward's
+/// half of the §3.3 shared definition — the emitter feeds the result to
+/// edge's generic `send_opaque_event([`TRACE_BATCH_KIND`], bytes)`, and the
+/// receiver round-trips them back through [`BatchEnvelope::from_json`].
+///
+/// The bytes are `serde_json` of the typed [`BatchEnvelope`] (no
+/// `serde_json::Value` anywhere in the type — MISSION.md §3 anti-pattern #1),
+/// so they parse losslessly on the receive side. Errors are surfaced rather
+/// than panicking so a caller never emits a half-serialized batch.
+pub fn trace_batch_payload_bytes(envelope: &BatchEnvelope) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(envelope)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the CC 0.7 wire-vocabulary hash to its hex source of truth
+    /// (§4). A drift here is a coordinated wire-break signal, not a bug
+    /// fix — and it must stay byte-identical to every other ratifying
+    /// repo's pin (CIRISEdge, CIRISRegistry artifact copy).
+    #[test]
+    fn wire_vocabulary_hash_pinned() {
+        const HEX: &str = "c6bd6aa44111b226a6f204801b1afaa7153fb43296652c1f7cbc23228ac9346c";
+        let mut expected = [0u8; 32];
+        for (i, byte) in expected.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(&HEX[i * 2..i * 2 + 2], 16).unwrap();
+        }
+        assert_eq!(WIRE_VOCABULARY_HASH, expected);
+    }
+
+    /// The ratified trace-batch kind sits inside persist's reserved
+    /// §3.1 range (and the range endpoints behave).
+    #[test]
+    fn trace_batch_kind_is_in_persist_range() {
+        assert_eq!(TRACE_BATCH_KIND, 0x0005_0001);
+        assert!(is_persist_kind(TRACE_BATCH_KIND));
+        assert!(is_persist_kind(0x0005_0000));
+        assert!(is_persist_kind(0x0005_FFFF));
+        assert!(!is_persist_kind(0x0004_FFFF));
+        assert!(!is_persist_kind(0x0006_0000));
+    }
+
+    /// The §3.3 shared definition round-trips: payload bytes produced by
+    /// the steward helper parse back through the verify-on-receive gate
+    /// to an equal envelope.
+    #[test]
+    fn payload_bytes_round_trip_through_from_json() {
+        let bytes = serde_json::json!({
+            "events": [{
+                "event_type": "complete_trace",
+                "trace_level": "generic",
+                "trace": {
+                    "trace_id": "trace-th_std_abc-20260430001553",
+                    "thought_id": "th_std_abc",
+                    "task_id": "ACCEPT_INCOMPLETENESS_xyz",
+                    "agent_id_hash": "deadbeef",
+                    "started_at": "2026-04-30T00:15:53.123456+00:00",
+                    "completed_at": "2026-04-30T00:16:12.789012+00:00",
+                    "trace_level": "generic",
+                    "trace_schema_version": "2.7.0",
+                    "components": [],
+                    "signature": "AAAA",
+                    "signature_key_id": "ciris-agent-key:dead"
+                }
+            }],
+            "batch_timestamp": "2026-04-30T00:16:13.000000+00:00",
+            "consent_timestamp": "2026-04-30T00:00:00.000000+00:00",
+            "trace_level": "generic",
+            "trace_schema_version": "2.7.0"
+        });
+        let envelope =
+            BatchEnvelope::from_json(&serde_json::to_vec(&bytes).unwrap()).expect("seed parses");
+
+        let payload = trace_batch_payload_bytes(&envelope).expect("serialize payload");
+        let round_tripped = BatchEnvelope::from_json(&payload).expect("payload re-parses");
+        assert_eq!(envelope, round_tripped, "steward payload must round-trip");
+    }
+}


### PR DESCRIPTION
Closes #337.

## What

Discharges CIRISPersist's CC 0.7 §3.3 **range-steward** duty for the Tier-2 range `0x0005_0000..=0x0005_FFFF` ("persist-tier telemetry") assigned in `CIRISConstitution/manifests/WIRE_VOCABULARY.md` v1.0.1 §3.1.

- **`WIRE_VOCABULARY_KINDS.md`** (repo root) — the authoritative `kind → semantics` table for persist's range.
- **`src/wire_vocabulary.rs`** (new module, re-exported at the crate root):
  | Symbol | Purpose |
  |---|---|
  | `TRACE_BATCH_KIND = 0x0005_0001` | ratifies the §3.3 migrant of retired `MessageType::AccordEventsBatch`; payload = canonical JSON of `schema::BatchEnvelope` |
  | `trace_batch_payload_bytes(&BatchEnvelope)` | produce half of the shared canonicalization (receive half = `BatchEnvelope::from_json`) |
  | `PERSIST_KIND_RANGE` + `is_persist_kind()` | §3.1 range membership |
  | `WIRE_VOCABULARY_HASH` | pins the §4 hash `c6bd6aa4…9346c` |

## Ratification correctness

- The pinned `WIRE_VOCABULARY_HASH` is **byte-identical** to `CIRISEdge::WIRE_VOCABULARY_HASH` (CIRISEdge#241) and the CIRISRegistry artifact copy. Verified locally: `sha256(WIRE_VOCABULARY.md) == c6bd6aa44111b226a6f204801b1afaa7153fb43296652c1f7cbc23228ac9346c` against both the Constitution and Registry copies (identical files). A pin test guards drift.
- `TRACE_BATCH_KIND` reconciles CIRISServer/lens-core's **provisional** `ACCORD_EVENTS_KIND = 0x0005_0001` — they repin onto this constant.
- New tests: hash pin, range membership, and a **round-trip** (`trace_batch_payload_bytes` → `BatchEnvelope::from_json`) proving the shared definition survives the verify-on-receive gate.

## Two judgement calls (documented in the doc + CHANGELOG)

1. **DSAR stays Tier-1**, not migrated — §3.3 keeps `DSAR{Request,Response}` closed (rights-bearing + Durable/requires-ack, which the three opaque channels can't express). The range table's "(…, DSAR)" scope is thus partly aspirational; the DSAR sub-range is documented **reserved-not-allocated**.
2. **No `send_trace_batch(edge, …)` wrapper in persist** — the §3.3 worked example (`CIRISAgent::send_inline_text` wrapping `edge.send_opaque_event`) works because agent sits *above* edge. Persist sits *below* edge (edge links persist), so that wrapper would invert the dependency. Persist owns the shared definition; the emitter (CIRISAgent#904) and receiver (CIRISServer/lens-core) compose it with edge's generic opaque send. Flagged so the convenience-API ask isn't mis-filed back here.

Verify pin unchanged at v8.3.0. Purely additive surface + a governance doc — no behavior change to any existing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)