### PR TITLE
v12.4.0 — #356 §Q StorageBudget/CorpusWant wheel surface (verify v8.7.0) + #354 catch_unwind FFI hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.4.0] — 2026-07-04
+
+### Added — #356: StorageBudgetV1 / CorpusWantV1 build+verify on the wheel (CC 6.1.5.2 §Q)
+
+Re-pin **ciris-verify-core/keyring/crypto v8.6.0 → v8.7.0** (CIRISVerify#170 lifted
+the two §Q signed shapes into `ciris_verify_core::holonomic::storage_contention` —
+their canonical home, on the shared `Preimage` + `verify_bound_hybrid` gate).
+persist wraps them on the Python wheel (`src/fountain/storage_contention.rs` +
+six PyO3 methods) — it does NOT redefine the crypto:
+
+- **`Engine.build_storage_budget_v1(payload_json)`** / **`build_corpus_want_v1(...)`** —
+  parse + structurally validate a payload, bound-hybrid sign its CC 6.1.3 preimage
+  (Ed25519 over preimage, ML-DSA-65 over `preimage ‖ ed25519_sig`) with the engine's
+  local signer, return the signed wire JSON.
+- **`verify_storage_budget_v1(wire, ed_pub_b64, mldsa_pub_b64)`** / **`verify_corpus_want_v1(...)`** —
+  PQC-mandatory bound-hybrid verify at ingest: `True` iff structurally valid AND both
+  halves verify; `False` on a structural/signature failure; raises only on
+  un-parseable JSON/base64.
+- **`storage_budget_supersedes(candidate, existing)`** (§Q B3 anti-rollback: same
+  `node_id`, strictly-higher `revision`) and **`corpus_want_admits(wire, cid, bytes)`**
+  (§Q B4 wanted-then-pulled).
+
+Serde **wire** structs convert to the verify-core payload for preimage/verify
+(same split as `AggregationMetaVerifyInputsV1` wrapping `AggregationMetaV1`). These
+shapes are verified-at-ingest, **not stored** — there is no persist admit/put table.
+Wheel `Requires-Dist: ciris-verify>=8.0.0,<9` unchanged (minor bump within major 8).
+
+Downstream: CIRISConformance `test_530` anti-rollback + want/have gates flip;
+CIRISEdge#269 (drop edge's local reimplementation, consume verify v8.7.0). The
+third gate — **pin-never-defeats-revocation** (§Q B6/N5, composing a pin surface
+with `evict_fountain_content_hard_delete`) — is tracked as a follow-up (needs a
+stored-pin design decision) and does not gate this wheel surface.
+
+### Fixed — #354: catch_unwind the executor-capsule C-ABI spawn boundary (no host abort)
+
+`persist_spawn` is an `extern "C"` frame; since Rust 1.81 a panic unwinding out of
+it aborts the process (`"cannot catch foreign exceptions"` → SIGABRT). Wrap the
+whole body (handle reconstruction + `runtime.spawn`) in `catch_unwind`: a panic in
+the synchronous FFI glue is contained + logged, never crossing back into the
+consumer's `.so`. (The spawned future's own panics are already contained by tokio's
+task harness.) The postgres `init_edge_runtime` SIGABRT itself was the OLD edge
+raw-`block_on` path — fixed edge-side in CIRISEdge#268; this is the persist-side
+defense-in-depth the issue asked for. Test: a panicking spawned task followed by a
+normal one proves the executor + process survive.
+
 ## [12.3.0] — 2026-07-03
 
 ### Fixed — #320: cross-cdylib capsule use-after-free (transport bring-up SIGSEGV)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.3.0"
+version = "12.4.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."
@@ -503,14 +503,14 @@ tls = ["dep:tokio-postgres-rustls", "dep:rustls", "dep:rustls-native-certs"]
 # ciris-crypto invariant (FSD §7.5a) means persist takes ZERO direct
 # deps on AES-GCM/PBKDF2/HKDF/HMAC primitive crates ever — the
 # `src/secrets/crypto.rs` facade lands as a single import-site change.
-ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa"] }
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8" }
+ciris-keyring     = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8" }
 # v0.3.6 (CIRISPersist#14) — direct ciris-crypto dep for HybridVerifier
 # in `Engine.verify_hybrid`. Same git source / tag as ciris-keyring +
 # ciris-verify-core so versions are workspace-coherent. Features
 # `ed25519` + `pqc-ml-dsa` light up the concrete Ed25519Verifier +
 # MlDsa65Verifier impls used by HybridVerifier::verify.
-ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
+ciris-crypto      = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "key-grant"] }
 async-trait   = "0.1"
 # v0.1.14 — filesystem advisory locks for the cohabitation
 # bootstrap (docs/COHABITATION.md). POSIX flock cross-process,
@@ -772,10 +772,10 @@ tokio-stream = "0.1"
 # key). Placed AFTER every platform-independent dep — see the v0.9.0
 # bug note on the rusqlite target table above.
 [target.'cfg(target_os = "linux")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8", features = ["pqc-ml-dsa"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8", features = ["pqc-ml-dsa", "ios"] }
 # v12.3.0 (CIRISPersist#355) — vendored openssl removed here too (dead leaf;
 # see the base-deps note). No iOS openssl in any configuration now.
 
@@ -783,7 +783,7 @@ ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0"
 # v3.5.2 (#132) — rusqlite `bundled` for Android. See comment block
 # before the iOS entry (~line 628) for the rationale.
 rusqlite = { version = "0.31", features = ["bundled", "chrono", "serde_json"], optional = true }
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["pqc-ml-dsa", "android"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.7.0", version = "8", features = ["pqc-ml-dsa", "android"] }
 # v12.3.0 (CIRISPersist#355) — vendored openssl removed here too (dead leaf;
 # see the base-deps note). No Android openssl in any configuration now,
 # retiring the flakiest part of the mobile wheel matrix.

--- a/src/ffi/executor_capsule.rs
+++ b/src/ffi/executor_capsule.rs
@@ -226,34 +226,69 @@ pub static PERSIST_EXECUTOR_VTABLE: AsyncExecutorVTable = AsyncExecutorVTable {
 /// MUST be invoked exclusively through the vtable's function pointer,
 /// never called directly from outside `ciris_persist.abi3.so`.
 unsafe extern "C" fn persist_spawn(data: *mut c_void, task: *mut TaskOpaque) {
-    // SAFETY: per the vtable contract, `data` was produced by
-    // `Arc::into_raw(Arc<Runtime>)` on the persist side. We
-    // reconstruct without dropping by cloning and re-leaking.
-    let runtime: Arc<tokio::runtime::Runtime> = unsafe {
-        let raw = data as *const tokio::runtime::Runtime;
-        let arc = Arc::from_raw(raw);
-        let clone = arc.clone();
-        // Don't drop ours — we don't own the data pointer; the
-        // capsule does. Re-leak to keep refcount stable.
-        let _ = Arc::into_raw(arc);
-        clone
-    };
+    // #354 (CIRISPersist#354): guard the C-ABI boundary. This is an
+    // `extern "C"` frame — a panic that unwinds out of it hits
+    // `"cannot catch foreign exceptions"` and **aborts the host
+    // process** (rc=-6 / SIGABRT). Since Rust 1.81 an `extern "C"` fn
+    // aborts on unwind by default. So wrap the whole body in
+    // `catch_unwind`: if reconstructing the handles or `runtime.spawn`
+    // (e.g. onto a shutting-down runtime) panics, we contain it here
+    // and log — never let it cross back into the consumer's `.so`.
+    //
+    // (The spawned *future's* own panics are already contained by
+    // tokio's task harness — a panicking task fails its JoinHandle, it
+    // does not abort the runtime. This guard covers the synchronous
+    // glue, which the harness does not.)
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: per the vtable contract, `data` was produced by
+        // `Arc::into_raw(Arc<Runtime>)` on the persist side. We
+        // reconstruct without dropping by cloning and re-leaking.
+        let runtime: Arc<tokio::runtime::Runtime> = unsafe {
+            let raw = data as *const tokio::runtime::Runtime;
+            let arc = Arc::from_raw(raw);
+            let clone = arc.clone();
+            // Don't drop ours — we don't own the data pointer; the
+            // capsule does. Re-leak to keep refcount stable.
+            let _ = Arc::into_raw(arc);
+            clone
+        };
 
-    // SAFETY: per the vtable contract, `task` was produced by
-    // `Box::into_raw(Box::new(Box::pin(async { ... }) as Pin<Box<dyn
-    // Future + Send + 'static>>))` on the consumer side. We
-    // reconstruct and take ownership.
-    type BoxedFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
-    let wrapped: Box<BoxedFut> = unsafe { Box::from_raw(task as *mut BoxedFut) };
-    let future: BoxedFut = *wrapped;
+        // SAFETY: per the vtable contract, `task` was produced by
+        // `Box::into_raw(Box::new(Box::pin(async { ... }) as Pin<Box<dyn
+        // Future + Send + 'static>>))` on the consumer side. We
+        // reconstruct and take ownership.
+        type BoxedFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+        let wrapped: Box<BoxedFut> = unsafe { Box::from_raw(task as *mut BoxedFut) };
+        let future: BoxedFut = *wrapped;
 
-    // Spawn onto persist's tokio runtime. The future's polling will
-    // happen on a worker thread owned by this runtime, so tokio's
-    // thread-local current-runtime context will resolve to persist's
-    // tokio throughout the future's lifetime. Calls to persist's
-    // public API from inside the future use persist's tokio
-    // primitives naturally.
-    runtime.spawn(future);
+        // Spawn onto persist's tokio runtime. The future's polling will
+        // happen on a worker thread owned by this runtime, so tokio's
+        // thread-local current-runtime context will resolve to persist's
+        // tokio throughout the future's lifetime. Calls to persist's
+        // public API from inside the future use persist's tokio
+        // primitives naturally.
+        runtime.spawn(future);
+    }));
+    if let Err(payload) = result {
+        let msg = panic_payload_msg(&payload);
+        tracing::error!(
+            panic = %msg,
+            "ciris_persist executor_capsule::spawn panicked — contained at the C-ABI \
+             boundary; host process NOT aborted (the spawn was dropped)"
+        );
+    }
+}
+
+/// #354 — extract a human-readable message from a `catch_unwind` payload
+/// (`Box<dyn Any + Send>`): `String`, then `&'static str`, then a fallback.
+fn panic_payload_msg(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else {
+        "(opaque panic payload)".to_string()
+    }
 }
 
 /// Implementation of `AsyncExecutorVTable::drop` for persist's tokio.
@@ -450,6 +485,50 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(2))
             .expect("multi-thread runtime drives spawned tasks; receive must succeed");
         assert_eq!(received, "hello from persist's tokio");
+
+        unsafe { (executor.vtable.drop)(executor.data) };
+        drop(runtime);
+    }
+
+    #[test]
+    fn panicking_spawned_task_does_not_abort_host_and_executor_survives() {
+        // #354: a consumer future that panics MUST NOT abort the host. tokio's
+        // task harness contains the future's panic; `persist_spawn`'s
+        // `catch_unwind` covers the synchronous C-ABI glue. This test proves
+        // the end-to-end guarantee: after a panicking task, the executor still
+        // runs a normal task to completion (runtime + process intact).
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        let executor = build_persist_executor(runtime.clone());
+
+        type BoxedFut = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+        // 1. Spawn a task that panics. If this aborted the host, the test
+        //    binary would die with SIGABRT (a hard test failure), not proceed.
+        let boom: BoxedFut = Box::pin(async move {
+            panic!("boom in a spawned consumer task (#354 containment probe)");
+        });
+        let boom_ptr: *mut TaskOpaque = Box::into_raw(Box::new(boom)).cast();
+        unsafe { (executor.vtable.spawn)(executor.data, boom_ptr) };
+
+        // 2. Spawn a normal task; if it completes, the runtime survived the panic.
+        let (tx, rx) = mpsc::channel::<&'static str>();
+        let ok: BoxedFut = Box::pin(async move {
+            let _ = tx.send("executor still alive");
+        });
+        let ok_ptr: *mut TaskOpaque = Box::into_raw(Box::new(ok)).cast();
+        unsafe { (executor.vtable.spawn)(executor.data, ok_ptr) };
+
+        assert_eq!(
+            rx.recv_timeout(std::time::Duration::from_secs(2)),
+            Ok("executor still alive"),
+            "the executor must keep running after a spawned task panicked"
+        );
 
         unsafe { (executor.vtable.drop)(executor.data) };
         drop(runtime);

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2769,6 +2769,148 @@ impl PyEngine {
         })
     }
 
+    /// #356 (CC 6.1.5.2 §Q / CIRISVerify#170) — build a signed `StorageBudgetV1`
+    /// wire JSON from a payload JSON, bound-hybrid signing its CC 6.1.3 preimage
+    /// with the engine's local signer. `payload_json` carries
+    /// `{node_id, epoch_id, revision, scopes:[{cohort_scope,budget_bytes,
+    /// pin_reserve_bytes}], pinned_class:[..]}`; returns the same fields plus
+    /// `signature_ed25519_base64` / `signature_ml_dsa_65_base64`. Raises
+    /// `ValueError` on a malformed / structurally-invalid payload (a `self` /
+    /// `family` scope, `pin_reserve > budget`, or unsorted lists), or if no
+    /// local signing key is configured.
+    #[pyo3(name = "build_storage_budget_v1")]
+    fn build_storage_budget_v1_py(&self, py: Python<'_>, payload_json: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+            let preimage =
+                crate::fountain::storage_contention::storage_budget_preimage(payload_json)
+                    .map_err(storage_contention_err_to_py)?;
+            let (ed_sig, pqc_sig) =
+                bound_hybrid_sign_qshape(self.local_signer.as_ref(), &self.runtime, py, &preimage)?;
+            crate::fountain::storage_contention::assemble_storage_budget_wire(
+                payload_json,
+                B64.encode(ed_sig),
+                B64.encode(pqc_sig),
+            )
+            .map_err(storage_contention_err_to_py)
+        })
+    }
+
+    /// #356 — build a signed `CorpusWantV1` wire JSON from a payload JSON.
+    /// `payload_json` carries `{node_id, epoch_id, cohort_scope, size_cap_bytes,
+    /// remaining_budget_bytes, want:[content_id,..]}`.
+    #[pyo3(name = "build_corpus_want_v1")]
+    fn build_corpus_want_v1_py(&self, py: Python<'_>, payload_json: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+            let preimage = crate::fountain::storage_contention::corpus_want_preimage(payload_json)
+                .map_err(storage_contention_err_to_py)?;
+            let (ed_sig, pqc_sig) =
+                bound_hybrid_sign_qshape(self.local_signer.as_ref(), &self.runtime, py, &preimage)?;
+            crate::fountain::storage_contention::assemble_corpus_want_wire(
+                payload_json,
+                B64.encode(ed_sig),
+                B64.encode(pqc_sig),
+            )
+            .map_err(storage_contention_err_to_py)
+        })
+    }
+
+    /// #356 — verify a signed `StorageBudgetV1` wire JSON at ingest (structure +
+    /// PQC-mandatory bound-hybrid signature) against the owner's raw pubkeys
+    /// (base64). Returns `True` iff both halves verify AND the shape is
+    /// structurally valid; `False` on a structural or signature failure. Raises
+    /// `ValueError` only on malformed JSON / base64 (un-parseable input).
+    #[pyo3(name = "verify_storage_budget_v1")]
+    fn verify_storage_budget_v1_py(
+        &self,
+        wire_json: &str,
+        ed25519_pubkey_base64: &str,
+        ml_dsa_65_pubkey_base64: &str,
+    ) -> PyResult<bool> {
+        catch_panic(|| {
+            use crate::fountain::storage_contention::StorageContentionError as E;
+            match crate::fountain::storage_contention::verify_storage_budget_wire(
+                wire_json,
+                ed25519_pubkey_base64,
+                ml_dsa_65_pubkey_base64,
+            ) {
+                Ok(()) => Ok(true),
+                Err(E::Invalid(_)) | Err(E::SignatureFailed) => Ok(false),
+                Err(e @ (E::MalformedJson(_) | E::MalformedBase64(_))) => {
+                    Err(storage_contention_err_to_py(e))
+                }
+            }
+        })
+    }
+
+    /// #356 — verify a signed `CorpusWantV1` wire JSON at ingest. Same contract
+    /// as [`Self::verify_storage_budget_v1_py`].
+    #[pyo3(name = "verify_corpus_want_v1")]
+    fn verify_corpus_want_v1_py(
+        &self,
+        wire_json: &str,
+        ed25519_pubkey_base64: &str,
+        ml_dsa_65_pubkey_base64: &str,
+    ) -> PyResult<bool> {
+        catch_panic(|| {
+            use crate::fountain::storage_contention::StorageContentionError as E;
+            match crate::fountain::storage_contention::verify_corpus_want_wire(
+                wire_json,
+                ed25519_pubkey_base64,
+                ml_dsa_65_pubkey_base64,
+            ) {
+                Ok(()) => Ok(true),
+                Err(E::Invalid(_)) | Err(E::SignatureFailed) => Ok(false),
+                Err(e @ (E::MalformedJson(_) | E::MalformedBase64(_))) => {
+                    Err(storage_contention_err_to_py(e))
+                }
+            }
+        })
+    }
+
+    /// #356 (§Q B3 anti-rollback) — does `candidate` supersede `existing`? Both
+    /// are signed `StorageBudgetV1` wire JSONs; `True` iff same `node_id` and
+    /// strictly-higher `revision`. Callers MUST reject a non-superseding
+    /// candidate from the same node (a rollback). Raises on malformed JSON.
+    #[pyo3(name = "storage_budget_supersedes")]
+    fn storage_budget_supersedes_py(
+        &self,
+        candidate_json: &str,
+        existing_json: &str,
+    ) -> PyResult<bool> {
+        catch_panic(|| {
+            crate::fountain::storage_contention::storage_budget_supersedes(
+                candidate_json,
+                existing_json,
+            )
+            .map_err(storage_contention_err_to_py)
+        })
+    }
+
+    /// #356 (§Q B4 wanted-then-pulled) — may a producer push `content_id` of
+    /// `object_bytes` against this signed `CorpusWantV1` wire JSON? `True` iff
+    /// the id is wanted AND within the advertised `size_cap_bytes`. Raises on
+    /// malformed JSON.
+    #[pyo3(name = "corpus_want_admits")]
+    fn corpus_want_admits_py(
+        &self,
+        wire_json: &str,
+        content_id: &str,
+        object_bytes: u64,
+    ) -> PyResult<bool> {
+        catch_panic(|| {
+            crate::fountain::storage_contention::corpus_want_admits(
+                wire_json,
+                content_id,
+                object_bytes,
+            )
+            .map_err(storage_contention_err_to_py)
+        })
+    }
+
     /// v1.4.0 (CIRISPersist#51) — Return the local-process ML-DSA-65
     /// public key (base64) for publishing to consumers
     /// (federation_keys.pubkey_ml_dsa_65_base64, peer pinning,
@@ -23809,6 +23951,41 @@ fn local_signer_err_to_py(e: crate::signing::LocalSignerError) -> PyErr {
             PyRuntimeError::new_err(format!("{e}"))
         }
     }
+}
+
+/// #356 — convert a §Q storage-contention wrapper error to a typed PyErr
+/// (carrying the stable `kind()` token for consumer-side sanitization).
+fn storage_contention_err_to_py(
+    e: crate::fountain::storage_contention::StorageContentionError,
+) -> PyErr {
+    PyErr::new::<LensQueryError, _>(format!("{e} (kind={})", e.kind()))
+}
+
+/// #356 — bound-hybrid sign a §Q CC 6.1.3 preimage with the engine's local
+/// signer: Ed25519 over `preimage`, ML-DSA-65 over `preimage ‖ ed25519_sig`.
+/// Returns `(ed25519_sig, ml_dsa_65_sig)`. Raises if no local signer / PQC key.
+fn bound_hybrid_sign_qshape(
+    local_signer: Option<&std::sync::Arc<crate::signing::LocalSigner>>,
+    runtime: &tokio::runtime::Runtime,
+    py: Python<'_>,
+    preimage: &[u8],
+) -> PyResult<(Vec<u8>, Vec<u8>)> {
+    let signer = local_signer.ok_or_else(|| {
+        PyValueError::new_err(
+            "no local signing key configured (pass local_key_id + local_key_path \
+             to the Engine constructor)",
+        )
+    })?;
+    let ed_sig = signer
+        .sign_ed25519(preimage)
+        .map_err(local_signer_err_to_py)?;
+    let mut bound = preimage.to_vec();
+    bound.extend_from_slice(&ed_sig);
+    let signer_c = signer.clone();
+    let pqc_sig = py
+        .detach(|| runtime.block_on(async move { signer_c.sign_ml_dsa_65(&bound).await }))
+        .map_err(local_signer_err_to_py)?;
+    Ok((ed_sig.to_vec(), pqc_sig))
 }
 
 /// v0.4.0 — outbound::Error → PyErr at the FFI boundary. Same

--- a/src/fountain/mod.rs
+++ b/src/fountain/mod.rs
@@ -41,6 +41,7 @@ pub mod admit;
 pub mod aggregation;
 pub mod eviction;
 pub mod retention;
+pub mod storage_contention;
 pub mod types;
 
 pub use admit::{

--- a/src/fountain/storage_contention.rs
+++ b/src/fountain/storage_contention.rs
@@ -1,0 +1,536 @@
+//! CC 6.1.5.2 §Q storage-contention — persist's Python-wheel surface over the
+//! canonical verify-core shapes (CIRISPersist#356 / CIRISVerify#170).
+//!
+//! The signed shapes themselves live in
+//! [`ciris_verify_core::holonomic::storage_contention`] (the canonical home for
+//! every §19/§Q signed object). persist does NOT redefine the crypto — it wraps
+//! it: serde **wire** structs that (de)serialize the JSON the PyO3 boundary
+//! carries, plus `build` (sign a payload with the engine's local signer) and
+//! `verify` (bound-hybrid verify at ingest) helpers. Same split as
+//! [`crate::fountain::aggregation::AggregationMetaVerifyInputsV1`] wrapping the
+//! verify-core `AggregationMetaV1`.
+//!
+//! These shapes are **verified-at-ingest, not stored** (CC 6.1.3 store-path):
+//! there is no persist admit/put table for them — a consumer builds one to
+//! advertise / verifies one it received. The pin-vs-revocation composition (the
+//! §Q B6/N5 gate that couples a pinned budget with hard-delete eviction) is
+//! tracked separately (CIRISPersist#356 follow-up) and does not gate this wheel
+//! surface.
+
+use serde::{Deserialize, Serialize};
+
+use ciris_verify_core::holonomic::storage_contention::{
+    verify_corpus_want_v1, verify_storage_budget_v1, CorpusWantV1, ScopeBudget, StorageBudgetV1,
+    StorageContentionVerification,
+};
+
+/// Why a §Q wheel-surface call failed. `kind()` gives a stable telemetry token.
+#[derive(Debug, thiserror::Error)]
+pub enum StorageContentionError {
+    /// The payload / wire JSON did not parse.
+    #[error("storage-contention: malformed JSON ({0})")]
+    MalformedJson(String),
+    /// Structural validation failed (suppressed scope, reserve>budget, unsorted).
+    #[error("storage-contention: structural validation failed ({0})")]
+    Invalid(String),
+    /// A base64 signature / pubkey field did not decode.
+    #[error("storage-contention: malformed base64 ({0})")]
+    MalformedBase64(&'static str),
+    /// The bound-hybrid signature failed to verify (bad/absent classical or
+    /// ML-DSA-65 half — PQC-mandatory).
+    #[error("storage-contention: bound-hybrid signature did not verify (PQC-mandatory)")]
+    SignatureFailed,
+}
+
+impl StorageContentionError {
+    /// Stable string token for telemetry / structured logging.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::MalformedJson(_) => "storage_contention_malformed_json",
+            Self::Invalid(_) => "storage_contention_invalid",
+            Self::MalformedBase64(_) => "storage_contention_malformed_base64",
+            Self::SignatureFailed => "storage_contention_signature_failed",
+        }
+    }
+}
+
+/// One `cohort_scope`'s allotment — wire mirror of verify-core [`ScopeBudget`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeBudgetWire {
+    /// The `cohort_scope` (`community` | `affiliations` | …; never self/family).
+    pub cohort_scope: String,
+    /// Total byte ceiling for this scope.
+    pub budget_bytes: u64,
+    /// Byte floor reserved for pinned corpus (MUST be ≤ `budget_bytes`).
+    pub pin_reserve_bytes: u64,
+}
+
+/// The `StorageBudgetV1` payload (no signatures) — what a caller supplies to
+/// [`build_storage_budget_v1`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageBudgetPayload {
+    /// The owner node this budget binds.
+    pub node_id: String,
+    /// Epoch keying (CC 5.1).
+    pub epoch_id: String,
+    /// Monotonic revision (anti-rollback).
+    pub revision: u64,
+    /// Per-`cohort_scope` allotments (sorted + deduped by `cohort_scope`).
+    pub scopes: Vec<ScopeBudgetWire>,
+    /// Corpus `subject_kind`s the owner elects to pin (sorted + deduped).
+    pub pinned_class: Vec<String>,
+}
+
+/// The signed `StorageBudgetV1` wire shape — payload + the bound-hybrid pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageBudgetWire {
+    /// The owner node this budget binds.
+    pub node_id: String,
+    /// Epoch keying (CC 5.1).
+    pub epoch_id: String,
+    /// Monotonic revision (anti-rollback).
+    pub revision: u64,
+    /// Per-`cohort_scope` allotments.
+    pub scopes: Vec<ScopeBudgetWire>,
+    /// Pinned `subject_kind`s.
+    pub pinned_class: Vec<String>,
+    /// Ed25519 signature over the CC 6.1.3 preimage, base64 standard.
+    pub signature_ed25519_base64: String,
+    /// ML-DSA-65 signature over `preimage ‖ ed25519_sig`, base64 standard.
+    pub signature_ml_dsa_65_base64: String,
+}
+
+impl From<&ScopeBudgetWire> for ScopeBudget {
+    fn from(s: &ScopeBudgetWire) -> Self {
+        ScopeBudget {
+            cohort_scope: s.cohort_scope.clone(),
+            budget_bytes: s.budget_bytes,
+            pin_reserve_bytes: s.pin_reserve_bytes,
+        }
+    }
+}
+
+impl StorageBudgetPayload {
+    /// The verify-core payload (for preimage / validate).
+    fn to_verify(&self) -> StorageBudgetV1 {
+        StorageBudgetV1 {
+            node_id: self.node_id.clone(),
+            epoch_id: self.epoch_id.clone(),
+            revision: self.revision,
+            scopes: self.scopes.iter().map(ScopeBudget::from).collect(),
+            pinned_class: self.pinned_class.clone(),
+        }
+    }
+}
+
+impl StorageBudgetWire {
+    /// The verify-core payload (for preimage / verify).
+    fn to_verify(&self) -> StorageBudgetV1 {
+        StorageBudgetV1 {
+            node_id: self.node_id.clone(),
+            epoch_id: self.epoch_id.clone(),
+            revision: self.revision,
+            scopes: self.scopes.iter().map(ScopeBudget::from).collect(),
+            pinned_class: self.pinned_class.clone(),
+        }
+    }
+
+    /// `true` iff `self` supersedes `other` (same node, strictly-higher
+    /// revision) — the §Q B3 anti-rollback rule.
+    #[must_use]
+    pub fn supersedes(&self, other: &StorageBudgetWire) -> bool {
+        self.to_verify().supersedes(&other.to_verify())
+    }
+}
+
+/// The `CorpusWantV1` payload (no signatures).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusWantPayload {
+    /// The advertising peer.
+    pub node_id: String,
+    /// Epoch keying (CC 5.1).
+    pub epoch_id: String,
+    /// The scope this want draws budget from (never self/family).
+    pub cohort_scope: String,
+    /// Max single-object size this peer will accept.
+    pub size_cap_bytes: u64,
+    /// Advertised headroom in the scope.
+    pub remaining_budget_bytes: u64,
+    /// Content-addressed ids wanted (sorted + deduped).
+    pub want: Vec<String>,
+}
+
+/// The signed `CorpusWantV1` wire shape — payload + the bound-hybrid pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CorpusWantWire {
+    /// The advertising peer.
+    pub node_id: String,
+    /// Epoch keying (CC 5.1).
+    pub epoch_id: String,
+    /// The scope this want draws budget from.
+    pub cohort_scope: String,
+    /// Max single-object size accepted.
+    pub size_cap_bytes: u64,
+    /// Advertised headroom.
+    pub remaining_budget_bytes: u64,
+    /// Content-addressed ids wanted (sorted + deduped).
+    pub want: Vec<String>,
+    /// Ed25519 signature over the CC 6.1.3 preimage, base64 standard.
+    pub signature_ed25519_base64: String,
+    /// ML-DSA-65 signature over `preimage ‖ ed25519_sig`, base64 standard.
+    pub signature_ml_dsa_65_base64: String,
+}
+
+impl CorpusWantPayload {
+    fn to_verify(&self) -> CorpusWantV1 {
+        CorpusWantV1 {
+            node_id: self.node_id.clone(),
+            epoch_id: self.epoch_id.clone(),
+            cohort_scope: self.cohort_scope.clone(),
+            size_cap_bytes: self.size_cap_bytes,
+            remaining_budget_bytes: self.remaining_budget_bytes,
+            want: self.want.clone(),
+        }
+    }
+}
+
+impl CorpusWantWire {
+    fn to_verify(&self) -> CorpusWantV1 {
+        CorpusWantV1 {
+            node_id: self.node_id.clone(),
+            epoch_id: self.epoch_id.clone(),
+            cohort_scope: self.cohort_scope.clone(),
+            size_cap_bytes: self.size_cap_bytes,
+            remaining_budget_bytes: self.remaining_budget_bytes,
+            want: self.want.clone(),
+        }
+    }
+
+    /// `true` iff a producer may push `content_id` of `object_bytes` against
+    /// this want (B4 wanted-then-pulled: wanted AND within the size cap).
+    #[must_use]
+    pub fn admits(&self, content_id: &str, object_bytes: u64) -> bool {
+        self.to_verify().admits(content_id, object_bytes)
+    }
+}
+
+/// Parse + structurally-validate a `StorageBudgetPayload`, returning its CC
+/// 6.1.3 signing preimage (the bytes the caller must bound-hybrid sign).
+///
+/// # Errors
+/// [`StorageContentionError::MalformedJson`] / [`StorageContentionError::Invalid`].
+pub fn storage_budget_preimage(payload_json: &str) -> Result<Vec<u8>, StorageContentionError> {
+    let payload: StorageBudgetPayload = serde_json::from_str(payload_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    let v = payload.to_verify();
+    v.validate()
+        .map_err(|e| StorageContentionError::Invalid(e.to_string()))?;
+    Ok(v.signing_preimage())
+}
+
+/// Parse + structurally-validate a `CorpusWantPayload`, returning its preimage.
+///
+/// # Errors
+/// [`StorageContentionError::MalformedJson`] / [`StorageContentionError::Invalid`].
+pub fn corpus_want_preimage(payload_json: &str) -> Result<Vec<u8>, StorageContentionError> {
+    let payload: CorpusWantPayload = serde_json::from_str(payload_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    let v = payload.to_verify();
+    v.validate()
+        .map_err(|e| StorageContentionError::Invalid(e.to_string()))?;
+    Ok(v.signing_preimage())
+}
+
+/// Assemble a signed [`StorageBudgetWire`] JSON from a payload + the two
+/// base64-encoded signatures. Re-validates before assembling (never emit a
+/// malformed shape).
+///
+/// # Errors
+/// [`StorageContentionError`] on parse / validation failure.
+pub fn assemble_storage_budget_wire(
+    payload_json: &str,
+    sig_ed25519_base64: String,
+    sig_ml_dsa_65_base64: String,
+) -> Result<String, StorageContentionError> {
+    let payload: StorageBudgetPayload = serde_json::from_str(payload_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    payload
+        .to_verify()
+        .validate()
+        .map_err(|e| StorageContentionError::Invalid(e.to_string()))?;
+    let wire = StorageBudgetWire {
+        node_id: payload.node_id,
+        epoch_id: payload.epoch_id,
+        revision: payload.revision,
+        scopes: payload.scopes,
+        pinned_class: payload.pinned_class,
+        signature_ed25519_base64: sig_ed25519_base64,
+        signature_ml_dsa_65_base64: sig_ml_dsa_65_base64,
+    };
+    serde_json::to_string(&wire).map_err(|e| StorageContentionError::MalformedJson(e.to_string()))
+}
+
+/// Assemble a signed [`CorpusWantWire`] JSON from a payload + base64 signatures.
+///
+/// # Errors
+/// [`StorageContentionError`] on parse / validation failure.
+pub fn assemble_corpus_want_wire(
+    payload_json: &str,
+    sig_ed25519_base64: String,
+    sig_ml_dsa_65_base64: String,
+) -> Result<String, StorageContentionError> {
+    let payload: CorpusWantPayload = serde_json::from_str(payload_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    payload
+        .to_verify()
+        .validate()
+        .map_err(|e| StorageContentionError::Invalid(e.to_string()))?;
+    let wire = CorpusWantWire {
+        node_id: payload.node_id,
+        epoch_id: payload.epoch_id,
+        cohort_scope: payload.cohort_scope,
+        size_cap_bytes: payload.size_cap_bytes,
+        remaining_budget_bytes: payload.remaining_budget_bytes,
+        want: payload.want,
+        signature_ed25519_base64: sig_ed25519_base64,
+        signature_ml_dsa_65_base64: sig_ml_dsa_65_base64,
+    };
+    serde_json::to_string(&wire).map_err(|e| StorageContentionError::MalformedJson(e.to_string()))
+}
+
+/// Verify a signed [`StorageBudgetWire`] JSON at ingest (structure + PQC-mandatory
+/// bound-hybrid signature) against the aggregator's raw pubkeys (base64).
+///
+/// # Errors
+/// [`StorageContentionError`] on malformed input, structural invalidity, or a
+/// failed signature.
+pub fn verify_storage_budget_wire(
+    wire_json: &str,
+    ed25519_pubkey_base64: &str,
+    ml_dsa_65_pubkey_base64: &str,
+) -> Result<(), StorageContentionError> {
+    let wire: StorageBudgetWire = serde_json::from_str(wire_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    let (ed_pub, mldsa_pub) = decode_pubkeys(ed25519_pubkey_base64, ml_dsa_65_pubkey_base64)?;
+    let (sig_ed, sig_mldsa) = decode_sigs(
+        &wire.signature_ed25519_base64,
+        &wire.signature_ml_dsa_65_base64,
+    )?;
+    match verify_storage_budget_v1(&wire.to_verify(), &sig_ed, &sig_mldsa, &ed_pub, &mldsa_pub) {
+        StorageContentionVerification::HybridVerified => Ok(()),
+        StorageContentionVerification::Invalid(e) => {
+            Err(StorageContentionError::Invalid(e.to_string()))
+        }
+        StorageContentionVerification::SignatureFailed => {
+            Err(StorageContentionError::SignatureFailed)
+        }
+    }
+}
+
+/// Verify a signed [`CorpusWantWire`] JSON at ingest.
+///
+/// # Errors
+/// [`StorageContentionError`] on malformed input, structural invalidity, or a
+/// failed signature.
+pub fn verify_corpus_want_wire(
+    wire_json: &str,
+    ed25519_pubkey_base64: &str,
+    ml_dsa_65_pubkey_base64: &str,
+) -> Result<(), StorageContentionError> {
+    let wire: CorpusWantWire = serde_json::from_str(wire_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    let (ed_pub, mldsa_pub) = decode_pubkeys(ed25519_pubkey_base64, ml_dsa_65_pubkey_base64)?;
+    let (sig_ed, sig_mldsa) = decode_sigs(
+        &wire.signature_ed25519_base64,
+        &wire.signature_ml_dsa_65_base64,
+    )?;
+    match verify_corpus_want_v1(&wire.to_verify(), &sig_ed, &sig_mldsa, &ed_pub, &mldsa_pub) {
+        StorageContentionVerification::HybridVerified => Ok(()),
+        StorageContentionVerification::Invalid(e) => {
+            Err(StorageContentionError::Invalid(e.to_string()))
+        }
+        StorageContentionVerification::SignatureFailed => {
+            Err(StorageContentionError::SignatureFailed)
+        }
+    }
+}
+
+/// Anti-rollback check between two signed budget wires (JSON): does `candidate`
+/// supersede `existing`?
+///
+/// # Errors
+/// [`StorageContentionError::MalformedJson`] if either does not parse.
+pub fn storage_budget_supersedes(
+    candidate_json: &str,
+    existing_json: &str,
+) -> Result<bool, StorageContentionError> {
+    let candidate: StorageBudgetWire = serde_json::from_str(candidate_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    let existing: StorageBudgetWire = serde_json::from_str(existing_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    Ok(candidate.supersedes(&existing))
+}
+
+/// B4 admission check: may a producer push `content_id` of `object_bytes`
+/// against this signed want (JSON)?
+///
+/// # Errors
+/// [`StorageContentionError::MalformedJson`] if the wire does not parse.
+pub fn corpus_want_admits(
+    wire_json: &str,
+    content_id: &str,
+    object_bytes: u64,
+) -> Result<bool, StorageContentionError> {
+    let wire: CorpusWantWire = serde_json::from_str(wire_json)
+        .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+    Ok(wire.admits(content_id, object_bytes))
+}
+
+fn b64_decode(s: &str, what: &'static str) -> Result<Vec<u8>, StorageContentionError> {
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    B64.decode(s)
+        .map_err(|_| StorageContentionError::MalformedBase64(what))
+}
+
+fn decode_pubkeys(
+    ed_b64: &str,
+    mldsa_b64: &str,
+) -> Result<(Vec<u8>, Vec<u8>), StorageContentionError> {
+    Ok((
+        b64_decode(ed_b64, "ed25519_pubkey")?,
+        b64_decode(mldsa_b64, "ml_dsa_65_pubkey")?,
+    ))
+}
+
+fn decode_sigs(
+    ed_b64: &str,
+    mldsa_b64: &str,
+) -> Result<(Vec<u8>, Vec<u8>), StorageContentionError> {
+    Ok((
+        b64_decode(ed_b64, "sig_ed25519")?,
+        b64_decode(mldsa_b64, "sig_ml_dsa_65")?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    use ciris_crypto::{ClassicalSigner, Ed25519Signer, MlDsa65Signer, PqcSigner};
+
+    struct Id {
+        ed: Ed25519Signer,
+        pqc: MlDsa65Signer,
+    }
+    fn id() -> Id {
+        Id {
+            ed: Ed25519Signer::random().unwrap(),
+            pqc: MlDsa65Signer::new().unwrap(),
+        }
+    }
+    fn pubs(id: &Id) -> (String, String) {
+        (
+            B64.encode(id.ed.public_key().unwrap()),
+            B64.encode(id.pqc.public_key().unwrap()),
+        )
+    }
+    /// Mirror the engine's bound-hybrid sign over a preimage.
+    fn sign(id: &Id, preimage: &[u8]) -> (String, String) {
+        let ed_sig = id.ed.sign(preimage).unwrap();
+        let mut bound = preimage.to_vec();
+        bound.extend_from_slice(&ed_sig);
+        let pqc_sig = id.pqc.sign(&bound).unwrap();
+        (B64.encode(&ed_sig), B64.encode(&pqc_sig))
+    }
+
+    const BUDGET_PAYLOAD: &str = r#"{"node_id":"n1","epoch_id":"e1","revision":3,
+        "scopes":[{"cohort_scope":"affiliations","budget_bytes":1000,"pin_reserve_bytes":200},
+                  {"cohort_scope":"community","budget_bytes":2000,"pin_reserve_bytes":0}],
+        "pinned_class":["av_chunk","trace"]}"#;
+    const WANT_PAYLOAD: &str = r#"{"node_id":"n1","epoch_id":"e1","cohort_scope":"community",
+        "size_cap_bytes":4096,"remaining_budget_bytes":1800,"want":["cid-a","cid-b"]}"#;
+
+    fn build_budget(id: &Id, payload: &str) -> String {
+        let (ed, pqc) = sign(id, &storage_budget_preimage(payload).unwrap());
+        assemble_storage_budget_wire(payload, ed, pqc).unwrap()
+    }
+
+    #[test]
+    fn budget_build_verify_round_trip_and_tamper() {
+        let id = id();
+        let (ed_pub, pqc_pub) = pubs(&id);
+        let wire = build_budget(&id, BUDGET_PAYLOAD);
+        assert!(verify_storage_budget_wire(&wire, &ed_pub, &pqc_pub).is_ok());
+
+        // Tamper the revision → preimage diverges → signature fails.
+        let mut w: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        w["revision"] = serde_json::json!(99);
+        assert!(matches!(
+            verify_storage_budget_wire(&w.to_string(), &ed_pub, &pqc_pub),
+            Err(StorageContentionError::SignatureFailed)
+        ));
+    }
+
+    #[test]
+    fn budget_pqc_mandatory() {
+        let id = id();
+        let (ed_pub, pqc_pub) = pubs(&id);
+        let wire = build_budget(&id, BUDGET_PAYLOAD);
+        let mut w: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        w["signature_ml_dsa_65_base64"] = serde_json::json!("");
+        assert!(matches!(
+            verify_storage_budget_wire(&w.to_string(), &ed_pub, &pqc_pub),
+            Err(StorageContentionError::SignatureFailed)
+        ));
+    }
+
+    #[test]
+    fn budget_suppressed_scope_and_reserve_rejected_at_preimage() {
+        let bad_scope = r#"{"node_id":"n1","epoch_id":"e1","revision":1,
+            "scopes":[{"cohort_scope":"self","budget_bytes":1,"pin_reserve_bytes":0}],"pinned_class":[]}"#;
+        assert!(matches!(
+            storage_budget_preimage(bad_scope),
+            Err(StorageContentionError::Invalid(_))
+        ));
+        let bad_reserve = r#"{"node_id":"n1","epoch_id":"e1","revision":1,
+            "scopes":[{"cohort_scope":"community","budget_bytes":10,"pin_reserve_bytes":11}],"pinned_class":[]}"#;
+        assert!(matches!(
+            storage_budget_preimage(bad_reserve),
+            Err(StorageContentionError::Invalid(_))
+        ));
+    }
+
+    #[test]
+    fn budget_anti_rollback_supersedes() {
+        let id = id();
+        let lo = build_budget(&id, BUDGET_PAYLOAD); // revision 3
+        let mut p: serde_json::Value = serde_json::from_str(BUDGET_PAYLOAD).unwrap();
+        p["revision"] = serde_json::json!(5);
+        let hi = build_budget(&id, &p.to_string());
+        assert!(storage_budget_supersedes(&hi, &lo).unwrap());
+        assert!(!storage_budget_supersedes(&lo, &hi).unwrap());
+    }
+
+    #[test]
+    fn want_build_verify_and_admits() {
+        let id = id();
+        let (ed_pub, pqc_pub) = pubs(&id);
+        let (ed, pqc) = sign(&id, &corpus_want_preimage(WANT_PAYLOAD).unwrap());
+        let wire = assemble_corpus_want_wire(WANT_PAYLOAD, ed, pqc).unwrap();
+        assert!(verify_corpus_want_wire(&wire, &ed_pub, &pqc_pub).is_ok());
+        assert!(corpus_want_admits(&wire, "cid-a", 4096).unwrap());
+        assert!(!corpus_want_admits(&wire, "cid-a", 4097).unwrap()); // over cap
+        assert!(!corpus_want_admits(&wire, "cid-z", 1).unwrap()); // not wanted
+    }
+
+    #[test]
+    fn malformed_json_raises_not_false() {
+        assert!(matches!(
+            verify_storage_budget_wire("{not json", "", ""),
+            Err(StorageContentionError::MalformedJson(_))
+        ));
+    }
+}


### PR DESCRIPTION
Closes #354. Addresses #356 (build+verify surface; the pin-vs-revocation gate is the tracked follow-up #359).

## #356 — StorageBudgetV1 / CorpusWantV1 build+verify on the wheel (CC 6.1.5.2 §Q)

Re-pin **verify v8.6.0 → v8.7.0** (CIRISVerify#170 lifted the two §Q signed shapes into `ciris_verify_core::holonomic::storage_contention` — their canonical home, on the shared `Preimage` + `verify_bound_hybrid` gate). persist **wraps** them on the Python wheel; it does not redefine the crypto (`src/fountain/storage_contention.rs` — serde wire structs converting to the verify-core payload, same split as `AggregationMetaVerifyInputsV1`):

- `Engine.build_storage_budget_v1(payload_json)` / `build_corpus_want_v1(...)` — validate + bound-hybrid sign the CC 6.1.3 preimage (Ed25519 over preimage, ML-DSA-65 over `preimage ‖ ed25519_sig`) with the engine's local signer → signed wire JSON.
- `verify_storage_budget_v1(wire, ed_pub_b64, mldsa_pub_b64)` / `verify_corpus_want_v1(...)` — PQC-mandatory bound-hybrid verify at ingest: `True` iff valid+verified, `False` on structural/signature failure, raises only on un-parseable input.
- `storage_budget_supersedes(candidate, existing)` (B3 anti-rollback) + `corpus_want_admits(wire, cid, bytes)` (B4 wanted-then-pulled).

Verified-at-ingest, not stored (no admit/put table). The §Q **B6/N5 pin-never-defeats-revocation** gate is tracked as **#359** (needs a stored-pin design decision) and does not gate this surface.

## #354 — catch_unwind the executor-capsule C-ABI spawn boundary

`persist_spawn` is an `extern "C"` frame; since Rust 1.81 a panic unwinding out of it aborts the process (SIGABRT). Wrap the body in `catch_unwind` so a panic in the synchronous FFI glue is contained + logged, never crossing back into the consumer's `.so`. (The postgres `init_edge_runtime` SIGABRT itself was the OLD edge raw-`block_on` path — fixed edge-side in CIRISEdge#268; this is the persist-side defense-in-depth.) Test proves a panicking spawned task can't take down the executor/process.

## Verification
- **1285 pg+sqlite lib tests / 0 failed**; 6 §Q module tests + 1 #354 containment test; Python round-trip (build→verify→tamper→anti-rollback→admits→suppressed-scope) green.
- No pg/sqlite asymmetry. `Requires-Dist: ciris-verify>=8.0.0,<9` unchanged.

## Downstream
- CIRISConformance `test_530` anti-rollback + want/have gates flip.
- **CIRISEdge#269** — drop edge's local `storage_contention.rs`, consume verify v8.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)