### PR TITLE
v11.9.1 — #339: sqlite-only builds drop openssl (retire mobile vendored-openssl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [11.9.1] — 2026-07-02
+
+### Fixed — #339: sqlite-only builds no longer pull openssl (retires mobile vendored-openssl)
+
+A `pyo3-sqlite` / sqlite-only build no longer drags `openssl-sys` into the
+dependency tree on **any** target, letting CIRISEdge#246 drop the
+vendored-openssl-from-source builds on iOS/Android (the flakiest part of the
+mobile matrix, pure build-time cost for a NoTls path never exercised).
+
+**Corrected root cause.** #339 (and the prior in-code comments at the android/
+iOS target tables) diagnosed the openssl as transitive via
+`refinery → tokio-postgres → postgres-native-tls → native-tls → openssl-sys`.
+That chain **does not exist** — verified with `cargo tree -i native-tls`
+(absent on every target; refinery's `tokio-postgres` backend uses `NoTls`).
+The openssl was **self-inflicted**: the `[target.'cfg(target_os = "ios")']` and
+`[target.'cfg(target_os = "android")']` tables declared
+`openssl = { features = ["vendored"] }` as an **unconditional hard dep**, so
+cargo unioned it into an always-on openssl on mobile regardless of feature.
+
+**Fix.**
+- Both mobile target-table `openssl` entries are now `optional = true`, so they
+  activate only when the `postgres` feature enables `dep:openssl` (+ union the
+  `vendored` feature on mobile). A sqlite-only mobile wheel pulls no openssl.
+- `refinery` base dep → `default-features = false` (drops the unused `toml`
+  config feature and the previously-hardcoded `tokio-postgres` backend); each
+  backend feature now opts into its own refinery backend: `sqlite` →
+  `refinery/rusqlite`, `postgres` → `refinery/tokio-postgres`. This also
+  removes the dead `tokio-postgres` compile from sqlite-only builds. Migrations
+  are compile-time `embed_migrations!`, so `toml` was never used.
+- Corrected the misleading target-table comments.
+
+**Verified** (`cargo tree -i openssl-sys`): absent under `pyo3-sqlite sqlite` on
+host / android / ios; present under `pyo3 sqlite` on host / android / ios
+(postgres path intact). `tokio-postgres` absent from the sqlite-only tree.
+sqlite migrations run clean (`migrations_run_clean_in_memory` + 295 sqlite
+tests) with the reduced refinery. Verify pin unchanged at v8.3.0.
+
 ## [11.9.0] — 2026-07-01
 
 ### Added — #337: CC 0.7 wire-vocabulary range-steward surface (ratify `0x0005_0001` + publish `WIRE_VOCABULARY_KINDS.md`)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "11.9.0"
+version = "11.9.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -18,7 +18,7 @@ publish = false
 default = []
 
 # Phase 1 features.
-postgres = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:bytes", "dep:postgres-types", "dep:refinery", "dep:openssl"]
+postgres = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:bytes", "dep:postgres-types", "dep:refinery", "refinery/tokio-postgres", "dep:openssl"]
 server   = ["dep:axum", "dep:tower", "dep:http-body-util"]
 # pyo3 implies postgres — the lens FastAPI integration shape (FSD §3.5)
 # needs the Postgres backend to be available. This is the published-wheel
@@ -595,19 +595,28 @@ tokio-postgres    = { version = "0.7.18", features = ["with-chrono-0_4", "with-s
 deadpool-postgres = { version = "0.14", optional = true }
 bytes             = { version = "1", optional = true }
 postgres-types    = { version = "0.2.14", optional = true }
-refinery          = { version = "0.9", features = ["tokio-postgres"], optional = true }
+# CIRISPersist#339 — `default-features = false` drops refinery's default
+# `toml` feature (config-file loading, which we never use — migrations are
+# compile-time `embed_migrations!`) AND the previously-hardcoded
+# `tokio-postgres` backend. Each backend feature now opts into its own
+# refinery backend: `sqlite` → `refinery/rusqlite`, `postgres` →
+# `refinery/tokio-postgres`. This keeps `tokio-postgres` (and its build
+# weight) out of a sqlite-only (`pyo3-sqlite`) tree.
+refinery          = { version = "0.9", default-features = false, optional = true }
 
 # v0.1.3 — TLS for tokio-postgres connection pool (THREAT_MODEL.md AV-18).
 tokio-postgres-rustls = { version = "0.13", optional = true }
 rustls                = { version = "0.23", optional = true }
 rustls-native-certs   = { version = "0.8", optional = true }
-# refinery transitively pulls postgres-native-tls → native-tls →
-# openssl-sys. We use NoTls so the TLS path is never exercised, but
-# the dep tree still requires openssl to *build*. Vendored builds
-# openssl from source for whatever target arch we're compiling for —
-# no system libssl-dev:<arch> needed. The cost is a few extra seconds
-# of CI compile time; the benefit is arm64/Pi-class cross-compile
-# works without multi-arch apt gymnastics.
+# `openssl` is pulled ONLY by the `postgres` feature (`dep:openssl`,
+# below) — the Postgres connection pool builds against it. It is NOT a
+# transitive requirement of refinery (verified via `cargo tree -i
+# native-tls` → absent on every target; CIRISPersist#339): refinery's
+# `tokio-postgres` backend uses `NoTls` and does not pull
+# postgres-native-tls/native-tls/openssl-sys. `vendored` builds openssl
+# from source for the target arch (no system libssl-dev:<arch> needed),
+# which matters for the postgres-enabled cross-compiles. A sqlite-only
+# build pulls no openssl at all.
 openssl           = { version = "0.10", features = ["vendored"], optional = true }
 
 # Phase 1 — server feature
@@ -772,26 +781,34 @@ ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
-# v2.0.4 — vendored openssl for iOS PyO3 cross-compilation. The `pyo3`
-# feature implies `postgres` which depends on `openssl`. On iOS there is
-# no system libssl; vendored build-from-source handles it (ARM64 has no
-# SM4-NI issue unlike Android x86_64). Same pattern as the Android entry.
-openssl = { version = "0.10", features = ["vendored"] }
+# v2.0.4 / CIRISPersist#339 — vendored openssl for iOS PyO3
+# cross-compilation, but ONLY when the `postgres` feature is active.
+# `optional = true` (was unconditional) unions with the base `dep:openssl`
+# (which only the `postgres` feature enables) + adds the `vendored`
+# feature on iOS, where there is no system libssl. A `pyo3-sqlite`
+# (sqlite-only) iOS wheel now pulls NO openssl at all — retiring the
+# vendored build-from-source (CIRISEdge#246). ARM64 has no SM4-NI issue
+# unlike Android x86_64. Same pattern as the Android entry.
+openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
 ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["pqc-ml-dsa", "android"] }
-# v2.0.3 — vendored openssl for Android cross-compilation. refinery-core
-# unconditionally pulls postgres-native-tls → native-tls → openssl-sys
-# regardless of which backend feature is active. On desktop builds the
-# system libssl satisfies it; on Android there's no system openssl, so
-# we force vendored build-from-source. This dep merges with the
-# optional `openssl` in `[dependencies]` (cargo unions features across
-# target tables); on non-Android targets the vendored feature is only
-# active when the `postgres` feature explicitly enables `dep:openssl`.
-openssl = { version = "0.10", features = ["vendored"] }
+# v2.0.3 / CIRISPersist#339 — vendored openssl for Android
+# cross-compilation, gated behind the `postgres` feature. NOTE: an earlier
+# comment here blamed refinery-core for transitively pulling
+# postgres-native-tls → native-tls → openssl-sys "regardless of feature".
+# That was wrong — verified via `cargo tree -i native-tls` (absent on every
+# target, sqlite-only and postgres alike): refinery's tokio-postgres backend
+# uses NoTls and pulls no openssl. openssl comes ONLY from the `postgres`
+# connection pool's `dep:openssl`. So `optional = true` (was unconditional)
+# unions with the base `dep:openssl` + adds `vendored` on Android (no system
+# openssl). A `pyo3-sqlite` Android wheel now pulls NO openssl — retiring the
+# vendored build-from-source, the flakiest part of the mobile matrix
+# (CIRISEdge#246).
+openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [dev-dependencies]
 # Mission category §4: canonicalization parity. Used to validate our


### PR DESCRIPTION
Closes #339. Unblocks CIRISEdge#246 (mobile half; the Windows half shipped via #328/edge#247).

## Corrected root cause

#339 (and the in-code comments at the ios/android target tables) diagnosed the mobile openssl as transitive:
`refinery → tokio-postgres → postgres-native-tls → native-tls → openssl-sys`.

**That chain does not exist.** `cargo tree -i native-tls` returns "did not match any packages" on *every* target (host, android, ios; sqlite-only and postgres alike) — refinery's `tokio-postgres` backend uses `NoTls` and pulls no openssl. The openssl was **self-inflicted**: the `[target.'cfg(target_os = "ios")']` / `[target.'cfg(target_os = "android")']` tables declared `openssl = { features = ["vendored"] }` as an **unconditional hard dep**, which cargo unioned into an always-on openssl on mobile regardless of the active backend feature.

## Fix

- Both mobile target-table `openssl` entries → `optional = true`, so they activate only when the `postgres` feature enables `dep:openssl` (and union the `vendored` feature on mobile). A sqlite-only mobile wheel pulls no openssl.
- `refinery` base dep → `default-features = false` (drops the unused `toml` config feature + the hardcoded `tokio-postgres` backend). Each backend feature opts into its own refinery backend: `sqlite → refinery/rusqlite`, `postgres → refinery/tokio-postgres`. Also removes the dead `tokio-postgres` compile from sqlite-only builds. Migrations are compile-time `embed_migrations!`, so `toml` was never used.
- Corrected the misleading comments.

## Verification (all pass)

`cargo tree -i openssl-sys`:
| features | host | android | ios |
|---|---|---|---|
| `pyo3-sqlite sqlite` | absent ✅ | absent ✅ | absent ✅ |
| `pyo3 sqlite` | present ✅ | present ✅ | present ✅ |

Plus: `tokio-postgres` absent from the sqlite-only tree; both feature paths build; sqlite migrations run clean (`migrations_run_clean_in_memory` + 295 sqlite tests) with the reduced refinery. Verify pin unchanged at v8.3.0.

Cargo.toml-only change (no code paths touched) — the CI-relevant checks are compile-across-feature-combos + `cargo deny` (no new deps; refinery loses features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)