### PR TITLE
v12.3.0 — #320 capsule UAF fix + #357 §19.7.1.2 dominance gate (verify v8.6.0) + #355 drop dead openssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ so the fold's *effective* N is checkable at admission.
 Wheel `Requires-Dist: ciris-verify>=8.0.0,<9` unchanged (minor bump within
 major 8). Full suite green: 1049 sqlite / 882 postgres · aggregation_tier pg+sqlite.
 
+### Removed — #355: drop the dead vendored `openssl` + unused `bytes`
+
+`openssl = { "0.10", vendored }` was gated behind `postgres` (+ the android/ios
+target tables) but had **zero code references** — `cargo tree -i openssl`
+confirmed a leaf (only `ciris-persist`); the pool uses `NoTls` and TLS is the
+separate rustls path. Removed all three entries + `dep:openssl` from the
+`postgres` feature. This drops `openssl`/`-macros`/`-sys` + `foreign-types{,-shared}`
+**and the `openssl-src` build-dep that compiles OpenSSL 3.6.3 from C on every
+wheel platform** — the slowest, flakiest step in the build matrix (the mobile
+`#246` pain, plausibly behind the recurring Windows-installer failures). Also
+dropped the unused direct `bytes` dep (only a doc-comment reference; still
+transitive via tokio-postgres/reqwest). Inert leaf, no link consumer — both
+backends + the wheel feature set build green with `openssl` absent from the tree.
+
+### Deps
+- `deny.toml`: ignore RUSTSEC-2026-0118 (hickory-proto NSEC3 DNSSEC-validation
+  loop) — transitive via verify → hickory-resolver (reqwest's plain resolver);
+  persist does not enable DNSSEC/NSEC3 validation so the path is unreachable, and
+  no patched version exists. Sibling of the already-ignored RUSTSEC-2026-0119.
+
 ## [12.2.0] — 2026-07-03
 
 ### Added — #351: adopt-scrub-upgrade primitive (self-signed → anchor-scrubbed own-key row)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.3.0] — 2026-07-03
+
+### Fixed — #320: cross-cdylib capsule use-after-free (transport bring-up SIGSEGV)
+
+`init_edge_runtime(enable_transport=True)` against persist ≥12.0 crashed with a
+SIGSEGV inside `Arc<dyn FederationDirectory>::clone` at `directory_capsule.rs`.
+Root cause: the `*_ops_capsule` / `executor_capsule` accessors each minted a
+**fresh** `PyCapsule` per call, whose GC destructor frees the boxed handle its
+raw `data` pointer targets. A consumer (edge) extracts the raw pointer once and
+relies on the engine owning the capsule — but the fresh temporary is GC'd
+immediately, so a later async op cloned a **freed** `Arc` → use-after-free.
+
+Fix: **cache the four capsules on `PyEngine`** (`std::sync::OnceLock<Py<PyCapsule>>`
+for `directory_ops` / `outbound_queue_ops` / `signer_ops` / `executor`) via a
+shared `cached_capsule` helper — build-once, return a bound clone of the same
+capsule on every access, so the boxed data outlives any consumer that extracted
+the pointer. Added env-gated (`CIRIS_PERSIST_TRACE`) `dtrace` on the directory-
+ops-proxy boundary (`SEND`/`BUILD_OP`/`EXECUTE`/`COMPLETE`/`CALLBACK`/`RECV`) —
+zero-cost when off — so a cohab hang localizes to an exact stage/op.
+
+Note: this fixes the **crash**. The separate transport **deadlock** in the same
+call is an edge-side bug (edge drives its own async via `runtime.block_on()` on
+persist's cross-cdylib raw `tokio::Handle`, which wedges in release builds inside
+`Handle::block_on`; the fix is to route through the executor vtable / `run_async`)
+— tracked as a CIRISEdge change, proven in a release build against this cut.
+
+### Added — #357: §19.7.1.2 dominance gate + AggregationMetaV1 v2 preimage (CIRISVerify#167)
+
+Re-pin **ciris-verify-core/keyring/crypto v8.5.0 → v8.6.0** (carries CIRISVerify#167).
+A composite where one source supplies ~90% of the mass (the 900/1000 case) was
+indistinguishable from a balanced fold (`source_count` is raw N). v8.6.0 adds a
+**signed** effective-source-count `n_eff` (inverse-Simpson participation ratio)
+so the fold's *effective* N is checkable at admission.
+
+- **`n_eff` threaded** through persist's `AggregationMetaVerifyInputsV1` →
+  `to_verify_meta` (`#[serde(default)]` so pre-#167 stored/wire inputs still
+  parse). Persist now reproduces the **v2 canonical preimage** (v1 layout `‖
+  u32(n_eff)` for version ≥ 2; a v1 tier's preimage is byte-identical to pre-#167,
+  so existing signatures/vectors verify unchanged).
+- **Dominance gate at admission** — after `verify_aggregation_meta` authenticates
+  `n_eff`, `AggregationMetaV1::verify_for_admission` calls
+  `passes_dominance_gate(meta, MIN_DOMINANCE_RATIO)` and rejects a dominated tier
+  with `AggregationMetaError::Dominated` (`kind = "aggregation_meta_dominated"`),
+  BEFORE persistence (§10.1.5.1.1). `MIN_DOMINANCE_RATIO = 0.5` (effective N must
+  be ≥ half of raw N; twins with CIRISConstitution#6). **Fail-closed**: a
+  version-1 tier carries no *signed* `n_eff` and is rejected — a dominated
+  aggregator cannot bypass the floor by declaring the pre-#167 schema.
+- `aggregation_tier` vectors upgraded to signed v2 folds; new `(b2)` assertion
+  proves a dominated fold (`n_eff=1, source_count=3 → 0.33 < 0.5`) is rejected
+  with zero rows written, on **both** sqlite + postgres.
+
+Wheel `Requires-Dist: ciris-verify>=8.0.0,<9` unchanged (minor bump within
+major 8). Full suite green: 1049 sqlite / 882 postgres · aggregation_tier pg+sqlite.
+
 ## [12.2.0] — 2026-07-03
 
 ### Added — #351: adopt-scrub-upgrade primitive (self-signed → anchor-scrubbed own-key row)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 default = []
 
 # Phase 1 features.
-postgres = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:bytes", "dep:postgres-types", "dep:refinery", "refinery/tokio-postgres", "dep:openssl"]
+postgres = ["dep:tokio-postgres", "dep:deadpool-postgres", "dep:postgres-types", "dep:refinery", "refinery/tokio-postgres"]
 server   = ["dep:axum", "dep:tower", "dep:http-body-util"]
 # pyo3 implies postgres — the lens FastAPI integration shape (FSD §3.5)
 # needs the Postgres backend to be available. This is the published-wheel
@@ -593,7 +593,6 @@ jsonschema    = { version = "0.46", default-features = false }
 # decoder paths.
 tokio-postgres    = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"], optional = true }
 deadpool-postgres = { version = "0.14", optional = true }
-bytes             = { version = "1", optional = true }
 postgres-types    = { version = "0.2.14", optional = true }
 # CIRISPersist#339 — `default-features = false` drops refinery's default
 # `toml` feature (config-file loading, which we never use — migrations are
@@ -608,16 +607,12 @@ refinery          = { version = "0.9", default-features = false, optional = true
 tokio-postgres-rustls = { version = "0.13", optional = true }
 rustls                = { version = "0.23", optional = true }
 rustls-native-certs   = { version = "0.8", optional = true }
-# `openssl` is pulled ONLY by the `postgres` feature (`dep:openssl`,
-# below) — the Postgres connection pool builds against it. It is NOT a
-# transitive requirement of refinery (verified via `cargo tree -i
-# native-tls` → absent on every target; CIRISPersist#339): refinery's
-# `tokio-postgres` backend uses `NoTls` and does not pull
-# postgres-native-tls/native-tls/openssl-sys. `vendored` builds openssl
-# from source for the target arch (no system libssl-dev:<arch> needed),
-# which matters for the postgres-enabled cross-compiles. A sqlite-only
-# build pulls no openssl at all.
-openssl           = { version = "0.10", features = ["vendored"], optional = true }
+# v12.3.0 (CIRISPersist#355) — the vendored `openssl` dep was removed. It
+# was a DEAD LEAF: gated behind `postgres` but with ZERO code references
+# (`cargo tree -i openssl` → only ciris-persist; the pool uses `NoTls`,
+# TLS is the separate rustls path). Dropping it (base + the android/ios
+# target entries below) kills the OpenSSL-from-C build-dep — the slowest,
+# flakiest step in the wheel matrix.
 
 # Phase 1 — server feature
 axum  = { version = "0.8", optional = true }
@@ -781,34 +776,17 @@ ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
-# v2.0.4 / CIRISPersist#339 — vendored openssl for iOS PyO3
-# cross-compilation, but ONLY when the `postgres` feature is active.
-# `optional = true` (was unconditional) unions with the base `dep:openssl`
-# (which only the `postgres` feature enables) + adds the `vendored`
-# feature on iOS, where there is no system libssl. A `pyo3-sqlite`
-# (sqlite-only) iOS wheel now pulls NO openssl at all — retiring the
-# vendored build-from-source (CIRISEdge#246). ARM64 has no SM4-NI issue
-# unlike Android x86_64. Same pattern as the Android entry.
-openssl = { version = "0.10", features = ["vendored"], optional = true }
+# v12.3.0 (CIRISPersist#355) — vendored openssl removed here too (dead leaf;
+# see the base-deps note). No iOS openssl in any configuration now.
 
 [target.'cfg(target_os = "android")'.dependencies]
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
 ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "android"] }
-# v2.0.3 / CIRISPersist#339 — vendored openssl for Android
-# cross-compilation, gated behind the `postgres` feature. NOTE: an earlier
-# comment here blamed refinery-core for transitively pulling
-# postgres-native-tls → native-tls → openssl-sys "regardless of feature".
-# That was wrong — verified via `cargo tree -i native-tls` (absent on every
-# target, sqlite-only and postgres alike): refinery's tokio-postgres backend
-# uses NoTls and pulls no openssl. openssl comes ONLY from the `postgres`
-# connection pool's `dep:openssl`. So `optional = true` (was unconditional)
-# unions with the base `dep:openssl` + adds `vendored` on Android (no system
-# openssl). A `pyo3-sqlite` Android wheel now pulls NO openssl — retiring the
-# vendored build-from-source, the flakiest part of the mobile matrix
-# (CIRISEdge#246).
-openssl = { version = "0.10", features = ["vendored"], optional = true }
+# v12.3.0 (CIRISPersist#355) — vendored openssl removed here too (dead leaf;
+# see the base-deps note). No Android openssl in any configuration now,
+# retiring the flakiest part of the mobile wheel matrix.
 
 [dev-dependencies]
 # Mission category §4: canonicalization parity. Used to validate our

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.2.0"
+version = "12.3.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -503,14 +503,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -777,10 +777,10 @@ tokio-stream = "0.1"
 # key). Placed AFTER every platform-independent dep — see the v0.9.0
 # bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v2.0.4 / CIRISPersist#339 — vendored openssl for iOS PyO3
 # cross-compilation, but ONLY when the `postgres` feature is active.
 # `optional = true` (was unconditional) unions with the base `dep:openssl`
@@ -795,7 +795,7 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v2.0.3 / CIRISPersist#339 — vendored openssl for Android
 # cross-compilation, gated behind the `postgres` feature. NOTE: an earlier
 # comment here blamed refinery-core for transitively pulling

--- a/deny.toml
+++ b/deny.toml
@@ -65,6 +65,11 @@ ignore = [
     # None of these advisories touch persist's ingest hot path.
     "RUSTSEC-2026-0119",  # hickory-proto DNS encoding O(n²) — DoS during DNS encoding;
                            # persist talks to Postgres, no DNS encode path
+    "RUSTSEC-2026-0118",  # hickory-proto NSEC3 closest-encloser proof loop on cross-zone
+                           # responses — a DNSSEC-VALIDATION vuln. Transitive via
+                           # ciris-verify-core → hickory-resolver (reqwest's plain resolver);
+                           # persist does NOT enable DNSSEC/NSEC3 validation, so the vulnerable
+                           # path is unreachable. No patched version exists (patched=[]).
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained — transitive via reqwest/rustls
     "RUSTSEC-2026-0098",  # rustls-webpki URI-name constraint (we don't validate URI SANs)
     "RUSTSEC-2026-0099",  # rustls-webpki wildcard-DNS constraint (no name-constraint certs)

--- a/src/ffi/directory_capsule.rs
+++ b/src/ffi/directory_capsule.rs
@@ -131,6 +131,42 @@ use crate::fountain::{FountainHeldMeta, FountainTier};
 // two must agree on the exact boxed-future type.
 use crate::ffi::executor_capsule::TaskOpaque;
 
+/// CIRISPersist#320 diagnostic — env-gated (`CIRIS_PERSIST_TRACE`) trace of the
+/// directory-ops-proxy boundary, so a transport-bring-up hang localizes to an
+/// exact stage/op. **Silent** unless the env var is set (checked once, cached),
+/// so it is zero-cost in production. The consumer (edge) side logs
+/// `SEND`/`RECV`; the persist-`.so` side logs `BUILD_OP`/`EXECUTE`/`COMPLETE`/
+/// `CALLBACK`. A stall shows as the last stage printed with no follow-up:
+///   * `SEND` with no `BUILD_OP`  → the op never crossed the FFI / spawned.
+///   * `EXECUTE` with no `COMPLETE` → the directory method itself hung.
+///   * `COMPLETE` with no `RECV`  → the result callback / consumer recv broke.
+#[inline]
+pub(crate) fn dtrace_enabled() -> bool {
+    use std::sync::atomic::{AtomicU8, Ordering};
+    static ON: AtomicU8 = AtomicU8::new(0); // 0=unknown, 1=off, 2=on
+    match ON.load(Ordering::Relaxed) {
+        0 => {
+            let v = if std::env::var_os("CIRIS_PERSIST_TRACE").is_some() {
+                2
+            } else {
+                1
+            };
+            ON.store(v, Ordering::Relaxed);
+            v == 2
+        }
+        v => v == 2,
+    }
+}
+
+#[inline]
+pub(crate) fn dtrace(stage: &str, op: &str) {
+    if dtrace_enabled() {
+        // Truncate the op preview so a large payload doesn't flood the log.
+        let op = if op.len() > 90 { &op[..90] } else { op };
+        eprintln!("[ciris_persist directory_op] {stage} {op}");
+    }
+}
+
 /// The boxed-future shape [`crate::ffi::executor_capsule`] spawns. The
 /// pointer returned by [`DirectoryVTable::build_op`] is a
 /// `Box<BoxedFut>` cast to `*mut TaskOpaque`, byte-identical to what the
@@ -865,6 +901,16 @@ unsafe extern "C" fn persist_directory_build_op(
     let parsed: Result<DirectoryOp, String> =
         serde_json::from_slice::<DirectoryOp>(op_bytes).map_err(|e| e.to_string());
 
+    // #320 trace: owned preview of the op JSON (op_bytes is only valid for
+    // this synchronous call; the future runs later on a worker thread).
+    // Allocated only when tracing is on — zero-cost in production.
+    let op_preview: String = if dtrace_enabled() {
+        String::from_utf8_lossy(op_bytes).into_owned()
+    } else {
+        String::new()
+    };
+    dtrace("BUILD_OP", &op_preview);
+
     // Capture the consumer callback + context in a Send bundle so the
     // future (spawned onto persist's worker pool) may hold it.
     let completion = SendCompletion {
@@ -876,10 +922,12 @@ unsafe extern "C" fn persist_directory_build_op(
         // Keep the cloned Arc + completion bundle alive across the await.
         let dir = dir;
         let completion = completion;
+        dtrace("EXECUTE", &op_preview);
         let result: DirectoryOpResult = match parsed {
             Ok(op) => dispatch_directory_op(dir.as_ref(), op).await,
             Err(msg) => DirectoryOpResult::Err(format!("directory op parse failure: {msg}")),
         };
+        dtrace("COMPLETE", &op_preview);
         // Serialization of `DirectoryOpResult` cannot realistically fail
         // (owned data, no non-string map keys). If it somehow did, fall
         // back to a serialized Err so the consumer's completion path
@@ -895,6 +943,7 @@ unsafe extern "C" fn persist_directory_build_op(
         // Send, called exactly once from this worker thread. `bytes`
         // outlives the synchronous call (dropped only after the callback
         // returns); the consumer copies before returning.
+        dtrace("CALLBACK", &op_preview);
         unsafe {
             (completion.cb)(completion.ctx, bytes.as_ptr(), bytes.len());
         }
@@ -1058,6 +1107,14 @@ impl OpsDirectory {
         let op_bytes = serde_json::to_vec(op).map_err(|e| {
             Error::Backend(format!("directory ops proxy: op serialize failure: {e}"))
         })?;
+        // #320 trace (consumer side): op preview for SEND/RECV bracketing.
+        // Allocated only when tracing is on — zero-cost in production.
+        let op_preview: String = if dtrace_enabled() {
+            String::from_utf8_lossy(&op_bytes).into_owned()
+        } else {
+            String::new()
+        };
+        dtrace("SEND", &op_preview);
 
         let (tx, rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
         // Hand the Sender to persist as an opaque `*mut c_void`; the
@@ -1100,6 +1157,7 @@ impl OpsDirectory {
                 "directory ops proxy: directory op producer dropped without responding".into(),
             )
         })?;
+        dtrace("RECV", &op_preview);
 
         serde_json::from_slice::<DirectoryOpResult>(&result_bytes).map_err(|e| {
             Error::Backend(format!(

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -623,6 +623,42 @@ pub struct PyEngine {
     /// state — `set_multimedia_config_json` mutates the shared slot.
     #[cfg(feature = "cirisnode")]
     multimedia_config: Arc<std::sync::RwLock<Option<Arc<crate::cirisnode::MultimediaConfig>>>>,
+    /// v12.2.1 (CIRISPersist#320) — the directory-ops-proxy capsule, built
+    /// once and **cached on the engine**. Consumers (CIRISEdge#245) extract the
+    /// raw `Directory { data, vtable }` pointer and rely on the capsule (and
+    /// thus the boxed `Arc<dyn FederationDirectory>` it owns + frees on GC)
+    /// outliving the consumer — "rooted in the Python engine object" per edge's
+    /// own contract. Minting a FRESH temporary per access GC'd it immediately,
+    /// so an async op (transport bring-up) called `build_op` on a dangling
+    /// `data` → `Arc::clone` UAF → SIGSEGV. Caching keeps it alive for the
+    /// engine's lifetime, making the consumer contract sound.
+    directory_ops_capsule_cache: std::sync::OnceLock<pyo3::Py<pyo3::types::PyCapsule>>,
+    /// v12.2.1 (CIRISPersist#320) — same UAF fix for the other capsules that
+    /// hand out a raw pointer with a GC-freeing destructor. The executor one is
+    /// the load-bearing case for the transport deadlock: `spawn` on a GC'd
+    /// executor lands the task on a torn-down runtime (task never runs → the
+    /// bring-up's `run_async` recv blocks forever). Outbound + signer are the
+    /// same latent class. Cached ⇒ alive for the engine's lifetime.
+    outbound_queue_ops_capsule_cache: std::sync::OnceLock<pyo3::Py<pyo3::types::PyCapsule>>,
+    signer_ops_capsule_cache: std::sync::OnceLock<pyo3::Py<pyo3::types::PyCapsule>>,
+    executor_capsule_cache: std::sync::OnceLock<pyo3::Py<pyo3::types::PyCapsule>>,
+}
+
+/// #320 — build-once/cache a capsule on the engine so the boxed value its raw
+/// `data` points at outlives any consumer that extracted the pointer (the
+/// PyCapsule's GC destructor would otherwise free it while still in use). The
+/// GIL (`py`) serializes init; `OnceLock::set` is race-safe regardless.
+fn cached_capsule<'py>(
+    cell: &std::sync::OnceLock<pyo3::Py<pyo3::types::PyCapsule>>,
+    py: Python<'py>,
+    build: impl FnOnce() -> PyResult<Bound<'py, pyo3::types::PyCapsule>>,
+) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
+    if let Some(cached) = cell.get() {
+        return Ok(cached.bind(py).clone());
+    }
+    let capsule = build()?;
+    let _ = cell.set(capsule.unbind());
+    Ok(cell.get().expect("just set").bind(py).clone())
 }
 
 impl PyEngine {
@@ -645,6 +681,10 @@ impl PyEngine {
             subscriptions: cell.subscriptions.clone(),
             #[cfg(feature = "cirisnode")]
             multimedia_config: cell.multimedia_config.clone(),
+            directory_ops_capsule_cache: std::sync::OnceLock::new(),
+            outbound_queue_ops_capsule_cache: std::sync::OnceLock::new(),
+            signer_ops_capsule_cache: std::sync::OnceLock::new(),
+            executor_capsule_cache: std::sync::OnceLock::new(),
         }
     }
 
@@ -2091,6 +2131,10 @@ impl PyEngine {
             subscriptions: self.subscriptions.clone(),
             #[cfg(feature = "cirisnode")]
             multimedia_config: self.multimedia_config.clone(),
+            directory_ops_capsule_cache: std::sync::OnceLock::new(),
+            outbound_queue_ops_capsule_cache: std::sync::OnceLock::new(),
+            signer_ops_capsule_cache: std::sync::OnceLock::new(),
+            executor_capsule_cache: std::sync::OnceLock::new(),
         })
     }
 
@@ -22581,14 +22625,19 @@ impl PyEngine {
         &self,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
-        let arc: Arc<dyn crate::federation::FederationDirectory> = match &self.backend {
-            #[cfg(feature = "postgres")]
-            BackendDispatch::Postgres(b) => b.clone(),
-            #[cfg(feature = "sqlite")]
-            BackendDispatch::Sqlite(b) => b.clone(),
-        };
-        crate::ffi::directory_capsule::build_capsule_with_destructor(py, arc)
-            .map_err(|e| PyErr::new::<LensQueryError, _>(format!("directory_ops_capsule: {e}")))
+        // #320: build ONCE and cache on the engine so the capsule (and the
+        // boxed Arc its `data` points at) outlives any consumer that extracts
+        // the raw pointer — the transport-bring-up UAF fix.
+        cached_capsule(&self.directory_ops_capsule_cache, py, || {
+            let arc: Arc<dyn crate::federation::FederationDirectory> = match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(b) => b.clone(),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => b.clone(),
+            };
+            crate::ffi::directory_capsule::build_capsule_with_destructor(py, arc)
+                .map_err(|e| PyErr::new::<LensQueryError, _>(format!("directory_ops_capsule: {e}")))
+        })
     }
 
     /// v2.7.0 (CIRISPersist#109) — cross-module accessor for the
@@ -22660,15 +22709,18 @@ impl PyEngine {
         &self,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
-        let dispatch = match &self.backend {
-            #[cfg(feature = "postgres")]
-            BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
-            #[cfg(feature = "sqlite")]
-            BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
-        };
-        crate::ffi::outbound_queue_capsule::build_capsule_with_destructor(py, dispatch).map_err(
-            |e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_ops_capsule: {e}")),
-        )
+        // #320: cache — same UAF fix as directory_ops_capsule.
+        cached_capsule(&self.outbound_queue_ops_capsule_cache, py, || {
+            let dispatch = match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
+            };
+            crate::ffi::outbound_queue_capsule::build_capsule_with_destructor(py, dispatch).map_err(
+                |e| PyErr::new::<LensQueryError, _>(format!("outbound_queue_ops_capsule: {e}")),
+            )
+        })
     }
 
     /// v2.7.0 (CIRISPersist#109) — cross-module accessor for the
@@ -22742,13 +22794,16 @@ impl PyEngine {
         &self,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyCapsule>> {
-        let handle = crate::signing::KeyringSignerHandle {
-            signer: self.signer.clone(),
-            pqc_signer: self.local_signer.as_ref().and_then(|ls| ls.pqc_signer()),
-            key_id: self.signer_key_id.clone(),
-        };
-        crate::ffi::signer_capsule::build_capsule_with_destructor(py, handle)
-            .map_err(|e| PyErr::new::<LensQueryError, _>(format!("signer_ops_capsule: {e}")))
+        // #320: cache — same UAF fix as directory_ops_capsule.
+        cached_capsule(&self.signer_ops_capsule_cache, py, || {
+            let handle = crate::signing::KeyringSignerHandle {
+                signer: self.signer.clone(),
+                pqc_signer: self.local_signer.as_ref().and_then(|ls| ls.pqc_signer()),
+                key_id: self.signer_key_id.clone(),
+            };
+            crate::ffi::signer_capsule::build_capsule_with_destructor(py, handle)
+                .map_err(|e| PyErr::new::<LensQueryError, _>(format!("signer_ops_capsule: {e}")))
+        })
     }
 
     /// v2.8.0 (CIRISPersist#111) — cross-cdylib accessor for the tokio
@@ -22908,8 +22963,15 @@ impl PyEngine {
         // Delegate to the executor_capsule module — the unsafe
         // PyCapsule::new_with_destructor lives there, scoped under
         // that module's `#![allow(unsafe_code)]` for FFI surfaces.
-        crate::ffi::executor_capsule::build_capsule_with_destructor(py, self.runtime.clone())
-            .map_err(|e| PyErr::new::<LensQueryError, _>(format!("executor_capsule: {e}")))
+        //
+        // #320: cache. This is the load-bearing one for the transport
+        // deadlock — a GC'd executor capsule frees the boxed runtime handle,
+        // so edge's `spawn` lands the task on a torn-down runtime and it never
+        // runs (the bring-up's `run_async` recv then blocks forever).
+        cached_capsule(&self.executor_capsule_cache, py, || {
+            crate::ffi::executor_capsule::build_capsule_with_destructor(py, self.runtime.clone())
+                .map_err(|e| PyErr::new::<LensQueryError, _>(format!("executor_capsule: {e}")))
+        })
     }
 
     /// v2.11.0 (CIRISPersist#115) — cross-module accessor for the blob

--- a/src/fountain/aggregation.rs
+++ b/src/fountain/aggregation.rs
@@ -61,9 +61,22 @@ use serde::{Deserialize, Serialize};
 
 pub use ciris_verify_core::holonomic::aggregation::descend_order;
 pub use ciris_verify_core::holonomic::{
-    ejection_verdict, member_commitment, verify_aggregation_meta, verify_member_commitment,
-    AggregationMetaVerification, EjectionVerdict,
+    ejection_verdict, member_commitment, passes_dominance_gate, verify_aggregation_meta,
+    verify_member_commitment, AggregationMetaVerification, EjectionVerdict,
 };
+
+/// §19.7.1.2 (CIRISVerify#167 / CIRISPersist#357) — the CC 6.1.2 noise-floor
+/// dominance floor persist enforces at admission: a composite's **effective**
+/// source count (`n_eff`) must be at least this fraction of its raw
+/// `source_count`, else one source supplies too much of the mass and the
+/// "aggregate" leaks a recoverable dominant source (the 900/1000 case →
+/// `n_eff ≈ 1`). `0.5` = effective N must be ≥ half of raw N.
+///
+/// **Fail-closed:** [`passes_dominance_gate`] is `false` for a version-1 tier
+/// (no *signed* `n_eff`), so a v1 tier is rejected — this is the intended
+/// §19.7.1.2 posture (a dominated aggregator cannot bypass the floor by
+/// declaring the pre-#167 schema). Pinned here; twins with CIRISConstitution#6.
+pub const MIN_DOMINANCE_RATIO: f64 = 0.5;
 
 /// `corpus_kind` prefix for an aggregate composite: a composite folding
 /// `"trace"` sources has `corpus_kind = "aggregate:trace"`.
@@ -104,6 +117,17 @@ pub struct AggregationMetaVerifyInputsV1 {
     pub aggregation_algorithm_id: String,
     /// N members aggregated into this tier (the descent fan-in).
     pub source_count: u32,
+    /// §19.7.1.2 (CIRISVerify#167) — signed effective-source-count
+    /// (inverse-Simpson `n_eff = (Σmᵢ)²/Σmᵢ²`). **Signed only when
+    /// `version >= 2`**; a v1 tier's preimage does NOT include it, so its
+    /// value is verification-neutral (persist re-emits it into the
+    /// verify-core meta so a version-2 tier's canonical preimage — which
+    /// appends `u32(n_eff)` — reproduces byte-for-byte). `#[serde(default)]`
+    /// so pre-#167 stored/wire inputs (no `n_eff`) still parse; a v1 tier
+    /// defaults to `0`, which is fine (not in its preimage, and it fails
+    /// [`ciris_verify_core::holonomic::passes_dominance_gate`] closed).
+    #[serde(default)]
+    pub n_eff: u32,
     /// §19.7.1.1 Merkle root over the source member ids — base16 (hex) of the
     /// raw 32 bytes. Mirrors the stored
     /// [`AggregationMetaV1::member_commitment`] (which is the SAME hex value).
@@ -132,6 +156,7 @@ impl AggregationMetaVerifyInputsV1 {
             tier: self.tier,
             aggregation_algorithm_id: self.aggregation_algorithm_id.clone(),
             source_count: self.source_count,
+            n_eff: self.n_eff,
             member_commitment: mc,
             noise_floor_descriptor: self.noise_floor_descriptor.clone(),
         })
@@ -162,6 +187,16 @@ pub enum AggregationMetaError {
     /// would store a commitment the signature does not cover).
     #[error("aggregation_meta verify: stored member_commitment != signed §19.7.1 commitment")]
     MemberCommitmentMismatch,
+    /// §19.7.1.2 (CIRISVerify#167 / CIRISPersist#357) — the tier's authenticated
+    /// effective-source-count `n_eff` is below the [`MIN_DOMINANCE_RATIO`] floor
+    /// (a dominated fold: one source supplies too much of the mass, so the
+    /// aggregate is not a genuine noise-floor composite). Fail-closed: a
+    /// version-1 tier carries no signed `n_eff` and is rejected here.
+    #[error(
+        "aggregation_meta §19.7.1.2 dominance gate: effective source count below \
+         the noise-floor ratio (n_eff too low, or a version-1 tier with no signed n_eff)"
+    )]
+    Dominated,
 }
 
 impl AggregationMetaError {
@@ -172,6 +207,7 @@ impl AggregationMetaError {
             Self::MissingAggregatorPubkey(_) => "aggregation_meta_missing_pubkey",
             Self::MalformedInput(_) => "aggregation_meta_invalid",
             Self::MemberCommitmentMismatch => "aggregation_meta_member_commitment",
+            Self::Dominated => "aggregation_meta_dominated",
         }
     }
 }
@@ -320,7 +356,17 @@ impl AggregationMetaV1 {
 
         let verify_meta = self.verification.to_verify_meta()?;
         match verify_aggregation_meta(&verify_meta, &sig_ed, &sig_mldsa, &ed_pub, &mldsa_pub) {
-            AggregationMetaVerification::HybridVerified => Ok(()),
+            AggregationMetaVerification::HybridVerified => {
+                // §19.7.1.2 (CIRISVerify#167 / CIRISPersist#357) — dominance
+                // gate. Only now that the bound-hybrid signature authenticated
+                // `n_eff` is the effective-source-count trustworthy; reject a
+                // dominated fold (and, fail-closed, any version-1 tier that
+                // carries no signed n_eff). §10.1.5.1.1: BEFORE persistence.
+                if !passes_dominance_gate(&verify_meta, MIN_DOMINANCE_RATIO) {
+                    return Err(AggregationMetaError::Dominated);
+                }
+                Ok(())
+            }
             AggregationMetaVerification::Failed => Err(AggregationMetaError::HybridRequired),
         }
     }
@@ -485,6 +531,10 @@ pub async fn descend_aggregated_sources_on_backend<B: crate::store::Backend>(
         tier: 0,
         aggregation_algorithm_id: String::new(),
         source_count: member_ids.len() as u32,
+        // §19.7.1.2 (#167): v1 neutral placeholder (n_eff == source_count).
+        // This meta drives only `verify_member_commitment` (membership), and a
+        // v1 preimage excludes n_eff, so the value is verification-neutral.
+        n_eff: member_ids.len() as u32,
         member_commitment: aggregation_member_commitment_from_hex(&record.member_commitment)
             .map_err(crate::store::Error::AggregationMetaRejected)?,
         noise_floor_descriptor: String::new(),

--- a/tests/aggregation_tier.rs
+++ b/tests/aggregation_tier.rs
@@ -44,16 +44,33 @@ async fn signed_verify_inputs(
     tamper: bool,
     drop_pqc: bool,
 ) -> (AggregationMetaVerifyInputsV1, String) {
+    // §19.7.1.2 (#167): default to a balanced fold — n_eff == N — the honest
+    // case that clears the MIN_DOMINANCE_RATIO=0.5 admission gate.
+    signed_verify_inputs_n_eff(member_ids, tamper, drop_pqc, member_ids.len() as u32).await
+}
+
+/// As [`signed_verify_inputs`] but with an explicit signed `n_eff`, so a test
+/// can model a **dominated** fold (`n_eff` far below `source_count`) that the
+/// §19.7.1.2 dominance gate must reject.
+async fn signed_verify_inputs_n_eff(
+    member_ids: &[String],
+    tamper: bool,
+    drop_pqc: bool,
+    n_eff: u32,
+) -> (AggregationMetaVerifyInputsV1, String) {
     let (ed_sk, _ed_pk_b64, mldsa) = producer_pubkeys();
     let commitment = member_commitment(member_ids);
     let commitment_hex = hex_lower(&commitment);
+    // A signed version-2 tier. The signature covers n_eff because the
+    // version-2 signing_preimage appends u32(n_eff).
     let meta = ciris_verify_core::holonomic::AggregationMetaV1 {
-        version: 1,
+        version: 2,
         content_id: "content-root-agg".to_owned(),
         corpus_kind: "trace".to_owned(),
         tier: 2,
         aggregation_algorithm_id: "raptorq-pyramid-v1".to_owned(),
         source_count: member_ids.len() as u32,
+        n_eff,
         member_commitment: commitment,
         noise_floor_descriptor: "mean+stddev".to_owned(),
     };
@@ -72,6 +89,7 @@ async fn signed_verify_inputs(
         tier: signed_tier,
         aggregation_algorithm_id: meta.aggregation_algorithm_id.clone(),
         source_count: meta.source_count,
+        n_eff: meta.n_eff,
         member_commitment_hex: commitment_hex.clone(),
         noise_floor_descriptor: meta.noise_floor_descriptor.clone(),
         sig_ed25519_b64: BASE64.encode(ed_sig),
@@ -300,6 +318,59 @@ async fn run_aggregation_assertions<B: Backend>(backend: &B, suffix: &str) {
     assert!(
         backend.get_aggregation(&bad_cid).await.unwrap().is_none(),
         "(b) rejected composite wrote ZERO content_aggregation rows"
+    );
+
+    // ── (b2) §19.7.1.2 dominance gate (CIRISVerify#167 / #357): a fully
+    //        HYBRID-signed composite whose authenticated n_eff is below the
+    //        MIN_DOMINANCE_RATIO=0.5 floor (n_eff=1, source_count=3 → 0.33)
+    //        is REJECTED at admission — the 900/1000 dominated-fold case —
+    //        with zero rows written.
+    let dom_cid = format!("agg-dominated-{suffix}");
+    let (m_dom, s_dom) = build_manifest_and_symbols(
+        &dom_cid,
+        &composite_corpus,
+        n_source,
+        k_repair,
+        symbol_size,
+        true, // hybrid-signed: clears the #225 hard cut, reaches the dominance gate
+    )
+    .await;
+    let (verif_dom, commitment_dom) =
+        signed_verify_inputs_n_eff(&member_ids, false, false, 1).await;
+    let agg_dom = AggregationMetaV1 {
+        aggregate_content_id: dom_cid.clone(),
+        source_corpus_kind: source_corpus.to_owned(),
+        aggregation_level: 1,
+        fan_in: 3,
+        member_commitment: commitment_dom,
+        aggregation_meta: vec![0x02],
+        verification: verif_dom,
+    };
+    let dom_err = backend
+        .put_aggregated_tier(&m_dom, &s_dom, &agg_dom, 2_500)
+        .await
+        .expect_err("(b2) dominated fold (n_eff below the floor) MUST be rejected");
+    assert!(
+        matches!(dom_err, StoreError::AggregationMetaRejected(_)),
+        "(b2) reject is an AggregationMetaRejected error, got {dom_err:?}"
+    );
+    assert_eq!(
+        dom_err.kind(),
+        "aggregation_meta_dominated",
+        "(b2) §19.7.1.2 dominance token"
+    );
+    // verify-before-mutation: NOTHING written for the dominated composite.
+    assert!(
+        backend
+            .get_fountain_content(&dom_cid, &composite_corpus)
+            .await
+            .unwrap()
+            .is_none(),
+        "(b2) rejected dominated composite wrote ZERO content_manifest rows"
+    );
+    assert!(
+        backend.get_aggregation(&dom_cid).await.unwrap().is_none(),
+        "(b2) rejected dominated composite wrote ZERO content_aggregation rows"
     );
 
     // ── (b2) §19.7.1 store-path gate: a valid composite manifest but a

--- a/tests/conformance_vectors_v19_7.rs
+++ b/tests/conformance_vectors_v19_7.rs
@@ -78,43 +78,58 @@ fn domain_separator_matches_vector() {
 /// `aggregation_meta/canonical_bytes.json` — build the verify-core
 /// `AggregationMetaV1` from the vector inputs and assert `signing_preimage()`
 /// equals the expected §19.7.1 canonical bytes byte-for-byte.
+/// Covers BOTH the v1 golden AND the §19.7.1.2 v2 golden (CIRISVerify#167):
+/// the v2 preimage appends a trailing big-endian `u32(n_eff)`, while the v1
+/// preimage is byte-identical to the pre-#167 layout. Persist reproduces each
+/// byte-for-byte — the cross-impl guarantee that a v2 aggregator's signature
+/// verifies here.
 #[test]
 fn aggregation_meta_canonical_bytes_reproduced() {
-    let v = load("aggregation_meta/canonical_bytes.json");
+    for rel in [
+        "aggregation_meta/canonical_bytes.json",
+        "aggregation_meta/canonical_bytes_v2.json",
+    ] {
+        let v = load(rel);
 
-    // member_commitment is itself reproduced from the source ids (and equals
-    // the vector's member_commitment_hex).
-    let source_ids = str_list(&v, "source_member_ids");
-    let mc = member_commitment(&source_ids);
-    assert_eq!(
-        hex_lower(&mc),
-        v["member_commitment_hex"].as_str().unwrap(),
-        "member_commitment over source_member_ids reproduces the vector"
-    );
+        // member_commitment is itself reproduced from the source ids (and equals
+        // the vector's member_commitment_hex).
+        let source_ids = str_list(&v, "source_member_ids");
+        let mc = member_commitment(&source_ids);
+        assert_eq!(
+            hex_lower(&mc),
+            v["member_commitment_hex"].as_str().unwrap(),
+            "{rel}: member_commitment over source_member_ids reproduces the vector"
+        );
 
-    let meta = AggregationMetaV1 {
-        version: v["version"].as_u64().unwrap() as u32,
-        content_id: v["content_id"].as_str().unwrap().to_owned(),
-        corpus_kind: v["corpus_kind"].as_str().unwrap().to_owned(),
-        tier: v["tier"].as_u64().unwrap() as u32,
-        aggregation_algorithm_id: v["aggregation_algorithm_id"].as_str().unwrap().to_owned(),
-        source_count: v["source_count"].as_u64().unwrap() as u32,
-        member_commitment: mc,
-        noise_floor_descriptor: v["noise_floor_descriptor"].as_str().unwrap().to_owned(),
-    };
+        let meta = AggregationMetaV1 {
+            version: v["version"].as_u64().unwrap() as u32,
+            content_id: v["content_id"].as_str().unwrap().to_owned(),
+            corpus_kind: v["corpus_kind"].as_str().unwrap().to_owned(),
+            tier: v["tier"].as_u64().unwrap() as u32,
+            aggregation_algorithm_id: v["aggregation_algorithm_id"].as_str().unwrap().to_owned(),
+            source_count: v["source_count"].as_u64().unwrap() as u32,
+            // §19.7.1.2 (#167): signed n_eff from the vector (version-2 golden)
+            // or the v1 neutral placeholder (source_count) when absent.
+            n_eff: v["n_eff"]
+                .as_u64()
+                .unwrap_or_else(|| v["source_count"].as_u64().unwrap()) as u32,
+            member_commitment: mc,
+            noise_floor_descriptor: v["noise_floor_descriptor"].as_str().unwrap().to_owned(),
+        };
 
-    let expected = hex_decode(v["expected_canonical_bytes_hex"].as_str().unwrap());
-    assert_eq!(
-        meta.signing_preimage(),
-        expected,
-        "§19.7.1 canonical signing preimage reproduced byte-for-byte"
-    );
-    // The domain separator the preimage starts with also matches the vector.
-    assert!(
-        meta.signing_preimage()
-            .starts_with(&hex_decode(v["domain_separator_hex"].as_str().unwrap())),
-        "preimage begins with the §19.7.1 domain separator"
-    );
+        let expected = hex_decode(v["expected_canonical_bytes_hex"].as_str().unwrap());
+        assert_eq!(
+            meta.signing_preimage(),
+            expected,
+            "{rel}: §19.7.1 canonical signing preimage reproduced byte-for-byte"
+        );
+        // The domain separator the preimage starts with also matches the vector.
+        assert!(
+            meta.signing_preimage()
+                .starts_with(&hex_decode(v["domain_separator_hex"].as_str().unwrap())),
+            "{rel}: preimage begins with the §19.7.1 domain separator"
+        );
+    }
 }
 
 /// `member_commitment/{single,three_unsorted,empty}.json` — each reproduces
@@ -184,6 +199,12 @@ async fn verify_aggregation_meta_admit_and_reject() {
         tier: v["tier"].as_u64().unwrap() as u32,
         aggregation_algorithm_id: v["aggregation_algorithm_id"].as_str().unwrap().to_owned(),
         source_count: v["source_count"].as_u64().unwrap() as u32,
+        // §19.7.1.2 (#167): read the signed n_eff when the vector carries it
+        // (version-2 golden); default to source_count for a v1 vector (neutral
+        // placeholder — a v1 preimage excludes n_eff).
+        n_eff: v["n_eff"]
+            .as_u64()
+            .unwrap_or_else(|| v["source_count"].as_u64().unwrap()) as u32,
         member_commitment: member_commitment(&source_ids),
         noise_floor_descriptor: v["noise_floor_descriptor"].as_str().unwrap().to_owned(),
     };

--- a/tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes_v2.json
+++ b/tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes_v2.json
@@ -1,0 +1,20 @@
+{
+  "aggregation_algorithm_id": "raptorq-pyramid-v1",
+  "content_id": "content-root-fixed",
+  "corpus_kind": "trace",
+  "description": "AggregationMetaV1 §19.7.1.2 v2 preimage — v1 layout followed by a trailing big-endian u32(n_eff) (CIRISVerify#167 dominance surface).",
+  "domain_separator_hex": "4147472d4d4554412d76310000000000",
+  "expected_canonical_bytes_hex": "4147472d4d4554412d763100000000000000000200000012636f6e74656e742d726f6f742d66697865640000000574726163650000000200000012726170746f72712d707972616d69642d763100000003a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d0000000b6d65616e2b73746464657600000003",
+  "member_commitment_hex": "a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d",
+  "n_eff": 3,
+  "noise_floor_descriptor": "mean+stddev",
+  "source_count": 3,
+  "source_member_ids": [
+    "src-001",
+    "src-002",
+    "src-003"
+  ],
+  "tier": 2,
+  "vector_id": "aggregation_meta/canonical_bytes_v2",
+  "version": 2
+}


### PR DESCRIPTION
One release, three issues. Closes #320 (persist half), closes #357, closes #355.

## #320 — cross-cdylib capsule use-after-free (transport bring-up SIGSEGV)
Fresh per-call `PyCapsule`s were GC-freed while edge held the raw `data` pointer → UAF → SIGSEGV in `Arc<dyn FederationDirectory>::clone`. Fix: cache the four capsules on `PyEngine` (`OnceLock<Py<PyCapsule>>`) via a shared `cached_capsule` helper. Added env-gated (`CIRIS_PERSIST_TRACE`) `dtrace` on the ops-proxy boundary. (The separate transport **deadlock** is edge-side — `block_on` on persist's raw cross-cdylib tokio Handle; fix = route via the executor vtable / `run_async`, proven in a release build, tracked as a CIRISEdge change.)

## #357 — §19.7.1.2 dominance gate + AggregationMetaV1 v2 preimage (CIRISVerify#167)
Re-pin verify v8.5.0 → v8.6.0. Thread signed `n_eff` through `AggregationMetaVerifyInputsV1` → `to_verify_meta` (`#[serde(default)]`) so persist reproduces the v2 canonical preimage. Dominance gate at admission: `passes_dominance_gate(meta, 0.5)` rejects a dominated tier (`AggregationMetaError::Dominated`) before persistence — fail-closed (a v1 tier has no signed `n_eff`). `aggregation_tier` upgraded to signed v2 + new `(b2)` dominated-reject assertion; vendored the v2 golden; `conformance_vectors_v19_7` reproduces v1 + v2.

## #355 — drop dead vendored openssl + unused bytes (wheel cleanup)
`openssl` was a dead leaf (zero code refs, `NoTls` pool). Removed all entries + `dep:openssl` — kills the `openssl-src` OpenSSL-from-C build step (slowest/flakiest wheel-matrix stage, plausibly behind the Windows failures). Dropped unused direct `bytes`.

## Deps
`deny.toml`: ignore RUSTSEC-2026-0118 (hickory NSEC3 DNSSEC loop) — unreachable (persist doesn't enable DNSSEC validation), no patched version.

## Verification
1278 pg+sqlite lib / 0 failed; postgres pool re-verified after openssl/bytes removal; `aggregation_tier` + `conformance_vectors_v19_7` green both backends; `openssl` absent from the tree. No pg/sqlite asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)