### PR TITLE
v12.2.0 — #351: adopt-scrub-upgrade primitive (self-signed → anchor-scrubbed own-key row)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.2.0] — 2026-07-03
+
+### Added — #351: adopt-scrub-upgrade primitive (self-signed → anchor-scrubbed own-key row)
+
+The missing producer step for the **in-place** genesis mesh seed. An upgraded-in-
+place node holds its **self-signed** own-key row from `register_self_key` at boot;
+`register_federation_key` is `ON CONFLICT DO NOTHING`, so applying the accord-
+holder-**scrubbed** record for the same `key_id` was a no-op — the self-signed row
+won forever and no peer could root it. New `Engine::adopt_scrub_upgrade` (+ the
+`PyEngine` FFI mirror) does the gated in-place upgrade:
+
+- **`Engine::adopt_scrub_upgrade(record)`** — verifies the incoming scrub-signature
+  first (the same `verify_key_registration` Strict gate as
+  `register_federation_key`: granting-authority resolves the scrubber's pubkeys
+  from the directory), then the backend's monotonic gated UPDATE.
+- **`{Sqlite,Postgres}Backend::adopt_scrub_upgrade`** — `ON CONFLICT DO UPDATE`
+  restricted to the self-signed→anchored transition via an atomic WHERE guard
+  (`scrub_key_id = key_id AND pubkey_ed25519_base64 = <incoming>`). Refuses: a
+  pubkey change (different identity), an anchored→self **downgrade** / re-anchor
+  to a different holder, and a missing row. Re-applying the exact record is
+  idempotent (`AdoptScrubOutcome::AlreadyAdopted`).
+- **`federation::register::AdoptScrubOutcome`** (`Upgraded` / `AlreadyAdopted`),
+  serde-exposed; the FFI returns `"upgraded"` / `"already_adopted"`.
+
+Verify pin unchanged v8.5.0. Gate tests (upgrade · idempotent · pubkey-change
+refused · downgrade refused · no-row) green. Unblocks CIRISServer `admit-node`
+(target = local node) + the 0.5.78 Key plane (CIRISServer#144) + the genesis mesh
+seed (CIRISServer#139).
+
 ## [12.1.0] — 2026-07-03
 
 ### Added — #349: per-`cohort_scope` byte size on the held-content surface (for CC 6.1.5.2 §Q B5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.1.0"
+version = "12.2.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3600,6 +3600,36 @@ impl Engine {
         directory.put_public_key(record).await
     }
 
+    /// v12.2.0 (CIRISPersist#351) — adopt-scrub-**upgrade**: replace this
+    /// node's **self-signed** own-key row with the accord-anchor-**scrubbed**
+    /// record (same `key_id`, same pubkey) so it can root against the seeded
+    /// A1/B1/C1 anchor. The in-place seed's missing primitive:
+    /// `register_federation_key` is `ON CONFLICT DO NOTHING`, so the boot-time
+    /// self-signed row is otherwise sticky and no peer can root it.
+    ///
+    /// Verifies the incoming scrub-signature first (same
+    /// [`verify_key_registration`](crate::federation::verify_key_registration)
+    /// gate as `register_federation_key` — granting-authority resolves the
+    /// scrubber's pubkeys from the directory), THEN applies the backend's
+    /// monotonic gated UPDATE (self-signed → anchored only; pubkey change and
+    /// anchored→self downgrade refused; re-applying the same record is
+    /// idempotent — see [`AdoptScrubOutcome`](crate::federation::register::AdoptScrubOutcome)).
+    /// Fail-secure: a reject never mutates the row.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn adopt_scrub_upgrade(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::AdoptScrubOutcome, crate::federation::Error> {
+        let directory = self.federation_directory();
+        crate::federation::verify_key_registration(directory.as_ref(), &record.record).await?;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.adopt_scrub_upgrade(record).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.adopt_scrub_upgrade(record).await,
+        }
+    }
+
     /// v8.8.0 (CIRISPersist#234, CEG 1.0-RC28/RC29 §5.6.8.15) — the
     /// symmetric **deregister** path: the revocation teeth a withdrawn
     /// `consent:replication` relies on.

--- a/src/federation/register.rs
+++ b/src/federation/register.rs
@@ -94,6 +94,19 @@ use super::{Error, FederationDirectory};
 use crate::verify::canonical::ceg_produce_canonicalize;
 use crate::verify::{verify_hybrid, HybridPolicy, VerifyOutcome};
 
+/// Outcome of an [`adopt_scrub_upgrade`](crate::engine::Engine::adopt_scrub_upgrade)
+/// — the self-signed → anchor-scrubbed upgrade of a node's own key row
+/// (CIRISPersist#351).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdoptScrubOutcome {
+    /// The self-signed row was replaced by the anchor-scrubbed record.
+    Upgraded,
+    /// The row already carried this exact anchor-scrubbed record — idempotent
+    /// no-op (re-applying the outbox record on a second boot).
+    AlreadyAdopted,
+}
+
 /// v10.1.0 (CIRISPersist#275 hardening) — the **write-path admission
 /// invariant** for a `federation_keys` row's classical public key: it
 /// MUST base64-decode to exactly 32 bytes (a valid Ed25519 key).

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3516,6 +3516,71 @@ impl PyEngine {
         })
     }
 
+    /// v12.2.0 (CIRISPersist#351) — adopt-scrub-**upgrade** this node's own
+    /// key row: replace its self-signed record with the accord-anchor-scrubbed
+    /// one (same `key_id` + pubkey) so it can root. FFI mirror of
+    /// [`Engine::adopt_scrub_upgrade`](crate::engine::Engine::adopt_scrub_upgrade)
+    /// — the `admit-node`/boot "adopt my scrubbed record from the outbox" step.
+    ///
+    /// `signed_key_record_json` is the granting-authority-scrubbed
+    /// `SignedKeyRecord` (`scrub_key_id` = an accord holder). Verifies the
+    /// scrub-signature (`Strict`, same gate as `register_federation_key`) THEN
+    /// the backend's monotonic gated UPDATE. Returns `"upgraded"` or
+    /// `"already_adopted"`; a pubkey change / anchored→self downgrade / missing
+    /// row is a `ValueError`. Fail-secure: a reject never mutates the row.
+    fn adopt_scrub_upgrade(
+        &self,
+        py: Python<'_>,
+        signed_key_record_json: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let record: crate::federation::SignedKeyRecord =
+                serde_json::from_str(signed_key_record_json).map_err(|e| {
+                    PyValueError::new_err(format!("SignedKeyRecord JSON decode: {e}"))
+                })?;
+            let outcome = py.detach(|| match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        crate::federation::verify_key_registration(
+                            backend.as_ref(),
+                            &record.record,
+                        )
+                        .await
+                        .map_err(federation_err_to_py)?;
+                        backend
+                            .adopt_scrub_upgrade(record)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        crate::federation::verify_key_registration(
+                            backend.as_ref(),
+                            &record.record,
+                        )
+                        .await
+                        .map_err(federation_err_to_py)?;
+                        backend
+                            .adopt_scrub_upgrade(record)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+            })?;
+            serde_json::to_value(outcome)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_owned))
+                .ok_or_else(|| PyValueError::new_err("adopt_scrub_upgrade outcome serialize"))
+        })
+    }
+
     /// v1.5.3 — One-call helper that registers THIS engine's local
     /// pubkey as a `federation_keys` row of the specified
     /// `identity_type`. Composes the existing primitives

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2168,6 +2168,117 @@ impl PostgresBackend {
         }
         Ok(())
     }
+
+    /// Gated self-signed → anchor-scrubbed **upgrade** of an own-key row —
+    /// Postgres twin of [`SqliteBackend::adopt_scrub_upgrade`]
+    /// (CIRISPersist#351). Same monotonic + identity-preserving guards; the
+    /// scrub-signature is verified by `Engine::adopt_scrub_upgrade` first.
+    pub async fn adopt_scrub_upgrade(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::AdoptScrubOutcome, crate::federation::Error> {
+        use crate::federation::register::AdoptScrubOutcome;
+        let mut row = record.record;
+
+        if row.scrub_key_id == row.key_id {
+            return Err(crate::federation::Error::InvalidArgument(
+                "adopt_scrub_upgrade requires a granting-authority record (scrub_key_id != key_id)"
+                    .into(),
+            ));
+        }
+        crate::federation::register::validate_registration_pubkey(&row)?;
+        if row.algorithm != crate::federation::types::algorithm::HYBRID {
+            return Err(crate::federation::Error::InvalidArgument(format!(
+                "adopt_scrub_upgrade algorithm must be 'hybrid' (got '{}')",
+                row.algorithm
+            )));
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+
+        let existing = crate::federation::FederationDirectory::lookup_public_key(self, &row.key_id)
+            .await?
+            .ok_or_else(|| {
+                crate::federation::Error::InvalidArgument(format!(
+                    "adopt_scrub_upgrade: no existing row for {} — use register_federation_key",
+                    row.key_id
+                ))
+            })?;
+        if existing.pubkey_ed25519_base64 != row.pubkey_ed25519_base64 {
+            return Err(crate::federation::Error::Conflict(format!(
+                "adopt_scrub_upgrade {}: pubkey change refused (different identity)",
+                row.key_id
+            )));
+        }
+        if existing.scrub_key_id != existing.key_id {
+            return if existing.persist_row_hash == row.persist_row_hash {
+                Ok(AdoptScrubOutcome::AlreadyAdopted)
+            } else {
+                Err(crate::federation::Error::Conflict(format!(
+                    "adopt_scrub_upgrade {}: already anchored to a different record (downgrade/replace refused)",
+                    row.key_id
+                )))
+            };
+        }
+
+        let original_content_hash = hex::decode(&row.original_content_hash).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("original_content_hash hex: {e}"))
+        })?;
+        let roles_param: Option<&Vec<String>> = if row.roles.is_empty() {
+            None
+        } else {
+            Some(&row.roles)
+        };
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        // WHERE re-asserts the guards atomically: self-signed + same pubkey.
+        let n = client
+            .execute(
+                "UPDATE cirislens.federation_keys SET \
+                    pubkey_ml_dsa_65_base64 = $2, algorithm = $3, identity_type = $4, \
+                    identity_ref = $5, valid_from = $6, valid_until = $7, \
+                    registration_envelope = $8, original_content_hash = $9, \
+                    scrub_signature_classical = $10, scrub_signature_pqc = $11, \
+                    scrub_key_id = $12, scrub_timestamp = $13, pqc_completed_at = $14, \
+                    persist_row_hash = $15, roles = $16, attestation_evidence = $17 \
+                 WHERE key_id = $1 AND scrub_key_id = key_id AND pubkey_ed25519_base64 = $18",
+                &[
+                    &row.key_id,
+                    &row.pubkey_ml_dsa_65_base64,
+                    &row.algorithm,
+                    &row.identity_type,
+                    &row.identity_ref,
+                    &row.valid_from,
+                    &row.valid_until,
+                    &row.registration_envelope,
+                    &original_content_hash,
+                    &row.scrub_signature_classical,
+                    &row.scrub_signature_pqc,
+                    &row.scrub_key_id,
+                    &row.scrub_timestamp,
+                    &row.pqc_completed_at,
+                    &row.persist_row_hash,
+                    &roles_param,
+                    &row.attestation_evidence,
+                    &row.pubkey_ed25519_base64,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!(
+                    "adopt_scrub_upgrade {}: {e}",
+                    row.key_id
+                ))
+            })?;
+        if n == 0 {
+            return Err(crate::federation::Error::Conflict(format!(
+                "adopt_scrub_upgrade {}: row changed concurrently",
+                row.key_id
+            )));
+        }
+        Ok(AdoptScrubOutcome::Upgraded)
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1846,6 +1846,142 @@ impl SqliteBackend {
         }
         Ok(())
     }
+
+    /// Gated self-signed → anchor-scrubbed **upgrade** of an existing own-key
+    /// row (CIRISPersist#351). Replaces a self-signed `federation_keys` row
+    /// with the granting-authority-scrubbed record for the SAME `key_id` +
+    /// SAME pubkey, so an in-place node's own row can be re-rooted to the
+    /// accord anchor (its self-signed boot row is otherwise sticky —
+    /// `put_public_key` is `DO NOTHING`). The scrub-signature is verified by
+    /// [`Engine::adopt_scrub_upgrade`](crate::engine::Engine::adopt_scrub_upgrade)
+    /// BEFORE this call (mirrors `register_federation_key` → `put_public_key`).
+    ///
+    /// Monotonic + identity-preserving guards:
+    /// - incoming MUST be granting-authority (`scrub_key_id != key_id`);
+    /// - the existing row MUST be self-signed (`scrub_key_id == key_id`) —
+    ///   a downgrade (anchored → self) or re-anchor is refused;
+    /// - the Ed25519 pubkey MUST be unchanged (a pubkey change is a different
+    ///   identity, refused);
+    /// - re-applying the exact same anchored record is idempotent
+    ///   ([`AdoptScrubOutcome::AlreadyAdopted`]).
+    pub async fn adopt_scrub_upgrade(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::AdoptScrubOutcome, crate::federation::Error> {
+        use crate::federation::register::AdoptScrubOutcome;
+        let mut row = record.record;
+
+        if row.scrub_key_id == row.key_id {
+            return Err(crate::federation::Error::InvalidArgument(
+                "adopt_scrub_upgrade requires a granting-authority record (scrub_key_id != key_id)"
+                    .into(),
+            ));
+        }
+        crate::federation::register::validate_registration_pubkey(&row)?;
+        if row.algorithm != crate::federation::types::algorithm::HYBRID {
+            return Err(crate::federation::Error::InvalidArgument(format!(
+                "adopt_scrub_upgrade algorithm must be 'hybrid' (got '{}')",
+                row.algorithm
+            )));
+        }
+        row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+
+        // Resolve the existing row + classify the transition.
+        let existing = crate::federation::FederationDirectory::lookup_public_key(self, &row.key_id)
+            .await?
+            .ok_or_else(|| {
+                crate::federation::Error::InvalidArgument(format!(
+                    "adopt_scrub_upgrade: no existing row for {} — use register_federation_key",
+                    row.key_id
+                ))
+            })?;
+        if existing.pubkey_ed25519_base64 != row.pubkey_ed25519_base64 {
+            return Err(crate::federation::Error::Conflict(format!(
+                "adopt_scrub_upgrade {}: pubkey change refused (different identity)",
+                row.key_id
+            )));
+        }
+        if existing.scrub_key_id != existing.key_id {
+            // Already anchored: idempotent iff byte-identical, else refuse.
+            return if existing.persist_row_hash == row.persist_row_hash {
+                Ok(AdoptScrubOutcome::AlreadyAdopted)
+            } else {
+                Err(crate::federation::Error::Conflict(format!(
+                    "adopt_scrub_upgrade {}: already anchored to a different record (downgrade/replace refused)",
+                    row.key_id
+                )))
+            };
+        }
+
+        let envelope_text = serde_json::to_string(&row.registration_envelope)
+            .map_err(|e| crate::federation::Error::Backend(format!("envelope: {e}")))?;
+        let attestation_text: Option<String> = match &row.attestation_evidence {
+            Some(v) => Some(
+                serde_json::to_string(v)
+                    .map_err(|e| crate::federation::Error::Backend(format!("attestation: {e}")))?,
+            ),
+            None => None,
+        };
+        let roles_text: Option<String> = if row.roles.is_empty() {
+            None
+        } else {
+            Some(
+                serde_json::to_string(&row.roles)
+                    .map_err(|e| crate::federation::Error::Backend(format!("roles: {e}")))?,
+            )
+        };
+        let original_content_hash = hex::decode(&row.original_content_hash).map_err(|e| {
+            crate::federation::Error::InvalidArgument(format!("original_content_hash hex: {e}"))
+        })?;
+        let conn = self.conn.clone();
+        let kid = row.key_id.clone();
+        let n = (move || -> Result<usize, rusqlite::Error> {
+            let conn = conn.lock();
+            // The WHERE re-asserts the guards atomically: self-signed + same
+            // pubkey. The Ed25519 pubkey is the guard, so it is NOT updated.
+            conn.execute(
+                "UPDATE federation_keys SET \
+                    pubkey_ml_dsa_65_base64 = ?2, algorithm = ?3, identity_type = ?4, \
+                    identity_ref = ?5, valid_from = ?6, valid_until = ?7, \
+                    registration_envelope = ?8, original_content_hash = ?9, \
+                    scrub_signature_classical = ?10, scrub_signature_pqc = ?11, \
+                    scrub_key_id = ?12, scrub_timestamp = ?13, pqc_completed_at = ?14, \
+                    persist_row_hash = ?15, roles = ?16, attestation_evidence = ?17 \
+                 WHERE key_id = ?1 AND scrub_key_id = key_id AND pubkey_ed25519_base64 = ?18",
+                rusqlite::params![
+                    row.key_id,
+                    row.pubkey_ml_dsa_65_base64,
+                    row.algorithm,
+                    row.identity_type,
+                    row.identity_ref,
+                    row.valid_from.to_rfc3339(),
+                    row.valid_until.map(|t| t.to_rfc3339()),
+                    envelope_text,
+                    original_content_hash,
+                    row.scrub_signature_classical,
+                    row.scrub_signature_pqc,
+                    row.scrub_key_id,
+                    row.scrub_timestamp.to_rfc3339(),
+                    row.pqc_completed_at.map(|t| t.to_rfc3339()),
+                    row.persist_row_hash,
+                    roles_text,
+                    attestation_text,
+                    row.pubkey_ed25519_base64,
+                ],
+            )
+        })()
+        .map_err(|e| {
+            crate::federation::Error::Backend(format!("adopt_scrub_upgrade {kid}: {e}"))
+        })?;
+        if n == 0 {
+            // Guards passed the Rust checks but the atomic WHERE matched 0 —
+            // a concurrent mutation raced us. Fail-secure.
+            return Err(crate::federation::Error::Conflict(format!(
+                "adopt_scrub_upgrade {kid}: row changed concurrently"
+            )));
+        }
+        Ok(AdoptScrubOutcome::Upgraded)
+    }
 }
 
 #[async_trait::async_trait]
@@ -14924,6 +15060,119 @@ mod tests {
             roles: Vec::new(),
             attestation_evidence: None,
         }
+    }
+
+    /// #351 — the backend adopt-scrub-upgrade gate: self-signed → anchored
+    /// succeeds, is idempotent, and refuses pubkey-change / downgrade /
+    /// no-such-row. (The scrub-signature is verified by the Engine layer; this
+    /// exercises the backend's monotonic DB gate directly.)
+    #[tokio::test]
+    async fn adopt_scrub_upgrade_gate_sqlite() {
+        use crate::federation::register::AdoptScrubOutcome;
+        use crate::federation::FederationDirectory;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        // The anchor holders must exist (scrub_key_must_exist FK; mirrors the
+        // real seed where A1/B1 are genesis rows).
+        for a in ["A1", "B1"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key(a, a, a),
+                })
+                .await
+                .unwrap();
+        }
+        // A self-signed own-key row (the in-place boot state).
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("node-x", "node-x", "node-x"),
+            })
+            .await
+            .unwrap();
+
+        // Upgrade: same key_id + same pubkey, scrub_key_id = an anchor holder.
+        let scrubbed = SignedKeyRecord {
+            record: fed_key("node-x", "node-x", "A1"),
+        };
+        assert_eq!(
+            backend.adopt_scrub_upgrade(scrubbed.clone()).await.unwrap(),
+            AdoptScrubOutcome::Upgraded
+        );
+        let row = FederationDirectory::lookup_public_key(&backend, "node-x")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.scrub_key_id, "A1", "row is now anchor-scrubbed");
+        assert_ne!(row.scrub_key_id, row.key_id, "no longer self-signed");
+
+        // Idempotent re-adopt.
+        assert_eq!(
+            backend.adopt_scrub_upgrade(scrubbed).await.unwrap(),
+            AdoptScrubOutcome::AlreadyAdopted
+        );
+
+        // Downgrade / re-anchor to a DIFFERENT holder refused.
+        let err = backend
+            .adopt_scrub_upgrade(SignedKeyRecord {
+                record: fed_key("node-x", "node-x", "B1"),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::Conflict(_)),
+            "re-anchor refused, got {err:?}"
+        );
+
+        // A self-signed record is not an upgrade.
+        let err = backend
+            .adopt_scrub_upgrade(SignedKeyRecord {
+                record: fed_key("node-x", "node-x", "node-x"),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+    }
+
+    /// #351 — a pubkey change (different identity) is refused even with a
+    /// granting-authority scrub, and adopting a key with no existing row errors.
+    #[tokio::test]
+    async fn adopt_scrub_upgrade_pubkey_change_refused_sqlite() {
+        use crate::federation::FederationDirectory;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("A1", "A1", "A1"),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("node-y", "node-y", "node-y"),
+            })
+            .await
+            .unwrap();
+        // Same key_id, anchor-scrubbed, but a DIFFERENT pubkey.
+        let mut rec = fed_key("node-y", "node-y", "A1");
+        rec.pubkey_ed25519_base64 =
+            crate::federation::tier_ingest::test_support::hybrid_pubkeys("someone-else").0;
+        let err = backend
+            .adopt_scrub_upgrade(SignedKeyRecord { record: rec })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::Conflict(_)),
+            "pubkey change refused, got {err:?}"
+        );
+
+        // No existing row → InvalidArgument.
+        let err = backend
+            .adopt_scrub_upgrade(SignedKeyRecord {
+                record: fed_key("ghost", "ghost", "A1"),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
     }
 
     /// v9.3.0 (#247) — the DERIVED federation key_id for `alias`'s


### PR DESCRIPTION
Closes #351. The missing producer step for the **in-place** genesis mesh seed.

## The gap

An upgraded-in-place node (A/B were upgraded, not wiped) holds its **self-signed** own-key row from `register_self_key` at boot. `register_federation_key` is `ON CONFLICT (key_id) DO NOTHING`, so applying the accord-holder-**scrubbed** record for the same `key_id` is a no-op — the self-signed row wins forever, so no peer can root it. The seed can't complete in place.

## The primitive

- **`Engine::adopt_scrub_upgrade(record)`** — verifies the incoming scrub-signature first (the same `verify_key_registration` `Strict` gate as `register_federation_key`; granting-authority resolves the scrubber's pubkeys from the directory), then dispatches to the backend's gated UPDATE. Fail-secure: a reject never mutates.
- **`{Sqlite,Postgres}Backend::adopt_scrub_upgrade`** — `ON CONFLICT DO UPDATE` restricted to the self-signed→anchored transition by an **atomic WHERE guard** (`scrub_key_id = key_id AND pubkey_ed25519_base64 = <incoming>`). The pubkey is the guard (never updated). Refuses:
  - **pubkey change** → `Conflict` (different identity);
  - **anchored→self downgrade** / re-anchor to a different holder → `Conflict` (monotonic);
  - **missing row** → `InvalidArgument` (use `register_federation_key`);
  - and is **idempotent** re-applying the same record (`AlreadyAdopted`).
- **`federation::register::AdoptScrubOutcome`** (`Upgraded`/`AlreadyAdopted`), serde-exposed; the **PyEngine FFI** `adopt_scrub_upgrade` returns `"upgraded"`/`"already_adopted"` (the `admit-node`/boot "adopt my scrubbed record from the outbox" step).

## Tests

`adopt_scrub_upgrade_gate_sqlite` (upgrade → idempotent → re-anchor refused → self-record refused) + `adopt_scrub_upgrade_pubkey_change_refused_sqlite` (pubkey change refused, no-row errors). The scrubber (A1) must exist as a `federation_keys` row — the `scrub_key_must_exist` FK, which also mirrors the real seed. All 3 backends compile; verify pin unchanged v8.5.0.

Unblocks CIRISServer `admit-node` (target = local node) + the 0.5.78 Key plane (CIRISServer#144) + the genesis mesh seed (CIRISServer#139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)