### PR TITLE
v12.0.1 — re-pin ciris-verify* v8.4.0 → v8.5.0 (no code change; genesis seed NOT included)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.0.1] — 2026-07-02
+
+### Changed — re-pin ciris-verify* v8.4.0 → v8.5.0
+
+Verify-only re-pin (ciris-verify-core / ciris-crypto / ciris-keyring, all 6 Cargo
+tags). No persist code change — the v12.0 genesis-mesh rooting substrate is
+unchanged. This tracks the verify v8.5.0 cut (the `produce_scrubbed_key_record`
+holder-scrub-sign primitive the CIRISServer#140 op needs). **The genesis seed is
+NOT in this cut** — seeding of the signed A1/B1/C1 records lands in a later cut
+once the holder-app op has produced them. Verify bound `ciris-verify>=8,<9`
+unchanged (minor).
+
 ## [12.0.0] — 2026-07-02
 
 ### Security / BREAKING — #344: rooting anchors to the HUMANITY_ACCORD holder keyset (v12.0 genesis mesh, centipede body)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.0.0"
+version = "12.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -503,14 +503,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -777,10 +777,10 @@ tokio-stream = "0.1"
 # key). Placed AFTER every platform-independent dep — see the v0.9.0
 # bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 / CIRISPersist#339 — vendored openssl for iOS PyO3
 # cross-compilation, but ONLY when the `postgres` feature is active.
 # `optional = true` (was unconditional) unions with the base `dep:openssl`
@@ -795,7 +795,7 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 / CIRISPersist#339 — vendored openssl for Android
 # cross-compilation, gated behind the `postgres` feature. NOTE: an earlier
 # comment here blamed refinery-core for transitively pulling


### PR DESCRIPTION
Verify-only re-pin. **No persist code change**, and — explicitly — **the genesis seed is NOT in this cut** (seeding of the signed A1/B1/C1 records lands later, once the CIRISServer#140 holder-app op has produced them).

## Change
- `ciris-verify-core` / `ciris-crypto` / `ciris-keyring` — all 6 Cargo tags `v8.4.0` → `v8.5.0`.
- Version `12.0.0` → `12.0.1`.
- pyproject `ciris-verify>=8.0.0,<9` unchanged (minor bump within major 8).

## Why
Tracks the verify v8.5.0 cut (the `produce_scrubbed_key_record` holder-scrub-sign primitive the CIRISServer#140 op needs). Keeps persist's verify pin current so downstream cohabitation stays on one verify version.

## Verification
Builds clean against v8.5.0 (`pyo3 sqlite`), fmt + clippy clean, no API break — the v12.0 rooting substrate is byte-identical to v12.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)