### PR TITLE
v12.1.0 — #349: per-cohort_scope byte size on the held-content surface (CC 6.1.5.2 §Q B5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.1.0] — 2026-07-03
+
+### Added — #349: per-`cohort_scope` byte size on the held-content surface (for CC 6.1.5.2 §Q B5)
+
+`FountainHeldMeta` (from `list_held_fountain_content`) gains two fields so edge's
+§Q storage-contention arbitration (CIRISEdge#257) can recompute per-scope byte
+consumption from what persist actually holds:
+
+- **`content_bytes: u64`** — the durable footprint **actually held** for the
+  content unit = `held_symbols × symbol_size`. Recomputed from current holdings
+  (shrinks under eviction/degradation with `held_symbols`), so an owner's
+  declared consumption reconciles against real bytes — the B5
+  consumption-challengeability guarantee. (Both inputs were already on the
+  struct; this makes the byte figure explicit rather than an edge-side product.)
+- **`cohort_scope: Option<String>`** — the CC 5.2 lattice scope the content's
+  storage budget draws from, read from the content's **signed `envelope`**'s
+  `cohort_scope` key (`community` / `affiliations` / `species` / …). `None` when
+  the envelope declares none (legacy / unscoped). New
+  `fountain::cohort_scope_from_envelope`.
+
+**No schema migration** — the scope rides the already-stored signed `envelope`
+(`content_manifest.envelope`), extracted at list time; existing content whose
+envelope declares a scope surfaces it immediately. Persist doesn't interpret the
+value — it round-trips the producer's signed declaration; edge keeps the B5
+arbitration edge-internal (never trusted from the wire). All three backends
+(memory/sqlite/postgres) compute both fields; the PyEngine FFI surfaces them via
+serde automatically. Verify pin unchanged v8.5.0.
+
 ## [12.0.2] — 2026-07-03
 
 ### Added — #347: first-boot-seed the HUMANITY_ACCORD holder rooting-anchor rows (the anchor goes LIVE)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.0.2"
+version = "12.1.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/fountain/mod.rs
+++ b/src/fountain/mod.rs
@@ -59,6 +59,6 @@ pub use retention::{
     holding_claim_counts, map_consent_state, resolve_retention_action, RetentionAction,
 };
 pub use types::{
-    FountainContent, FountainHeldMeta, FountainManifestV1, FountainReadClass, FountainSymbolV1,
-    MANIFEST_VERSION_V1,
+    cohort_scope_from_envelope, FountainContent, FountainHeldMeta, FountainManifestV1,
+    FountainReadClass, FountainSymbolV1, MANIFEST_VERSION_V1,
 };

--- a/src/fountain/types.rs
+++ b/src/fountain/types.rs
@@ -207,6 +207,37 @@ pub enum FountainReadClass {
 mod tests {
     use super::*;
 
+    /// #349 — cohort_scope is read from the envelope's string `cohort_scope`
+    /// key; absent / non-string / non-object envelopes yield `None` (unscoped),
+    /// never an error.
+    #[test]
+    fn cohort_scope_extraction() {
+        assert_eq!(
+            cohort_scope_from_envelope(&serde_json::json!({ "cohort_scope": "community" })),
+            Some("community".to_owned())
+        );
+        assert_eq!(
+            cohort_scope_from_envelope(
+                &serde_json::json!({ "cohort_scope": "affiliations", "x": 1 })
+            ),
+            Some("affiliations".to_owned())
+        );
+        assert_eq!(
+            cohort_scope_from_envelope(&serde_json::json!({ "x": 1 })),
+            None,
+            "no cohort_scope key ⇒ None"
+        );
+        assert_eq!(
+            cohort_scope_from_envelope(&serde_json::json!({ "cohort_scope": 42 })),
+            None,
+            "non-string ⇒ None"
+        );
+        assert_eq!(
+            cohort_scope_from_envelope(&serde_json::json!("scalar")),
+            None
+        );
+    }
+
     #[test]
     fn classify_boundaries() {
         // n_source = 10, min_viable = 3.
@@ -296,9 +327,35 @@ pub struct FountainHeldMeta {
     /// Symbols CURRENTLY retained for this content (post-eviction /
     /// degradation) — `COUNT(content_symbols)`.
     pub held_symbols: u32,
+    /// The durable byte footprint **actually held** for this content unit —
+    /// `held_symbols × symbol_size` (CIRISPersist#349, for CC 6.1.5.2 §Q B5
+    /// consumption accounting). Recomputed from what persist currently holds,
+    /// so an owner's declared consumption reconciles against real bytes;
+    /// shrinks under eviction/degradation exactly as `held_symbols` does.
+    pub content_bytes: u64,
+    /// The CC 5.2 lattice `cohort_scope` this content's storage budget draws
+    /// from (`community` / `affiliations` / `species` / …), read from the
+    /// content's signed `envelope`'s `cohort_scope` key (CIRISPersist#349).
+    /// `None` when the envelope declares no scope (legacy / unscoped content) —
+    /// the §Q consumer treats that as unattributed budget.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cohort_scope: Option<String>,
     /// `held_symbols >= min_viable_symbols` — is the content still decodable
     /// from what persist currently holds?
     pub recoverable: bool,
     /// Admission timestamp (ISO-8601 UTC, as stored in `admitted_at`).
     pub admitted_at: String,
+}
+
+/// Extract the CC 5.2 `cohort_scope` a content unit's storage budget draws
+/// from, read from the `cohort_scope` string key of its signed `envelope`
+/// (CIRISPersist#349). `None` when absent or non-string (legacy / unscoped).
+/// Persist does not interpret the value — it round-trips the producer's
+/// signed declaration to the §Q consumer.
+#[must_use]
+pub fn cohort_scope_from_envelope(envelope: &serde_json::Value) -> Option<String> {
+    envelope
+        .get("cohort_scope")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1028,6 +1028,8 @@ impl Backend for MemoryBackend {
                     min_viable_symbols: m.min_viable_symbols,
                     symbol_size: m.symbol_size,
                     held_symbols: held,
+                    content_bytes: u64::from(held) * u64::from(m.symbol_size),
+                    cohort_scope: crate::fountain::cohort_scope_from_envelope(&m.envelope),
                     recoverable: held >= m.min_viable_symbols,
                     admitted_at: String::new(),
                 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1617,7 +1617,8 @@ impl Backend for PostgresBackend {
                         m.original_content_length, m.n_source, m.k_repair, \
                         m.min_viable_symbols, m.symbol_size, m.admitted_at, \
                         (SELECT COUNT(*) FROM cirislens.content_symbols s \
-                         WHERE s.content_id = m.content_id) AS held \
+                         WHERE s.content_id = m.content_id) AS held, \
+                        m.envelope \
                  FROM cirislens.content_manifest m WHERE m.pqc_key_id = $1 \
                  ORDER BY m.admitted_at DESC, m.content_id ASC",
                 &[&publisher_key_id],
@@ -1630,6 +1631,13 @@ impl Backend for PostgresBackend {
             let held: i64 = r.safe_get_with("held", Error::Backend)?;
             let admitted_at: chrono::DateTime<chrono::Utc> =
                 r.safe_get_with("admitted_at", Error::Backend)?;
+            let symbol_size =
+                u32::try_from(r.safe_get_with::<i64, _, _, _>("symbol_size", Error::Backend)?)
+                    .unwrap_or(0);
+            // cohort_scope: #349 — read from the signed envelope (JSONB → Value);
+            // a missing key yields None (unscoped / legacy content).
+            let envelope: serde_json::Value = r.safe_get_with("envelope", Error::Backend)?;
+            let cohort_scope = crate::fountain::cohort_scope_from_envelope(&envelope);
             out.push(crate::fountain::FountainHeldMeta {
                 content_id: r.safe_get_with("content_id", Error::Backend)?,
                 corpus_kind: r.safe_get_with("corpus_kind", Error::Backend)?,
@@ -1647,11 +1655,10 @@ impl Backend for PostgresBackend {
                 )
                 .unwrap_or(0),
                 min_viable_symbols: u32::try_from(min_viable).unwrap_or(0),
-                symbol_size: u32::try_from(
-                    r.safe_get_with::<i64, _, _, _>("symbol_size", Error::Backend)?,
-                )
-                .unwrap_or(0),
+                symbol_size,
                 held_symbols: u32::try_from(held).unwrap_or(0),
+                content_bytes: u64::try_from(held).unwrap_or(0) * u64::from(symbol_size),
+                cohort_scope,
                 recoverable: held >= min_viable,
                 admitted_at: admitted_at.to_rfc3339(),
             });

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1190,7 +1190,8 @@ impl Backend for SqliteBackend {
                         m.original_content_length, m.n_source, m.k_repair, \
                         m.min_viable_symbols, m.symbol_size, m.admitted_at, \
                         (SELECT COUNT(*) FROM content_symbols s \
-                         WHERE s.content_id = m.content_id) AS held \
+                         WHERE s.content_id = m.content_id) AS held, \
+                        m.envelope \
                  FROM content_manifest m WHERE m.pqc_key_id = ?1 \
                  ORDER BY m.admitted_at DESC, m.content_id ASC",
             )?;
@@ -1198,6 +1199,13 @@ impl Backend for SqliteBackend {
                 .query_map(rusqlite::params![publisher], |row| {
                     let min_viable: i64 = row.get(6)?;
                     let held: i64 = row.get(9)?;
+                    let symbol_size = u32::try_from(row.get::<_, i64>(7)?).unwrap_or(0);
+                    // cohort_scope: #349 — read from the signed envelope; a
+                    // parse fault or a missing key yields None (unscoped).
+                    let envelope_text: String = row.get(10)?;
+                    let cohort_scope = serde_json::from_str::<serde_json::Value>(&envelope_text)
+                        .ok()
+                        .and_then(|v| crate::fountain::cohort_scope_from_envelope(&v));
                     Ok(crate::fountain::FountainHeldMeta {
                         content_id: row.get(0)?,
                         corpus_kind: row.get(1)?,
@@ -1206,8 +1214,10 @@ impl Backend for SqliteBackend {
                         n_source: u32::try_from(row.get::<_, i64>(4)?).unwrap_or(0),
                         k_repair: u32::try_from(row.get::<_, i64>(5)?).unwrap_or(0),
                         min_viable_symbols: u32::try_from(min_viable).unwrap_or(0),
-                        symbol_size: u32::try_from(row.get::<_, i64>(7)?).unwrap_or(0),
+                        symbol_size,
                         held_symbols: u32::try_from(held).unwrap_or(0),
+                        content_bytes: u64::try_from(held).unwrap_or(0) * u64::from(symbol_size),
+                        cohort_scope,
                         recoverable: held >= min_viable,
                         admitted_at: row.get(8)?,
                     })


### PR DESCRIPTION
Closes #349. Enriches `FountainHeldMeta` (Option A, the preferred shape) so edge's §Q storage-contention arbitration can recompute per-scope byte consumption from what persist actually holds.

## What

Two fields on `FountainHeldMeta` (returned by `list_held_fountain_content`):
- **`content_bytes: u64`** = `held_symbols × symbol_size` — the durable footprint *actually held*, recomputed from current holdings (shrinks with eviction/degradation), so declared consumption reconciles against real bytes (the B5 challengeability guarantee).
- **`cohort_scope: Option<String>`** — the CC 5.2 lattice scope, read from the content's **signed `envelope`**'s `cohort_scope` key. `None` when unscoped/legacy. New `fountain::cohort_scope_from_envelope`.

## One correction to the issue's premise

The issue assumed persist "already stores... scope" — it doesn't: fountain had **no `cohort_scope` concept** (no column, opaque envelope, no corpus→scope map). Per your call, the scope is **declared in the signed envelope**. Since `content_manifest.envelope` is *already stored*, I extract it at list time — **no schema migration**, and existing content whose envelope declares a scope surfaces it immediately. Persist round-trips the producer's signed declaration; it doesn't interpret the value (edge keeps the B5 arbitration edge-internal, never trusted from the wire).

## Coverage

All three backends (memory/sqlite/postgres) compute both fields; sqlite/postgres add `m.envelope` to the `list_held` SELECT. The PyEngine FFI surfaces them automatically (it `serde_json::to_string(&rows)`). Unit test for `cohort_scope_from_envelope` (present/absent/non-string/scalar). Fountain + list_held tests green; fmt/clippy clean. Verify pin unchanged v8.5.0.

Downstream: CIRISEdge#257 (§Q consumer), CIRISServer#145 (twin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)