### PR TITLE
v12.5.0 — CC 0.9.3 conformance batch: #309 age/capacity + #238 moderator/consent + #359 §Q pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.5.0] — 2026-07-04 — CC 0.9.3 conformance batch
+
+Read against the now-standalone **CIRISConstitution v0.9.3**. Three conformance
+issues, one release.
+
+### Added — #309: 4-band age + capacity assurance + adult-incapacity steward-binding + fail-to-liberty (CC 3.4.11–13 / 3.2)
+
+- **Four-band age** (`src/federation/age.rs`): `AgeBandFine { Under13, EarlyTeen13_15,
+  OlderTeen16_17, Adult, Unknown }` (tokens `under_13`/`13_15`/`16_17`/`adult`;
+  `minor` = union of the three sub-bands) + `age_band_fine()` resolver (witness-
+  outranks-self ratchet). The binary `AgeBand`/`age_band()` predicate is preserved
+  so the CC 3.2 minor gate keeps working; `Engine.age_band_fine_json` added.
+- **Capacity assurance** (new `src/federation/capacity.rs`): recognizes
+  `capacity_assurance:{level}:{domain}:{band}:v1` (level ∈ provider/panel/government;
+  band ∈ capacitated/incapacitated) + `reversible_excluded/pending:{domain}`;
+  witness-reserved (subject MUST NOT emit; steward MUST NOT attest);
+  `capacity_state()` resolver (presumption of capacity, one-way ratchet, `valid_until`
+  freshness); `Engine.capacity_state_json`.
+- **Adult-incapacity steward-binding** (`check_adult_incapacity_binding` in
+  admission.rs): admits an adult target ONLY under a live incapacitated capacity
+  attestation with `reversible_excluded` (or a T1 `reversible_pending` emergency
+  path), attester ∉ {steward, petitioner}, delegated scope ⊆ attested domains,
+  scope ∩ `PROTECTED_NON_TRANSFERABLE` (`contact`/`relational`/`voting`/`marriage`/
+  `reproduction`) = ∅, a mandatory `binding_legitimacy_source` ∈ {`prior_will_proxy`,
+  `wa_due_process_quorum`, `emergency_necessity_expedited`}, and a mandatory
+  `valid_until` ≤ `T2_REVIEW_CADENCE_DAYS` (90, operator-tunable). **Never the
+  steward's own signature alone.**
+- **Fail-to-liberty**: a lapsed `valid_until` makes the binding non-live and the
+  adult auto-re-sovereigns with no action required — wired into all three liveness
+  resolvers (`is_steward_bound` / `steward_bindings_of` / `steward_binding_chain`).
+- Deliberately deferred to higher layers (documented in-code): `panel` M-of-N
+  quorum *counting*, the T1 retrospective-WA-audit deadline timer, ward's-champion /
+  supported-vs-substituted wire shapes, `moderation:capacity_misattestation`
+  adjudication, and the `content_class:adult` visibility gate.
+
+### Added — #238: substrate no-moderator-no-federate gate + consent-revocation SLA (CC 4.5.4 / 5.3.2.2)
+
+0.9.3 makes both explicit and substrate-level:
+- **No-moderator gate** (§11.11): `check_no_moderator_federate_admission` +
+  `check_no_moderator_federate_apply` (wired into `put_attestation` on all three
+  backends) refuse to admit-to / continue federating a `community` with no live
+  `moderate`-holder — new `Error::CommunityHasNoModerator` (`kind =
+  federation_community_no_moderator`), fail-secure. The single federation-apply
+  chokepoint subsumes both admission (first apply) and the continue-to-federate
+  re-check (every subsequent apply); infrastructure communities exempt. Merit
+  auto-promotion / 48h recovery are signed appointment ceremonies (a higher layer;
+  persist provides the fail-secure floor, never fabricates a moderator).
+- **Consent-revocation SLA / AV-61** (§10.1.3): 0.9.3 ratifies the transit-not-rest
+  model — a subject-side revocation may transit local-tier but MUST NOT rest as a
+  durable local row; the substrate emits `hard_case:consent_revocation_promotion_overdue`
+  past the (default 24h) window. Closed the memory-backend `list_consent_revocations`
+  gap (was an erroring default → now scans subject-side revocations, matching
+  sqlite/postgres — no asymmetry) and rewrote the stale AV-61 comment.
+
+### Added — #359: §Q pin-never-defeats-revocation invariant, proven (CC 6.1.5.2 §Q B6 / N5)
+
+The spec mandates the invariant (revocation descends **regardless of pin state**),
+not a stored-pin override. persist verifies §Q shapes at ingest and stores no pin
+state, so `evict_fountain_content_hard_delete` (no pin parameter, no pin column,
+identical on both backends) can't consult a pin — the invariant holds by
+construction. Locked with a both-backend test: a verified `StorageBudgetV1` pinning
+`"trace"` does not prevent hard-delete of trace content. Also confirmed: the
+Constitution does **not** pin a dominance `min_ratio`, so persist's `0.5` stands.
+
+Verify pin unchanged (v8.7.0). Full suite green: **1306 pg+sqlite / 0 failed**.
+
 ## [12.4.0] — 2026-07-04
 
 ### Added — #356: StorageBudgetV1 / CorpusWantV1 build+verify on the wheel (CC 6.1.5.2 §Q)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.4.0"
+version = "12.5.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -416,6 +416,18 @@ pub fn default_reserved_prefix_rules() -> Vec<ReservedPrefixRule> {
         },
         ReservedPrefixRule {
             pattern_prefix: "age_assurance:".into(),
+            required_identity_types: vec![witness.clone()],
+        },
+        // v11.9.0 (CIRISPersist#309, CC 3.4.12) — the capacity-assurance
+        // ladder, the witness-reserved sibling of `age_assurance:`. A
+        // registered qualified assessor (identity_type ⊇ {witness}) attests;
+        // this covers both the `capacity_assurance:{level}:{domain}:{band}`
+        // verdicts AND the `reversible_excluded` / `reversible_pending`
+        // companions (same prefix). The SUBJECT-must-not-emit rule (attester
+        // == attested) is enforced separately in
+        // `check_reserved_prefix_admission` (an identity-independent check).
+        ReservedPrefixRule {
+            pattern_prefix: crate::federation::capacity::CAPACITY_ASSURANCE_PREFIX.into(),
             required_identity_types: vec![witness],
         },
     ]
@@ -1218,6 +1230,27 @@ fn delegation_scope_grants(envelope: &serde_json::Value, scope_token: &str) -> b
 /// `⊆`-parent attenuation check (`child.scope ⊆ parent.scope`) compares
 /// these sets along the chain. A `scope` that is neither string nor array
 /// (or absent) yields the empty set.
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12 fail-to-liberty) — has a
+/// `delegates_to` row's envelope `valid_until` lapsed as of `now`? An
+/// adult-incapacity binding carries a mandatory `valid_until`; on lapse it
+/// goes non-live and the adult auto-re-sovereigns with NO steward assent. A
+/// minor-guardianship row carries no `valid_until`, so this returns `false`
+/// for it (unaffected). An unparseable `valid_until` is treated as
+/// NOT-lapsed (fail-open at read is wrong here — but a malformed binding is
+/// rejected at admission, so this branch is unreachable for admitted rows;
+/// we do not silently un-live a row on a parse quirk).
+fn delegation_valid_until_lapsed(
+    envelope: &serde_json::Value,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    envelope
+        .get(crate::federation::capacity::binding_field::VALID_UNTIL)
+        .and_then(serde_json::Value::as_str)
+        .and_then(|s| s.parse::<chrono::DateTime<chrono::Utc>>().ok())
+        .map(|vu| vu <= now)
+        .unwrap_or(false)
+}
+
 fn delegation_scope_set(envelope: &serde_json::Value) -> std::collections::HashSet<String> {
     match envelope.get("scope") {
         Some(serde_json::Value::String(s)) => std::iter::once(s.clone()).collect(),
@@ -2184,6 +2217,11 @@ pub async fn is_steward_bound(
                 continue;
             }
         }
+        // (b') fail-to-liberty — a lapsed adult-incapacity `valid_until` is
+        //      not live (CC 3.4.12; no-op for minor rows).
+        if delegation_valid_until_lapsed(&r.attestation_envelope, now) {
+            continue;
+        }
         let Some(granter) = directory.lookup_public_key(&r.attesting_key_id).await? else {
             continue;
         };
@@ -2262,6 +2300,11 @@ pub async fn steward_bindings_of(
             if exp <= now {
                 continue;
             }
+        }
+        // Fail-to-liberty (CC 3.4.12): a lapsed adult-incapacity `valid_until`
+        // is non-live; the adult auto-re-sovereigns. No-op for minor rows.
+        if delegation_valid_until_lapsed(&r.attestation_envelope, now) {
+            continue;
         }
         let Some(granter) = directory.lookup_public_key(&r.attesting_key_id).await? else {
             continue;
@@ -2417,6 +2460,11 @@ pub async fn steward_binding_chain(
             if exp <= now {
                 continue;
             }
+        }
+        // Fail-to-liberty (CC 3.4.12): a lapsed adult-incapacity `valid_until`
+        // is non-live; the adult auto-re-sovereigns. No-op for minor rows.
+        if delegation_valid_until_lapsed(&r.attestation_envelope, now) {
+            continue;
         }
         let Some(granter) = directory.lookup_public_key(&r.attesting_key_id).await? else {
             continue;
@@ -3105,6 +3153,13 @@ pub async fn check_node_agency_admission(
 ///   attesting_key_id` is structural on the emit path, so no separate signer
 ///   check is needed.
 ///
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12): an ADULT user target is no longer
+/// rejected unconditionally — it is dispatched to
+/// [`check_adult_incapacity_binding`], the single narrow aperture that admits
+/// an attested-incapacitated adult under a scoped, bounded, independently-
+/// attested fiduciary binding (and re-asserts `target_is_self_sovereign` when
+/// no live incapacity is attested — the presumption of capacity).
+///
 /// Verify-before-mutation (AV-9): wired into every backend's
 /// `put_attestation` immediately AFTER [`check_node_agency_admission`], so a
 /// rejected emission leaves no trace. Backend-agnostic — resolution uses the
@@ -3131,18 +3186,29 @@ pub async fn check_user_target_steward_binding_admission(
     if !target_set.contains(identity_type::USER) {
         return Ok(());
     }
-    // The target is a user. It must be a PROVEN minor to be stewardable.
+    // The target is a user. The default CC 3.2 rule admits ONLY a proven
+    // minor (guardianship). An ADULT target is un-stewardable by default —
+    // EXCEPT the single narrow CC 3.4.12 adult-incapacity aperture, which
+    // this dispatches to. An unverified age is neither (presumption of
+    // sovereignty).
     let target_band = age_band(directory, &row.attested_key_id).await?;
-    if target_band != AgeBand::Minor {
-        let reason = match target_band {
-            AgeBand::Adult => "target_is_self_sovereign",
-            // Unknown (presumption of sovereignty).
-            _ => "target_age_unverified",
-        };
-        return Err(Error::UserTargetStewardBindingForbidden {
-            target_key_id: row.attested_key_id.clone(),
-            reason,
-        });
+    match target_band {
+        AgeBand::Minor => { /* fall through to minor-guardianship checks */ }
+        AgeBand::Adult => {
+            // The adult-incapacity path is the ONLY way to steward-bind an
+            // adult. It reasserts `target_is_self_sovereign` when no live
+            // incapacity is attested (presumption of capacity).
+            return check_adult_incapacity_binding(directory, row).await;
+        }
+        AgeBand::Unknown => {
+            return Err(Error::UserTargetStewardBindingForbidden {
+                target_key_id: row.attested_key_id.clone(),
+                // Presumption of sovereignty (age axis): not PROVEN a minor,
+                // and not PROVEN an adult (so not eligible for the incapacity
+                // aperture either — that predicate requires age_band == adult).
+                reason: "target_age_unverified",
+            });
+        }
     }
     // Target is a proven minor — require the granter is a proven adult user.
     let Some(granter) = directory.lookup_public_key(&row.attesting_key_id).await? else {
@@ -3161,6 +3227,179 @@ pub async fn check_user_target_steward_binding_admission(
         });
     }
     // Admit the minor-guardianship binding (S == attesting_key_id structural).
+    Ok(())
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the **adult-incapacity
+/// steward-binding** admission predicate: the third — and final — admissible
+/// user-target case, and the single narrow aperture in the CC 3.2
+/// un-stewardable-adult wall. Called by
+/// [`check_user_target_steward_binding_admission`] only when the target `T`
+/// resolves to a `user`-role identity with `age_band(T) == Adult`.
+///
+/// Admits `delegates_to(S -> T)` **only** when ALL hold (CC 3.4.12 admission
+/// predicate); otherwise REJECTS with a stable reason token on
+/// [`Error::UserTargetStewardBindingForbidden`]:
+///
+/// - **`target_is_self_sovereign`** — no LIVE `capacity_assurance:*:{d}:
+///   incapacitated` for any domain (the **presumption of capacity**: absence
+///   ⇒ full capacity ⇒ the un-stewardable default reasserts).
+/// - **`scope_missing`** — the binding declares no scope (a scope-less adult
+///   binding grants nothing checkable and cannot be `⊆` the attested loss).
+/// - **`scope_exceeds_attested_domains`** — a scoped domain has no live
+///   `:incapacitated` verdict (scope MUST be `⊆` the attested loss).
+/// - **`capacity_reversible_not_excluded`** — a scoped incapacitated domain
+///   lacks its mandatory `reversible_excluded` companion, and the acute T1
+///   `reversible_pending` path does not apply (wrong tier / missing pending /
+///   wrong legitimacy source).
+/// - **`scope_touches_protected_domain`** — scope intersects
+///   [`crate::federation::capacity::PROTECTED_NON_TRANSFERABLE`] (the
+///   apophatic floor: contact / relational / voting / marriage / reproduction
+///   are never delegable).
+/// - **`attester_conflicted`** — a capacity assessor for a covered domain is
+///   the steward `S` or the `petitioner` (assessor-independence; no one mints
+///   the incapacity of a person they propose to steward).
+/// - **`missing_legitimacy_source`** — `binding_legitimacy_source` is absent
+///   or not one of {`prior_will_proxy`, `wa_due_process_quorum`,
+///   `emergency_necessity_expedited`} (NEVER the steward's signature alone).
+/// - **`missing_valid_until`** — no `valid_until` (mandatory expiry ⇒
+///   fail-to-liberty).
+/// - **`valid_until_unparseable`** — `valid_until` is not an ISO-8601 instant.
+/// - **`valid_until_exceeds_review_cadence`** — the window exceeds
+///   [`crate::federation::capacity::T2_REVIEW_CADENCE_DAYS`] (no window may
+///   outrun periodic review).
+///
+/// **Fail-to-liberty** is enforced at READ time, not here: a binding whose
+/// `valid_until` has lapsed is treated as non-live by
+/// [`steward_bindings_of`], so the adult auto-re-sovereigns with no steward
+/// assent (see that function). This gate only guarantees a mandatory,
+/// bounded `valid_until` is present so the lapse mechanism can fire.
+///
+/// **Deliberately scoped down (CIRISPersist#309), tracked for follow-up:**
+/// the `panel`-rung M-of-N independent-quorum requirement for continuing /
+/// asset-bearing domains, the T1 retrospective-WA-audit HARD_DEADLINE + the
+/// irreversible-acts prohibition, the ward's-champion / inalienable-channel
+/// roles, and the supported-vs-substituted distinct-wire-shape check are
+/// governance/temporal concerns above this admission chokepoint. This gate
+/// enforces the structural core (per-domain incapacity + reversible exclusion,
+/// scope containment, protected-domain exclusion, assessor independence vs
+/// steward/petitioner, a mandatory bounded legitimacy source, and the
+/// fail-to-liberty `valid_until`).
+pub async fn check_adult_incapacity_binding(
+    directory: &dyn super::FederationDirectory,
+    row: &super::Attestation,
+) -> Result<(), Error> {
+    use super::age::{age_band, AgeBand};
+    use crate::federation::capacity::{
+        binding_field, is_protected_domain, legitimacy_source, tier, T2_REVIEW_CADENCE_DAYS,
+    };
+    let reject = |reason: &'static str| {
+        Err(Error::UserTargetStewardBindingForbidden {
+            target_key_id: row.attested_key_id.clone(),
+            reason,
+        })
+    };
+    let env = &row.attestation_envelope;
+
+    // Gather the ward's live incapacity facts in a single pass.
+    let facts =
+        crate::federation::capacity::incapacity_facts(directory, &row.attested_key_id).await?;
+
+    // (1) presumption of capacity: NO live incapacity attested anywhere ⇒ the
+    // adult is sovereign, the CC 3.2 default reasserts. (Checked FIRST so a
+    // capacitated adult target always reports `target_is_self_sovereign`.)
+    if facts.incapacitated_domains.is_empty() {
+        return reject("target_is_self_sovereign");
+    }
+
+    // The steward S must itself be an adult `user` (CC 3.4.12 "steward is a
+    // user identity (adult)"). A minor / non-user cannot be a fiduciary.
+    let steward_is_adult_user = match directory.lookup_public_key(&row.attesting_key_id).await? {
+        Some(rec) => {
+            identity_type::set_contains(&rec.identity_type, identity_type::USER)
+                && age_band(directory, &row.attesting_key_id).await? == AgeBand::Adult
+        }
+        None => false,
+    };
+    if !steward_is_adult_user {
+        return reject("granter_not_adult_user");
+    }
+
+    // (2) the delegated scope — the domains the steward may act in. Reuse the
+    // shared `scope` reader (bare-string OR array-set). For an adult-incapacity
+    // binding the scope tokens are decision-domains.
+    let scope = delegation_scope_set(env);
+    if scope.is_empty() {
+        return reject("scope_missing");
+    }
+
+    // Whether the T1 acute path (reversible_pending in lieu of _excluded) is
+    // available for this binding: tier == T1 AND legitimacy == emergency.
+    let legit = env
+        .get(binding_field::LEGITIMACY_SOURCE)
+        .and_then(serde_json::Value::as_str);
+    let binding_tier = env
+        .get(binding_field::TIER)
+        .and_then(serde_json::Value::as_str);
+    let t1_path = binding_tier == Some(tier::T1_EMERGENCY_NECESSITY)
+        && legit == Some(legitimacy_source::EMERGENCY_NECESSITY_EXPEDITED);
+
+    // (3) scope ⊆ attested-incapacitated domains, each with reversible
+    // exclusion (or the T1 pending path), and none protected.
+    for d in &scope {
+        if is_protected_domain(d) {
+            return reject("scope_touches_protected_domain");
+        }
+        if !facts.incapacitated_domains.contains(d) {
+            return reject("scope_exceeds_attested_domains");
+        }
+        let excluded = facts.reversible_excluded_domains.contains(d);
+        let pending_ok = t1_path && facts.reversible_pending_domains.contains(d);
+        if !excluded && !pending_ok {
+            return reject("capacity_reversible_not_excluded");
+        }
+    }
+
+    // (4) assessor independence: no capacity attester for the covered domains
+    // may be the steward S or the petitioner (anti-capture). `S` is the
+    // granter = attesting_key_id of the delegates_to.
+    let steward = row.attesting_key_id.as_str();
+    let petitioner = env
+        .get(binding_field::PETITIONER_KEY_ID)
+        .and_then(serde_json::Value::as_str);
+    if facts.incapacity_attesters.contains(steward)
+        || petitioner
+            .map(|p| facts.incapacity_attesters.contains(p))
+            .unwrap_or(false)
+    {
+        return reject("attester_conflicted");
+    }
+
+    // (5) mandatory legitimacy source ∈ the closed set — NEVER the steward's
+    // signature alone (naked self-appointment).
+    match legit {
+        Some(s) if legitimacy_source::is_valid(s) => {}
+        _ => return reject("missing_legitimacy_source"),
+    }
+
+    // (6) mandatory bounded valid_until (fail-to-liberty).
+    let Some(vu_raw) = env
+        .get(binding_field::VALID_UNTIL)
+        .and_then(serde_json::Value::as_str)
+    else {
+        return reject("missing_valid_until");
+    };
+    let Ok(valid_until) = vu_raw.parse::<chrono::DateTime<chrono::Utc>>() else {
+        return reject("valid_until_unparseable");
+    };
+    // No window may outrun the T2 periodic-review cadence.
+    let ceiling = chrono::Utc::now() + chrono::Duration::days(T2_REVIEW_CADENCE_DAYS);
+    if valid_until > ceiling {
+        return reject("valid_until_exceeds_review_cadence");
+    }
+
+    // ADMIT the scoped, bounded, independently-attested adult-incapacity
+    // fiduciary binding (CC 3.4.12).
     Ok(())
 }
 
@@ -3200,6 +3439,21 @@ pub async fn check_reserved_prefix_admission(
     // CC 3.4.5 — capacity:* self-emission. Cheapest check (no lookup); an
     // attester==attested rule independent of identity_type.
     if at.starts_with("capacity:") && row.attesting_key_id == row.attested_key_id {
+        return Err(Error::CapacitySelfEmissionRejected {
+            key_id: row.attesting_key_id.clone(),
+            attestation_type: at.to_owned(),
+        });
+    }
+
+    // CC 3.4.12 — capacity_assurance:* the SUBJECT must not self-mint their
+    // own (in)capacity ("the subject MUST NOT emit it"). An attester==attested
+    // check independent of identity_type; the witness-RESERVED half (only a
+    // registered `witness` assessor may emit) rides the reserved-prefix rule
+    // table below. (`capacity_assurance:` does not start with `capacity:`, so
+    // the CC 3.4.5 check above never fires for it.)
+    if at.starts_with(crate::federation::capacity::CAPACITY_ASSURANCE_PREFIX)
+        && row.attesting_key_id == row.attested_key_id
+    {
         return Err(Error::CapacitySelfEmissionRejected {
             key_id: row.attesting_key_id.clone(),
             attestation_type: at.to_owned(),

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -2616,6 +2616,164 @@ pub async fn check_community_membership_steward_binding(
     Ok(())
 }
 
+/// v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11 — the no-moderator-no-federate
+/// existence invariant) — the **substrate** federate-gate: a `community`
+/// federates (is admitted to, and continues at, moderated capability) ONLY
+/// while ≥1 live holder of its `moderate` duty exists. This is the moderation
+/// analogue of the CC 3.2 steward-binding gate, and — like it — lives in the
+/// substrate where the write lands, NOT in a governance / consumer-policy
+/// layer (§11.11 "the gate lives where the write lands"; resolving the
+/// CIRISPersist#238 / CIRISRegistry#110(a) ownership ambiguity to SUBSTRATE).
+///
+/// Takes the [`Community`](crate::federation::types::Community) record
+/// **directly** (not via `lookup_community`) — the reusable admission-decision
+/// primitive over a record in hand (in-flight or stored). For the
+/// federation-apply re-check keyed on a stored community's id, see
+/// [`check_no_moderator_federate_admission_by_id`]; both are the load-bearing
+/// enforcement point [`check_no_moderator_federate_apply`] consumes.
+///
+/// # Enforcement point (design note — CIRISPersist#238)
+///
+/// The §11.11 gate is enforced at the **federation-apply chokepoint**: every
+/// federation-tier attestation apply step keyed on `C`
+/// ([`check_no_moderator_federate_apply`], wired into every backend's
+/// `put_attestation`). This point subsumes BOTH spec evaluation points — a
+/// community's **first** federation-tier apply keyed on `C` IS its
+/// admission-to-federate (i), and every subsequent one is the continue-to-
+/// federate re-check (ii). It is deliberately NOT wired into `put_community`:
+/// storing a community *record* is not itself "federating" (a local-only
+/// community that never emits federation-tier content keyed on `C` causes no
+/// unmoderated-federation harm), and hard-failing record storage would also
+/// fail-secure communities that §11.11 rule-2 merit auto-promotion / the CC
+/// 4.5.13 recovery could still rescue — ceremonies persist cannot itself
+/// perform (it cannot forge the authority's appointment signature). The gate
+/// thus "lives where the [federation] write lands." This function remains the
+/// admission-decision primitive a consumer/governance layer MAY call to decide
+/// admission ahead of federation.
+///
+/// # The existence check
+///
+/// A named moderator exists IFF the community has ≥1 **steward-bound authority
+/// root**. This is exact, not an approximation: [`is_named_moderator`] admits
+/// `k` only via a chain rooted at some `root ∈ authority_set(C)` with
+/// [`is_steward_bound(root)`](is_steward_bound) — and that steward-bound root
+/// is itself a **zero-hop** named moderator. So `moderators_of(C, moderate)`
+/// is non-empty IFF such a root exists; we test that directly (the authority
+/// set computed from the in-flight record's roster, per
+/// [`community_authority_set`]'s `founder_only`-vs-open rule), avoiding the
+/// per-delegate walk.
+///
+/// # Carve-out + fail-secure
+///
+/// `cohort_subkind: infrastructure` communities
+/// ([`is_authorized_infrastructure_community`]) are EXEMPT — a node MAY trust +
+/// serve an infrastructure community (`ciris-canonical` / governance roots)
+/// with no moderator, mirroring the CC 3.2 steward-binding carve-out. Every
+/// other community with no steward-bound authority root is REFUSED with
+/// [`Error::CommunityHasNoModerator`] BEFORE any row is stored
+/// (verify-before-mutation, AV-9) — §11.11 rule 3 fail-secure, "better no
+/// group than an unmoderated one".
+///
+/// Merit auto-promotion (§11.11 rule 2) + the CC 4.5.13 48-hour recovery are
+/// signed appointment *ceremonies* (a `delegates_to(moderate)` emitted by the
+/// community authority); persist cannot forge that authority signature, so
+/// they live one layer up. This gate is the fail-secure floor the ceremony
+/// recovers the community out of — the substrate never *fabricates* a
+/// moderator, it only refuses to federate one that does not exist.
+pub async fn check_no_moderator_federate_admission(
+    directory: &dyn super::FederationDirectory,
+    community: &super::Community,
+) -> Result<(), Error> {
+    // Infrastructure carve-out (authorized only — SecReview F2 fail-secure):
+    // trust + serve needs no moderator.
+    if is_authorized_infrastructure_community(directory, community).await? {
+        return Ok(());
+    }
+    // Authority set from the in-flight roster (mirrors community_authority_set:
+    // founders always; every member too under a non-`founder_only` protocol).
+    let founder_only =
+        community.consensus_protocol == crate::federation::types::consensus_protocol::FOUNDER_ONLY;
+    for m in &community.members {
+        let is_authority = m.role.as_deref() == Some(MEMBER_ROLE_FOUNDER) || !founder_only;
+        if is_authority && is_steward_bound(directory, &m.key_id).await? {
+            // ≥1 steward-bound authority root ⇒ a live (zero-hop) named
+            // moderator exists ⇒ the community may federate.
+            return Ok(());
+        }
+    }
+    Err(Error::CommunityHasNoModerator {
+        community_key_id: community.community_key_id.clone(),
+    })
+}
+
+/// v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — the **federation-apply**
+/// re-check of [`check_no_moderator_federate_admission`], keyed on a stored
+/// community's `community_id`. §11.11 requires the moderator-existence gate at
+/// **two** points: (i) at admission (`put_community` — the record-in-flight
+/// form above) AND (ii) **on the federation path** — "every cross-region
+/// propagation / federation apply step keyed on C MUST re-check live
+/// `moderate`-holder existence at apply time, so a community that *loses* its
+/// moderator (lapse / `withdraws`-revocation / freshness expiry) cannot
+/// continue at moderated capability." Mid-life moderator loss happens via
+/// `delegates_to` retraction / steward-binding lapse — NOT via a community
+/// re-write — so the community-record admission gate alone cannot catch it;
+/// this apply-time re-check does.
+///
+/// Resolves the community via [`FederationDirectory::lookup_community`]. A
+/// community **not locally known** is out of scope — `Ok(())` (fail-open): the
+/// substrate cannot resolve an absent record's moderators, and a
+/// federation-tier row keyed on it is governed by that peer's own admission
+/// gate; the known-community record admission gate is the authoritative point.
+/// A known community runs the full existence + infrastructure-carve-out check.
+pub async fn check_no_moderator_federate_admission_by_id(
+    directory: &dyn super::FederationDirectory,
+    community_id: &str,
+) -> Result<(), Error> {
+    if community_id.is_empty() {
+        return Ok(());
+    }
+    let Some(community) = directory.lookup_community(community_id).await? else {
+        return Ok(());
+    };
+    check_no_moderator_federate_admission(directory, &community).await
+}
+
+/// v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — the `put_attestation` entry
+/// point for the §11.11 federation-apply re-check (point ii). A
+/// **federation-tier** attestation carrying a `community_id` in its envelope is
+/// a "federation apply step keyed on C"; it is refused if `C` has no live
+/// `moderate`-holder ([`check_no_moderator_federate_admission_by_id`]).
+///
+/// A no-op (`Ok(())`) for:
+/// - **local-tier** rows — a local-tier write is private to the producing
+///   occurrence and not a federation apply step (CC 5.3.2.2), and
+/// - rows carrying **no** `community_id` (not keyed on a community), and
+/// - a `community_id` **not locally known** (out of scope — fail-open, per
+///   [`check_no_moderator_federate_admission_by_id`]).
+///
+/// A founder appointment (`delegates_to(moderate)` keyed on C) is NOT
+/// chicken-and-egg-blocked: a steward-bound founder is already a zero-hop named
+/// moderator, so `C` is not moderator-less at that point; and a non-steward-
+/// bound founder could not root a moderator via the appointment anyway (the
+/// walk requires a steward-bound root). Verify-before-mutation (AV-9) — wired
+/// alongside the other shared admission gates on every backend's
+/// `put_attestation`, before the row is hashed + INSERTed.
+pub async fn check_no_moderator_federate_apply(
+    directory: &dyn super::FederationDirectory,
+    row: &super::Attestation,
+) -> Result<(), Error> {
+    // Only federation-tier rows are a federation apply step.
+    if row.tier != crate::federation::types::attestation_tier::FEDERATION {
+        return Ok(());
+    }
+    let community_id = row
+        .attestation_envelope
+        .get("community_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    check_no_moderator_federate_admission_by_id(directory, community_id).await
+}
+
 /// v8.7.1 (CIRISPersist#233, CEG RC25/RC26 §11.11) — is key `k` a **named
 /// moderator** of community `community_id` for `duty` (`moderate` /
 /// `takedown` / `review`)? True iff a live scope-bearing `delegates_to`

--- a/src/federation/age.rs
+++ b/src/federation/age.rs
@@ -33,6 +33,107 @@
 
 use super::{Error, FederationDirectory};
 
+/// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1) — the **four-band age
+/// vocabulary** that rides the `{band}` slot of the `age_assurance:{level}:
+/// {band}:v1` / `age_self_declared:{band}:v1` tokens. These are the finer
+/// grain ABOVE the unchanged binary `minor`/`adult` wire predicate (CC
+/// 3.4.13 Q1: "the four-band granularity is a policy/vocabulary layer above
+/// the unchanged binary wire predicate, never a replacement of it"). `minor`
+/// = the union of the three sub-18 bands.
+///
+/// Operator-approved defaults (CIRISPersist#309), documented as named
+/// consts. The tokens use the existing underscore convention (matching
+/// `age_self_declared:band:minor`).
+pub mod band {
+    /// Under-13 band (CC 3.4.13 Q1 "under-13"). The most protective minor
+    /// band; the fail-secure default a CONTENT-axis consumer resolves an
+    /// absent/declined/unknown assurance DOWN to (CC 3.4.13 Q1 fail-secure).
+    pub const UNDER_13: &str = "under_13";
+    /// Early-teen band (CC 3.4.13 Q1 "13–15").
+    pub const EARLY_TEEN_13_15: &str = "13_15";
+    /// Older-teen band (CC 3.4.13 Q1 "16–17"). CC 3.4.13 Q2 sets the
+    /// self-consent floor at 16 (a policy layer above this substrate band).
+    pub const OLDER_TEEN_16_17: &str = "16_17";
+    /// Adult band (CC 3.4.13 Q1 "adult (18+)"). Same token as the binary
+    /// `adult` wire predicate — an adult has no finer sub-band.
+    pub const ADULT: &str = "adult";
+    /// The coarse binary minor token (CC 3.2 / CC 3.4.11 wire predicate).
+    /// Recognized as `minor` = the union of the three sub-18 bands.
+    pub const MINOR: &str = "minor";
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1) — the **finer** four-band age
+/// vocabulary, the policy layer ABOVE the binary [`AgeBand`] wire predicate.
+/// The three sub-18 variants all coarsen to [`AgeBand::Minor`]
+/// ([`Self::is_minor`] / [`Self::coarsen`]); `Adult`/`Unknown` map through
+/// unchanged. Resolved by [`age_band_fine`].
+///
+/// Like [`AgeBand`] this primitive is **three-axis-neutral**: it returns
+/// [`AgeBandFine::Unknown`] verbatim when there is no usable proof. A
+/// CONTENT-axis consumer floors `Unknown` DOWN to the most-protective
+/// [`AgeBandFine::Under13`] (CC 3.4.13 Q1 fail-secure); the steward-binding
+/// axis keeps `Unknown` = non-minor = self-sovereign (CC 1.15.6). The
+/// primitive does NOT bake either policy in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgeBandFine {
+    /// Under-13 (most protective). Coarsens to [`AgeBand::Minor`].
+    Under13,
+    /// 13–15 early-teen. Coarsens to [`AgeBand::Minor`].
+    EarlyTeen13_15,
+    /// 16–17 older-teen. Coarsens to [`AgeBand::Minor`].
+    OlderTeen16_17,
+    /// 18+ adult. Coarsens to [`AgeBand::Adult`].
+    Adult,
+    /// No usable age proof. Coarsens to [`AgeBand::Unknown`].
+    Unknown,
+}
+
+impl AgeBandFine {
+    /// The stable FFI/telemetry token
+    /// (`"under_13"` / `"13_15"` / `"16_17"` / `"adult"` / `"unknown"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AgeBandFine::Under13 => band::UNDER_13,
+            AgeBandFine::EarlyTeen13_15 => band::EARLY_TEEN_13_15,
+            AgeBandFine::OlderTeen16_17 => band::OLDER_TEEN_16_17,
+            AgeBandFine::Adult => band::ADULT,
+            AgeBandFine::Unknown => "unknown",
+        }
+    }
+
+    /// `minor` is derivable — any of the three sub-18 bands (CC 3.4.13 Q1
+    /// "`minor` = the union of the three sub-bands").
+    pub fn is_minor(self) -> bool {
+        matches!(
+            self,
+            AgeBandFine::Under13 | AgeBandFine::EarlyTeen13_15 | AgeBandFine::OlderTeen16_17
+        )
+    }
+
+    /// Coarsen to the binary [`AgeBand`] wire predicate (the three sub-18
+    /// bands → [`AgeBand::Minor`]).
+    pub fn coarsen(self) -> AgeBand {
+        match self {
+            _ if self.is_minor() => AgeBand::Minor,
+            AgeBandFine::Adult => AgeBand::Adult,
+            _ => AgeBand::Unknown,
+        }
+    }
+
+    /// Protectiveness rank (LOWER = more protective). Used to take the
+    /// most-protective of several self-declared minor sub-bands (self may
+    /// only ratchet DOWN — CC 3.4.11 "`self` is unfalsifiable").
+    fn protection_rank(self) -> u8 {
+        match self {
+            AgeBandFine::Under13 => 0,
+            AgeBandFine::EarlyTeen13_15 => 1,
+            AgeBandFine::OlderTeen16_17 => 2,
+            AgeBandFine::Adult => 3,
+            AgeBandFine::Unknown => 4,
+        }
+    }
+}
+
 /// The I1 age band of a key (CC 3.3.12). Three-valued: a person with no
 /// usable age attestation resolves to [`AgeBand::Unknown`], which the
 /// steward-binding gate treats as NON-minor (un-stewardable —
@@ -66,25 +167,47 @@ impl AgeBand {
 /// `':'` and recognizes exactly `adult` → [`AgeBand::Adult`] and `minor` →
 /// [`AgeBand::Minor`] as a segment; returns `None` if neither is present.
 ///
-/// Deliberately small + #309-extensible: #309 will add the 4-band
-/// `under_13` / `13_15` / `16_17` → all map to [`AgeBand::Minor`]. For now we
-/// recognize only the coarse `adult` / `minor` tokens both rungs use.
+/// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1): the 4-band vocabulary now rides
+/// the `{band}` slot too — `under_13` / `13_15` / `16_17` all coarsen to
+/// [`AgeBand::Minor`] (they are minors on the binary wire predicate), while
+/// `adult` stays [`AgeBand::Adult`]. The binary predicate is UNCHANGED on the
+/// wire; the sub-band tokens are simply recognized as `minor` here so the CC
+/// 3.2 steward-binding gate keeps working when a producer stamps a finer
+/// band. See [`parse_age_band_fine_token`] for the finer resolution.
 fn parse_age_band_token(attestation_type: &str) -> Option<AgeBand> {
-    let mut found_adult = false;
-    let mut found_minor = false;
+    parse_age_band_fine_token(attestation_type).map(AgeBandFine::coarsen)
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1) — parse the finer [`AgeBandFine`]
+/// out of an age `attestation_type` token. Splits on `':'` and recognizes
+/// exactly one of the four bands (`under_13` / `13_15` / `16_17` / `adult`)
+/// PLUS the coarse `minor` token (→ [`AgeBandFine::Under13`], the most
+/// protective minor band — a bare `minor` carries no finer grain, so it
+/// resolves to the fail-secure floor). Returns `None` if no recognized band
+/// segment is present, or if the token is malformed (carries more than one
+/// distinct band).
+fn parse_age_band_fine_token(attestation_type: &str) -> Option<AgeBandFine> {
+    let mut found: Option<AgeBandFine> = None;
     for seg in attestation_type.split(':') {
-        match seg {
-            "adult" => found_adult = true,
-            "minor" => found_minor = true,
-            _ => {}
+        let b = match seg {
+            band::UNDER_13 => AgeBandFine::Under13,
+            band::EARLY_TEEN_13_15 => AgeBandFine::EarlyTeen13_15,
+            band::OLDER_TEEN_16_17 => AgeBandFine::OlderTeen16_17,
+            band::ADULT => AgeBandFine::Adult,
+            // A coarse `minor` token has no sub-grain → the most protective
+            // minor band (fail-secure). Coarsens back to `Minor`.
+            band::MINOR => AgeBandFine::Under13,
+            _ => continue,
+        };
+        match found {
+            None => found = Some(b),
+            // Defensive: a malformed token carrying two DISTINCT bands → no
+            // clean band. (`minor` + `under_13` both → Under13 is consistent.)
+            Some(prev) if prev != b => return None,
+            Some(_) => {}
         }
     }
-    // Defensive: a malformed token carrying both → no clean band.
-    match (found_adult, found_minor) {
-        (true, false) => Some(AgeBand::Adult),
-        (false, true) => Some(AgeBand::Minor),
-        _ => None,
-    }
+    found
 }
 
 /// Resolve the [`AgeBand`] of key `k` from its INCOMING age attestations
@@ -124,4 +247,146 @@ pub async fn age_band(directory: &dyn FederationDirectory, k: &str) -> Result<Ag
         return Ok(AgeBand::Minor);
     }
     Ok(AgeBand::Unknown)
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1) — resolve the finer
+/// [`AgeBandFine`] of key `k` from its INCOMING age attestations, the policy
+/// layer ABOVE [`age_band`]. Same witness-outranks-self one-way ratchet + the
+/// `expires_at`-only liveness, but preserving the four-band grain:
+///
+///   1. the finer band of the most-recent live **witness**-rung age
+///      attestation that parses to a recognized band, if any (this is the
+///      ONLY way to graduate UP a band — CC 3.4.11 "`self` is unfalsifiable;
+///      graduating up requires a witness-reserved `age_assurance:*` row");
+///      ELSE
+///   2. the **most-protective** (lowest) self-declared MINOR sub-band on
+///      record (`self` may only ratchet DOWN — a self-declared adult is
+///      ignored, and among several self-declared minor bands the most
+///      protective wins); ELSE
+///   3. [`AgeBandFine::Unknown`] (no usable proof — returned verbatim; a
+///      CONTENT-axis consumer floors this to [`AgeBandFine::Under13`], the
+///      steward-binding axis treats it as self-sovereign).
+///
+/// [`age_band`] is exactly `age_band_fine(..).coarsen()`; both are kept so a
+/// consumer can pick the grain it needs without re-deriving liveness.
+pub async fn age_band_fine(
+    directory: &dyn FederationDirectory,
+    k: &str,
+) -> Result<AgeBandFine, Error> {
+    let now = chrono::Utc::now();
+    let mut best_self_minor: Option<AgeBandFine> = None;
+    for r in directory.list_attestations_for(k).await? {
+        if let Some(exp) = r.expires_at {
+            if exp <= now {
+                continue;
+            }
+        }
+        let at = r.attestation_type.as_str();
+        if at.starts_with("age_assurance:") {
+            // Witness rung — authoritative; most-recent parse wins outright.
+            if let Some(band) = parse_age_band_fine_token(at) {
+                return Ok(band);
+            }
+        } else if at.starts_with("age_self_declared:") {
+            // Self rung — one-way ratchet: only a self-declared MINOR band
+            // counts (a self-declared adult is ignored). Keep the most
+            // protective (self may only LOWER access).
+            if let Some(b) = parse_age_band_fine_token(at) {
+                if b.is_minor()
+                    && best_self_minor
+                        .map(|cur| b.protection_rank() < cur.protection_rank())
+                        .unwrap_or(true)
+                {
+                    best_self_minor = Some(b);
+                }
+            }
+        }
+    }
+    Ok(best_self_minor.unwrap_or(AgeBandFine::Unknown))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── CIRISPersist#309 (CC 3.4.13 Q1) — four-band vocabulary ──────────
+
+    #[test]
+    fn fine_token_parses_four_bands_plus_coarse_minor() {
+        assert_eq!(
+            parse_age_band_fine_token("age_assurance:provider:under_13:v1"),
+            Some(AgeBandFine::Under13)
+        );
+        assert_eq!(
+            parse_age_band_fine_token("age_assurance:provider:13_15:v1"),
+            Some(AgeBandFine::EarlyTeen13_15)
+        );
+        assert_eq!(
+            parse_age_band_fine_token("age_self_declared:16_17:v1"),
+            Some(AgeBandFine::OlderTeen16_17)
+        );
+        assert_eq!(
+            parse_age_band_fine_token("age_assurance:government:adult:v1"),
+            Some(AgeBandFine::Adult)
+        );
+        // A coarse `minor` token → the most protective minor band.
+        assert_eq!(
+            parse_age_band_fine_token("age_assurance:provider:minor:v1"),
+            Some(AgeBandFine::Under13)
+        );
+        // No recognized band segment.
+        assert_eq!(parse_age_band_fine_token("age_assurance:provider:v1"), None);
+    }
+
+    #[test]
+    fn fine_token_two_distinct_bands_is_malformed() {
+        assert_eq!(
+            parse_age_band_fine_token("age_assurance:provider:under_13:adult:v1"),
+            None
+        );
+        // `minor` + `under_13` are CONSISTENT (both → Under13) → not malformed.
+        assert_eq!(
+            parse_age_band_fine_token("age:minor:under_13"),
+            Some(AgeBandFine::Under13)
+        );
+    }
+
+    #[test]
+    fn sub_band_tokens_coarsen_to_minor_on_binary_predicate() {
+        // The binary wire predicate is UNCHANGED: every sub-18 band → Minor.
+        for t in [
+            "age_assurance:provider:under_13:v1",
+            "age_assurance:provider:13_15:v1",
+            "age_assurance:provider:16_17:v1",
+            "age_assurance:provider:minor:v1",
+        ] {
+            assert_eq!(parse_age_band_token(t), Some(AgeBand::Minor), "{t}");
+        }
+        assert_eq!(
+            parse_age_band_token("age_assurance:provider:adult:v1"),
+            Some(AgeBand::Adult)
+        );
+    }
+
+    #[test]
+    fn fine_is_minor_and_coarsen() {
+        assert!(AgeBandFine::Under13.is_minor());
+        assert!(AgeBandFine::EarlyTeen13_15.is_minor());
+        assert!(AgeBandFine::OlderTeen16_17.is_minor());
+        assert!(!AgeBandFine::Adult.is_minor());
+        assert!(!AgeBandFine::Unknown.is_minor());
+        assert_eq!(AgeBandFine::Under13.coarsen(), AgeBand::Minor);
+        assert_eq!(AgeBandFine::OlderTeen16_17.coarsen(), AgeBand::Minor);
+        assert_eq!(AgeBandFine::Adult.coarsen(), AgeBand::Adult);
+        assert_eq!(AgeBandFine::Unknown.coarsen(), AgeBand::Unknown);
+    }
+
+    #[test]
+    fn fine_as_str_tokens_stable() {
+        assert_eq!(AgeBandFine::Under13.as_str(), "under_13");
+        assert_eq!(AgeBandFine::EarlyTeen13_15.as_str(), "13_15");
+        assert_eq!(AgeBandFine::OlderTeen16_17.as_str(), "16_17");
+        assert_eq!(AgeBandFine::Adult.as_str(), "adult");
+        assert_eq!(AgeBandFine::Unknown.as_str(), "unknown");
+    }
 }

--- a/src/federation/capacity.rs
+++ b/src/federation/capacity.rs
@@ -1,0 +1,428 @@
+//! v11.9.0 (CIRISPersist#309, CC 3.4.12) — the **capacity-assurance ladder**:
+//! the witness-reserved, PER-DOMAIN sibling of the [`super::age`]
+//! age-assurance ladder. Where age is a scalar binary predicate, capacity is
+//! a *time-varying, non-monotonic vector*: a person may be `incapacitated`
+//! for `financial` decisions yet `capacitated` for `medical` ones, so every
+//! attestation is qualified by a `{domain}` (CC 3.4.12).
+//!
+//! Tokens travel as the **`attestation_type`** string (like age; NOT the
+//! `scores` envelope `dimension`):
+//!
+//! - `capacity_assurance:{level}:{domain}:{band}:v1` — the witness verdict.
+//!   `level ∈ {provider, panel, government}` (ascending confidence; `panel`
+//!   = an M-of-N quorum of independent assessors), `band ∈ {capacitated,
+//!   incapacitated}`. Witness-RESERVED (`witness ∈ attesting_key.identity_type`)
+//!   AND the subject MUST NOT self-emit — enforced at admission (see
+//!   [`super::admission::check_reserved_prefix_admission`]).
+//! - `capacity_assurance:reversible_excluded:{domain}` — the mandatory
+//!   companion: delirium / infection-confusion / depression / polypharmacy
+//!   have been ruled out for `{domain}` (the genuine restoration path and the
+//!   most-abused mis-attribution). Required for any *continuing* binding.
+//! - `capacity_assurance:reversible_pending:{domain}` — ACUTE-WINDOW ONLY:
+//!   exclusion in progress; admissible solely for the T1 emergency-necessity
+//!   tier and MUST resolve to `reversible_excluded` or the binding lapses.
+//!
+//! **The two load-bearing inversions of the minor rule (CC 3.4.12):**
+//!   1. **Presumption of capacity** — *absence* of a capacity attestation
+//!      resolves to `capacitated` / sovereign, NOT to protection. Getting
+//!      this backwards would be catastrophic and is forbidden.
+//!      [`capacity_state`] returns [`CapacityState::Unknown`] on absence; a
+//!      consumer treats `Unknown` as full capacity.
+//!   2. **Fail-to-liberty** — every binding carries a short `valid_until` that
+//!      cannot exceed the [`T2_REVIEW_CADENCE_DAYS`] periodic-review cadence;
+//!      on lapse the binding goes non-live and the adult auto-re-sovereigns
+//!      (see [`super::admission::check_adult_incapacity_binding`] and the
+//!      steward-binding liveness in [`super::admission::steward_bindings_of`]).
+
+use super::{Error, FederationDirectory};
+use std::collections::HashSet;
+
+/// The witness-reserved capacity-assurance `attestation_type` prefix.
+pub const CAPACITY_ASSURANCE_PREFIX: &str = "capacity_assurance:";
+
+/// The `{level}` rung vocabulary (ascending confidence). Closed set.
+pub mod level {
+    /// A single qualified assessor (clinician/evaluator). Admissible ONLY for
+    /// the shortest provisional tier and never confers asset-preservation or
+    /// continuing power on its own (CC 3.4.12 "Confidence scales with scope").
+    pub const PROVIDER: &str = "provider";
+    /// An M-of-N quorum of *independent* assessors (CC 3.4.12 `panel` rung) —
+    /// required for any continuing or high-scope domain.
+    pub const PANEL: &str = "panel";
+    /// A court-appointed / government evaluator.
+    pub const GOVERNMENT: &str = "government";
+}
+
+/// The `{band}` per-domain per-decision-class vocabulary. Closed set.
+pub mod capacity_band {
+    /// The adult HOLDS the domain (presumption of capacity; the default).
+    pub const CAPACITATED: &str = "capacitated";
+    /// The adult has an attested loss of capacity for the domain.
+    pub const INCAPACITATED: &str = "incapacitated";
+}
+
+/// The reversible-cause exclusion companion sub-prefixes (CC 3.4.12).
+pub mod reversible {
+    /// `capacity_assurance:reversible_excluded:{domain}` — reversible mimics
+    /// ruled out for the domain (mandatory for a continuing binding).
+    pub const EXCLUDED_PREFIX: &str = "capacity_assurance:reversible_excluded:";
+    /// `capacity_assurance:reversible_pending:{domain}` — exclusion in
+    /// progress (T1 acute-window only).
+    pub const PENDING_PREFIX: &str = "capacity_assurance:reversible_pending:";
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — **T2 periodic-review cadence**:
+/// the maximum `valid_until` window (in days) an adult-incapacity binding may
+/// carry. No single window may outrun periodic review (CC 3.4.12 "no
+/// long-dated binding that escapes review between renewals").
+///
+/// **Operator-tunable default** (CIRISPersist#309 — operator approved "use
+/// your defaults"): 90 days. The Constitution fixes only the *ceiling*
+/// property ("no window exceeds the T2 review cadence"); the concrete cadence
+/// is a deployment policy knob surfaced here as a named const.
+pub const T2_REVIEW_CADENCE_DAYS: i64 = 90;
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the seed capacity `{domain}`
+/// vocabulary. **Open per spec** ("open per-domain vocabulary") — unknown
+/// domains are accepted; these are the named defaults (operator approved).
+pub mod domain {
+    /// Medical / healthcare decisions.
+    pub const MEDICAL: &str = "medical";
+    /// Financial / asset-management decisions.
+    pub const FINANCIAL: &str = "financial";
+    /// Residence / placement decisions.
+    pub const RESIDENCE: &str = "residence";
+    /// Contact / visitation (PROTECTED — see [`super::PROTECTED_NON_TRANSFERABLE`]).
+    pub const CONTACT: &str = "contact";
+    /// Relational / sexual autonomy (PROTECTED).
+    pub const RELATIONAL: &str = "relational";
+    /// Voting (PROTECTED).
+    pub const VOTING: &str = "voting";
+    /// Digital-identity / key-adjacent decisions.
+    pub const DIGITAL_IDENTITY: &str = "digital_identity";
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12 "protected non-transferable domains —
+/// the apophatic floor") — domains that are **never** delegable to a steward,
+/// even under attested incapacity (they map to the `prohibited:*` apophatic
+/// floor and are carved out of any granted scope). A binding whose scope
+/// intersects this set is rejected at admission.
+///
+/// Operator-approved default set (CIRISPersist#309): `contact` (anti-isolation),
+/// `relational` (relational/sexual autonomy), `voting`, `marriage`
+/// (marriage & association), `reproduction` (sterilization / forced medical
+/// alteration — the Buck v. Bell / Ashley legacy).
+pub const PROTECTED_NON_TRANSFERABLE: [&str; 5] = [
+    domain::CONTACT,
+    domain::RELATIONAL,
+    domain::VOTING,
+    "marriage",
+    "reproduction",
+];
+
+/// True iff `d` is a protected non-transferable domain (never delegable).
+pub fn is_protected_domain(d: &str) -> bool {
+    PROTECTED_NON_TRANSFERABLE.contains(&d)
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the `delegates_to` envelope fields
+/// an adult-incapacity binding carries (beyond the shared `scope` /
+/// `valid_until`). All are read at admission by
+/// [`super::admission::check_adult_incapacity_binding`].
+pub mod binding_field {
+    /// `binding_legitimacy_source` — MANDATORY. One of
+    /// [`legitimacy_source`]. NEVER the steward's own signature alone.
+    pub const LEGITIMACY_SOURCE: &str = "binding_legitimacy_source";
+    /// `binding_tier` — OPTIONAL. Present as [`tier::T1_EMERGENCY_NECESSITY`]
+    /// for the acute no-proxy path that admits a `reversible_pending`
+    /// companion in lieu of `reversible_excluded`.
+    pub const TIER: &str = "binding_tier";
+    /// `petitioner_key_id` — OPTIONAL. The party petitioning for the binding
+    /// (may differ from the steward `S`). The capacity assessor MUST NOT be
+    /// the petitioner (assessor-independence, anti-capture).
+    pub const PETITIONER_KEY_ID: &str = "petitioner_key_id";
+    /// `valid_until` — MANDATORY. ISO-8601 expiry; fail-to-liberty lapse.
+    pub const VALID_UNTIL: &str = "valid_until";
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the mandatory
+/// `binding_legitimacy_source` vocabulary. Closed set — the binding's
+/// legitimacy MUST root in one of these, NEVER the steward's self-signature
+/// alone (which would be naked self-appointment).
+pub mod legitimacy_source {
+    /// `prior_will_proxy` — the ward's own springing self-delegation, signed
+    /// while attested-competent (consent-across-time; the preferred path).
+    pub const PRIOR_WILL_PROXY: &str = "prior_will_proxy";
+    /// `wa_due_process_quorum` — a CC 4.3 WA quorum (the no-prior-will path).
+    pub const WA_DUE_PROCESS_QUORUM: &str = "wa_due_process_quorum";
+    /// `emergency_necessity_expedited` — T1-ONLY acute no-proxy case; a lone
+    /// provider attestation grants only life-preserving necessity (NOT asset
+    /// powers) until an accountable WA authorization attaches.
+    pub const EMERGENCY_NECESSITY_EXPEDITED: &str = "emergency_necessity_expedited";
+
+    /// True iff `s` is one of the three closed-set legitimacy sources.
+    pub fn is_valid(s: &str) -> bool {
+        matches!(
+            s,
+            PRIOR_WILL_PROXY | WA_DUE_PROCESS_QUORUM | EMERGENCY_NECESSITY_EXPEDITED
+        )
+    }
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the binding-tier discriminant.
+pub mod tier {
+    /// The T1 acute emergency-necessity tier — the ONLY tier that admits a
+    /// `reversible_pending` companion in lieu of `reversible_excluded`.
+    pub const T1_EMERGENCY_NECESSITY: &str = "T1_emergency_necessity";
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the resolved capacity state of a
+/// key for a single decision-`domain`. Three-valued; the presumption of
+/// capacity means [`CapacityState::Unknown`] (absence) is treated by a
+/// consumer as full capacity / sovereign.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapacityState {
+    /// A live witness `capacity_assurance:*:{d}:capacitated` — the adult
+    /// holds the domain.
+    Capacitated,
+    /// A live witness `capacity_assurance:*:{d}:incapacitated` — an attested
+    /// loss of capacity for the domain.
+    Incapacitated,
+    /// No usable, live capacity proof for the domain — the **presumption of
+    /// capacity** (CC 3.4.12): a consumer treats this as full capacity.
+    Unknown,
+}
+
+impl CapacityState {
+    /// The stable FFI/telemetry token
+    /// (`"capacitated"` / `"incapacitated"` / `"unknown"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CapacityState::Capacitated => capacity_band::CAPACITATED,
+            CapacityState::Incapacitated => capacity_band::INCAPACITATED,
+            CapacityState::Unknown => "unknown",
+        }
+    }
+}
+
+/// A parsed `capacity_assurance:{level}:{domain}:{band}:v1` token.
+pub struct CapacityToken<'a> {
+    /// The assurance rung (`provider` / `panel` / `government`).
+    pub level: &'a str,
+    /// The decision-domain (open vocabulary).
+    pub domain: &'a str,
+    /// The per-domain band (`capacitated` / `incapacitated`).
+    pub band: &'a str,
+}
+
+/// Parse a `capacity_assurance:{level}:{domain}:{band}:v1` token. Tolerates a
+/// trailing `:vN` version segment (CC 4.1.3). Returns `None` for the
+/// `reversible_*` companion tokens (they carry no `{band}`) and for any
+/// malformed shape. The `{band}` MUST be one of the closed-set values.
+pub fn parse_capacity_token(attestation_type: &str) -> Option<CapacityToken<'_>> {
+    let rest = attestation_type.strip_prefix(CAPACITY_ASSURANCE_PREFIX)?;
+    let mut segs = rest.split(':');
+    let level = segs.next()?;
+    // The reversible_* companions live under the same prefix but are not
+    // band-carrying capacity verdicts.
+    if level == "reversible_excluded" || level == "reversible_pending" {
+        return None;
+    }
+    if !matches!(level, level::PROVIDER | level::PANEL | level::GOVERNMENT) {
+        return None;
+    }
+    let domain = segs.next()?;
+    if domain.is_empty() {
+        return None;
+    }
+    let band = segs.next()?;
+    if !matches!(
+        band,
+        capacity_band::CAPACITATED | capacity_band::INCAPACITATED
+    ) {
+        return None;
+    }
+    // Any further segment must be a version tag (`vN`); anything else is
+    // malformed. (We do not validate the digits — parsers tolerate `:vN`.)
+    Some(CapacityToken {
+        level,
+        domain,
+        band,
+    })
+}
+
+/// Is `attestation_type` a live-relevant `capacity_assurance:*` verdict for
+/// domain `d`? (Ignoring liveness — that is the caller's `expires_at` check.)
+fn token_is_for_domain(attestation_type: &str, d: &str) -> Option<&'static str> {
+    let t = parse_capacity_token(attestation_type)?;
+    if t.domain == d {
+        // Return a `'static` band discriminant.
+        match t.band {
+            capacity_band::CAPACITATED => Some(capacity_band::CAPACITATED),
+            capacity_band::INCAPACITATED => Some(capacity_band::INCAPACITATED),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — resolve the [`CapacityState`] of
+/// key `k` for decision-`domain` `d`, from `k`'s INCOMING capacity
+/// attestations (`attested_key_id == k`). The **presumption of capacity**:
+/// absence resolves to [`CapacityState::Unknown`] (consumer-treated as
+/// capacitated). The band of the **most-recent live** witness
+/// `capacity_assurance:*:{d}:*` row wins (`list_attestations_for` is
+/// `asserted_at DESC`), with `expires_at`/`valid_until` freshness — a lapsed
+/// attestation confers nothing (fail-to-liberty).
+pub async fn capacity_state(
+    directory: &dyn FederationDirectory,
+    k: &str,
+    d: &str,
+) -> Result<CapacityState, Error> {
+    let now = chrono::Utc::now();
+    for r in directory.list_attestations_for(k).await? {
+        if let Some(exp) = r.expires_at {
+            if exp <= now {
+                continue; // lapsed — confers nothing.
+            }
+        }
+        if let Some(band) = token_is_for_domain(&r.attestation_type, d) {
+            return Ok(match band {
+                capacity_band::INCAPACITATED => CapacityState::Incapacitated,
+                _ => CapacityState::Capacitated,
+            });
+        }
+    }
+    Ok(CapacityState::Unknown)
+}
+
+/// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the set of domains for which `k`
+/// has a LIVE witness `:incapacitated` verdict, plus the domains that carry a
+/// live `reversible_excluded` / `reversible_pending` companion. Single pass
+/// over `k`'s incoming attestations (used by the adult-incapacity admission
+/// predicate). Liveness = `expires_at` freshness.
+pub struct IncapacityFacts {
+    /// Domains with a live `:incapacitated` verdict.
+    pub incapacitated_domains: HashSet<String>,
+    /// Domains with a live `reversible_excluded` companion.
+    pub reversible_excluded_domains: HashSet<String>,
+    /// Domains with a live `reversible_pending` companion.
+    pub reversible_pending_domains: HashSet<String>,
+    /// For each incapacitated domain, the set of attester key_ids that signed
+    /// a live `:incapacitated` verdict for it (for the assessor-independence
+    /// check: attester ∉ {steward, petitioner}).
+    pub incapacity_attesters: HashSet<String>,
+}
+
+/// Gather [`IncapacityFacts`] for `k` in a single pass.
+pub async fn incapacity_facts(
+    directory: &dyn FederationDirectory,
+    k: &str,
+) -> Result<IncapacityFacts, Error> {
+    let now = chrono::Utc::now();
+    let mut facts = IncapacityFacts {
+        incapacitated_domains: HashSet::new(),
+        reversible_excluded_domains: HashSet::new(),
+        reversible_pending_domains: HashSet::new(),
+        incapacity_attesters: HashSet::new(),
+    };
+    for r in directory.list_attestations_for(k).await? {
+        if let Some(exp) = r.expires_at {
+            if exp <= now {
+                continue;
+            }
+        }
+        let at = r.attestation_type.as_str();
+        if let Some(t) = parse_capacity_token(at) {
+            if t.band == capacity_band::INCAPACITATED {
+                facts.incapacitated_domains.insert(t.domain.to_owned());
+                facts
+                    .incapacity_attesters
+                    .insert(r.attesting_key_id.clone());
+            }
+        } else if let Some(d) = at.strip_prefix(reversible::EXCLUDED_PREFIX) {
+            if !d.is_empty() {
+                facts.reversible_excluded_domains.insert(d.to_owned());
+            }
+        } else if let Some(d) = at.strip_prefix(reversible::PENDING_PREFIX) {
+            if !d.is_empty() {
+                facts.reversible_pending_domains.insert(d.to_owned());
+            }
+        }
+    }
+    Ok(facts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_capacity_token_happy_and_versioned() {
+        let t = parse_capacity_token("capacity_assurance:panel:financial:incapacitated:v1")
+            .expect("valid token");
+        assert_eq!(t.level, level::PANEL);
+        assert_eq!(t.domain, domain::FINANCIAL);
+        assert_eq!(t.band, capacity_band::INCAPACITATED);
+
+        // Unknown domain accepted (OPEN vocabulary).
+        let t = parse_capacity_token("capacity_assurance:provider:aviation:capacitated:v1")
+            .expect("open-vocab domain");
+        assert_eq!(t.domain, "aviation");
+        assert_eq!(t.band, capacity_band::CAPACITATED);
+    }
+
+    #[test]
+    fn parse_capacity_token_rejects_bad_shapes() {
+        // reversible_* companions are not band-carrying verdicts.
+        assert!(parse_capacity_token("capacity_assurance:reversible_excluded:financial").is_none());
+        assert!(parse_capacity_token("capacity_assurance:reversible_pending:medical").is_none());
+        // bad level
+        assert!(parse_capacity_token("capacity_assurance:quack:financial:incapacitated").is_none());
+        // bad band
+        assert!(parse_capacity_token("capacity_assurance:panel:financial:tired:v1").is_none());
+        // missing prefix
+        assert!(parse_capacity_token("capacity:core_identity:v1").is_none());
+        // missing domain / band
+        assert!(parse_capacity_token("capacity_assurance:panel").is_none());
+    }
+
+    #[test]
+    fn protected_domains_are_the_apophatic_floor() {
+        for d in [
+            "contact",
+            "relational",
+            "voting",
+            "marriage",
+            "reproduction",
+        ] {
+            assert!(is_protected_domain(d), "{d} must be protected");
+        }
+        assert!(!is_protected_domain("financial"));
+        assert!(!is_protected_domain("medical"));
+    }
+
+    #[test]
+    fn defaults_are_the_documented_consts() {
+        assert_eq!(T2_REVIEW_CADENCE_DAYS, 90);
+        assert_eq!(CAPACITY_ASSURANCE_PREFIX, "capacity_assurance:");
+        assert_eq!(PROTECTED_NON_TRANSFERABLE.len(), 5);
+    }
+
+    #[test]
+    fn legitimacy_source_closed_set() {
+        assert!(legitimacy_source::is_valid("prior_will_proxy"));
+        assert!(legitimacy_source::is_valid("wa_due_process_quorum"));
+        assert!(legitimacy_source::is_valid("emergency_necessity_expedited"));
+        assert!(!legitimacy_source::is_valid("steward_says_so"));
+        assert!(!legitimacy_source::is_valid(""));
+    }
+
+    #[test]
+    fn capacity_state_tokens_stable() {
+        assert_eq!(CapacityState::Capacitated.as_str(), "capacitated");
+        assert_eq!(CapacityState::Incapacitated.as_str(), "incapacitated");
+        assert_eq!(CapacityState::Unknown.as_str(), "unknown");
+    }
+}

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -40,6 +40,7 @@ pub mod at_rest_cascade;
 pub mod backfill;
 pub mod blackhole;
 pub mod blobs;
+pub mod capacity;
 pub mod cohort;
 pub mod community_dek;
 #[cfg(feature = "cirisaudit")]
@@ -3654,6 +3655,26 @@ pub enum Error {
     /// - `granter_not_adult_user` — the granter is not a `user`, or not a
     ///   proven adult (a minor cannot be a guardian; a non-user cannot be a
     ///   guardian).
+    ///
+    /// v11.9.0 (CIRISPersist#309, CC 3.4.12) — an ADULT target is admissible
+    /// ONLY through the narrow adult-incapacity aperture
+    /// ([`admission::check_adult_incapacity_binding`]). Its rejection reasons:
+    ///
+    /// - `scope_missing` — the binding declares no scope.
+    /// - `scope_exceeds_attested_domains` — a scoped domain has no live
+    ///   `capacity_assurance:*:{d}:incapacitated`.
+    /// - `capacity_reversible_not_excluded` — a scoped domain lacks the
+    ///   mandatory `reversible_excluded` companion (and the T1
+    ///   `reversible_pending` acute path does not apply).
+    /// - `scope_touches_protected_domain` — scope intersects the apophatic
+    ///   [`crate::federation::capacity::PROTECTED_NON_TRANSFERABLE`] floor.
+    /// - `attester_conflicted` — a capacity assessor is the steward or
+    ///   petitioner (assessor-independence).
+    /// - `missing_legitimacy_source` — absent/invalid
+    ///   `binding_legitimacy_source` (never the steward's signature alone).
+    /// - `missing_valid_until` / `valid_until_unparseable` /
+    ///   `valid_until_exceeds_review_cadence` — the fail-to-liberty mandatory
+    ///   bounded expiry is missing, malformed, or outruns the T2 cadence.
     ///
     /// `node`/`agent`-target bindings are governed by
     /// [`admission::check_node_agency_admission`] and are NOT affected by this

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -2843,14 +2843,22 @@ pub trait FederationDirectory: Send + Sync {
             }
 
             // (b) §10.1.3 local-tier revocation unpromoted past the window.
-            // CAVEAT: persist's admission gate (AV-61) rejects subject-side
-            // revocations at the local tier — a subject revoke is always
-            // federation-tier — so under the *current* write model this
-            // condition has nothing to fire on. The check is kept
-            // forward-compatible: it fires correctly IF the #171
-            // agent-facing local-tier write/promote surface ever produces a
-            // local-tier subject revocation that then fails to promote. The
-            // §10.1.3-vs-AV-61 tension is flagged for CEG/§171 to resolve.
+            // AV-61 RESOLVED (CIRISPersist#238; §10.1.3 "transit-not-rest"
+            // ratification): a subject-side revocation is federation-tier by
+            // *classification*. It MAY *transit* the local-tier write path
+            // while in flight (the producing occurrence's substrate accepts the
+            // unsigned envelope before promotion) but MUST NOT *rest* there —
+            // its only conformant terminal states are *promoted* (tier becomes
+            // `federation`, so it drops out of this fire condition) or
+            // *overdue-flagged* (this emission). This overdue emission IS the
+            // SLA enforcement: the consent-promotion gate and the CC 5.3.2.4.3
+            // `local ⟹ caller is the producing occurrence` read-gate read this
+            // SAME overdue state, which is exactly what keeps the two gates
+            // from de-syncing (the AV-61 threat). persist itself never *rests*
+            // a subject revocation as a durable local row — its own admission
+            // gate (`check_local_tier_eligibility` rule 2) refuses to originate
+            // one; a transit-staged row here arrives via the #171 promote
+            // surface and this watcher drives it out (promote or flag).
             let local = rev.tier != crate::federation::types::attestation_tier::FEDERATION;
             if local && rev.promoted_at.is_none() && now - revoked_at > promotion {
                 self.record_hard_case(hard_case::HardCaseEvent {
@@ -3697,6 +3705,40 @@ pub enum Error {
         reason: &'static str,
     },
 
+    /// v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11 — the no-moderator-no-
+    /// federate existence invariant). A federation-tier apply step keyed on a
+    /// `community` was REFUSED because that community has **no live holder of
+    /// its `moderate` duty** — no
+    /// [`is_named_moderator`](admission::is_named_moderator) resolvable member.
+    /// A `community` federates only while ≥1 steward-bound authority root
+    /// exists (a founder / `consensus_protocol` signer who
+    /// [`is_steward_bound`](admission::is_steward_bound)); such a root is a
+    /// zero-hop named moderator, and every delegated moderator chains back to
+    /// one. Fail-secure per §11.11 rule 3 — "better no group than an
+    /// unmoderated one": a moderator-less community MUST NOT federate at
+    /// moderated capability. `cohort_subkind: infrastructure` communities are
+    /// EXEMPT (trust + serve needs no moderator, mirroring the CC 3.2 steward-
+    /// binding carve-out). The row/record is NOT stored (verify-before-
+    /// mutation, AV-9). Stable `kind()` token
+    /// `federation_community_no_moderator`. See
+    /// [`admission::check_no_moderator_federate_admission`].
+    ///
+    /// Merit auto-promotion (§11.11 rule 2) + the CC 4.5.13 48-hour recovery
+    /// are appointment *ceremonies* that emit a `delegates_to(moderate)` signed
+    /// by the community authority — persist cannot forge that signature, so
+    /// those live one layer up; this substrate gate is the fail-secure floor
+    /// they recover the community *out of*.
+    #[error(
+        "community {community_key_id:?} has no live `moderate`-duty holder — a community \
+         federates only while ≥1 steward-bound authority root (a named moderator) exists \
+         (CC 4.5.4 / §11.11 — no unmoderated federated space; better no group than an \
+         unmoderated one). Fail-secure: it MUST NOT federate at moderated capability"
+    )]
+    CommunityHasNoModerator {
+        /// The community whose federation was refused for lack of a moderator.
+        community_key_id: String,
+    },
+
     /// v8.2.0 (CEG 1.0-RC11 §19.1 / CIRISPersist#228 item 1 / #229 item 1)
     /// — a WholenessWitness was REJECTED at the verify-before-persist
     /// gate: the §19.0 PQC-mandatory hard cut (classical-only / missing
@@ -3782,6 +3824,7 @@ impl Error {
             Error::UserTargetStewardBindingForbidden { .. } => {
                 "federation_user_target_steward_binding_forbidden"
             }
+            Error::CommunityHasNoModerator { .. } => "federation_community_no_moderator",
             Error::FederationTierUnverified { .. } => "federation_federation_tier_unverified",
             Error::WitnessAdmit(e) => e.kind(),
             Error::Backend(_) => "federation_backend",

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -24466,6 +24466,10 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // caller-side malformed-content / authorization failure;
         // ValueError (4xx).
         crate::federation::Error::WitnessAdmit(_) => PyValueError::new_err(kind),
+        // #238 (CC 4.5.4 / §11.11) — a community with no live `moderate`-holder
+        // cannot be admitted-to / continue federating. A caller/state admission
+        // refusal (fail-secure), like the other admission gates → ValueError (4xx).
+        crate::federation::Error::CommunityHasNoModerator { .. } => PyValueError::new_err(kind),
         // Server-fault → RuntimeError (5xx).
         crate::federation::Error::Backend(_) => PyRuntimeError::new_err(kind),
         // v11.8.1 (CIRISPersist#329) — the directory-ops proxy was asked

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7484,6 +7484,102 @@ impl PyEngine {
         })
     }
 
+    /// v11.9.0 (CIRISPersist#309, CC 3.4.13 Q1) — the **finer four-band** age
+    /// resolution of `key_id`, the policy vocabulary ABOVE the binary
+    /// [`age_band_json`]. Returns one of `"under_13"` / `"13_15"` / `"16_17"`
+    /// / `"adult"` / `"unknown"`. The three sub-18 bands are all `minor` on
+    /// the binary wire predicate. Same witness-outranks-self one-way ratchet.
+    /// Wraps [`age_band_fine`](crate::federation::age::age_band_fine). The
+    /// `"unknown"` value is exposed verbatim: a CONTENT-axis consumer floors
+    /// it to the most-protective `"under_13"` (CC 3.4.13 Q1 fail-secure), the
+    /// steward-binding axis treats it as self-sovereign.
+    fn age_band_fine_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            py.detach(move || {
+                let band = match &self.backend {
+                    #[cfg(feature = "postgres")]
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::age::age_band_fine(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::age::age_band_fine(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(band.as_str())
+                    .map_err(|e| PyValueError::new_err(format!("age_band_fine serialize: {e}")))
+            })
+        })
+    }
+
+    /// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the resolved **capacity state**
+    /// of `key_id` for decision-`domain`, from its incoming witness
+    /// `capacity_assurance:*:{domain}:*` attestations (most-recent live wins,
+    /// `valid_until`/`expires_at` freshness). Returns one of `"capacitated"` /
+    /// `"incapacitated"` / `"unknown"`. Per the **presumption of capacity**
+    /// (CC 3.4.12), `"unknown"` (absence of any live proof) MUST be treated by
+    /// a consumer as full capacity / sovereign — never as incapacity. Wraps
+    /// [`capacity_state`](crate::federation::capacity::capacity_state).
+    fn capacity_state_json(&self, py: Python<'_>, key_id: &str, domain: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            let domain = domain.to_owned();
+            py.detach(move || {
+                let state = match &self.backend {
+                    #[cfg(feature = "postgres")]
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::capacity::capacity_state(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                                &domain,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::capacity::capacity_state(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                                &domain,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(state.as_str())
+                    .map_err(|e| PyValueError::new_err(format!("capacity_state serialize: {e}")))
+            })
+        })
+    }
+
     /// #249 Cut A — the **duty-holders** of a bare community-scoped action
     /// (a `moderation:*` / `reconsideration:*` over `community_id` with no
     /// content subject) for `duty` (`moderate` / `takedown` / `review`): the

--- a/src/fountain/storage_contention.rs
+++ b/src/fountain/storage_contention.rs
@@ -12,10 +12,39 @@
 //!
 //! These shapes are **verified-at-ingest, not stored** (CC 6.1.3 store-path):
 //! there is no persist admit/put table for them — a consumer builds one to
-//! advertise / verifies one it received. The pin-vs-revocation composition (the
-//! §Q B6/N5 gate that couples a pinned budget with hard-delete eviction) is
-//! tracked separately (CIRISPersist#356 follow-up) and does not gate this wheel
-//! surface.
+//! advertise / verifies one it received.
+//!
+//! # §Q B6/N5 — pinning never defeats revocation (CIRISPersist#359)
+//!
+//! CC 6.1.5.2 §Q B6: *"Pinning never defeats consent: an active `withdraws` /
+//! `consent:state:revoked` still forces immediate descent below the noise floor
+//! **regardless of pin state**. A pin holds content above the floor against
+//! **capacity** pressure only — never against revocation."* (N5, under CC
+//! 6.1.5: revocation is a content-level dominating signal that never competes
+//! inside the priority/rarity ordering.)
+//!
+//! persist satisfies this invariant **structurally**, and the THIN form the
+//! spec confirms is sufficient:
+//!
+//! - A `StorageBudgetV1.pinned_class` / `pin_reserve_bytes` is a **verified-at-
+//!   ingest advertisement**, not persisted pin STATE. There is no pin table, no
+//!   `pinned_class` column, and no migration — nothing a deletion path could
+//!   query.
+//! - The revocation path
+//!   [`crate::store::Backend::evict_fountain_content_hard_delete`] takes only
+//!   `(content_id, corpus_kind)`. It has **no §Q pin parameter and reads no pin
+//!   state**; it unconditionally drops every symbol (it does not even consult
+//!   `retention_priority`). A pin covering that `subject_kind` therefore cannot
+//!   reach the delete, so it cannot shield the content.
+//!
+//! Because the pin advertisement and the delete never share a code path, B6
+//! holds by construction. The proof is locked by
+//! `tests/fountain_content.rs` section (j): a *verified* `StorageBudgetV1` whose
+//! `pinned_class` covers `trace` with `pin_reserve_bytes > 0` does not prevent a
+//! subsequent `evict_fountain_content_hard_delete` from removing `trace`
+//! content. Making the gate "real" (a stored pin the delete overrides) would
+//! require adding the very pin STATE whose absence is what makes revocation
+//! unconditional today — so the thin form is the conformant one.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -9535,6 +9535,530 @@ mod tests {
             .expect("a node target is governed by the node-agency gate, not the user-target gate");
     }
 
+    // ── CIRISPersist#309 (CC 3.4.12) — adult-incapacity steward-binding ──
+
+    /// Build an adult-incapacity `delegates_to(steward -> ward)` carrying the
+    /// CC 3.4.12 envelope fields. `scope` = decision-domains; the optionals
+    /// mirror `capacity::binding_field::*`.
+    #[allow(clippy::too_many_arguments)]
+    fn fix_incapacity_binding(
+        id: &str,
+        steward: &str,
+        ward: &str,
+        scope: &[&str],
+        legit: Option<&str>,
+        valid_until: Option<&str>,
+        binding_tier: Option<&str>,
+        petitioner: Option<&str>,
+    ) -> Attestation {
+        let mut att = fix_attestation(id, steward, ward, steward);
+        att.attestation_type = crate::federation::types::attestation_type::DELEGATES_TO.into();
+        let mut env = serde_json::json!({
+            "id": id,
+            "scope": scope.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>(),
+        });
+        let obj = env.as_object_mut().unwrap();
+        if let Some(l) = legit {
+            obj.insert("binding_legitimacy_source".into(), serde_json::json!(l));
+        }
+        if let Some(v) = valid_until {
+            obj.insert("valid_until".into(), serde_json::json!(v));
+        }
+        if let Some(t) = binding_tier {
+            obj.insert("binding_tier".into(), serde_json::json!(t));
+        }
+        if let Some(p) = petitioner {
+            obj.insert("petitioner_key_id".into(), serde_json::json!(p));
+        }
+        att.attestation_envelope = env;
+        resign_fix(&mut att);
+        att
+    }
+
+    fn assert_forbidden(e: &crate::federation::Error, want: &str) {
+        assert_eq!(e.kind(), "federation_user_target_steward_binding_forbidden");
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(*reason, want, "wrong rejection reason");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden({want}), got {other:?}"),
+        }
+    }
+
+    /// Register `assessor`(witness), `S`(adult user), `A`(adult user); attest
+    /// S and A adults. Returns nothing; keys are `<p>-assessor/-S/-A`.
+    async fn bootstrap_incapacity(backend: &MemoryBackend, p: &str) {
+        put_typed_key(backend, &format!("{p}-assessor"), "witness").await;
+        put_typed_key(backend, &format!("{p}-S"), "user").await;
+        put_typed_key(backend, &format!("{p}-A"), "user").await;
+        for who in ["S", "A"] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: fix_age_attestation(
+                        &format!("{p}w-{who}"),
+                        &format!("{p}-assessor"),
+                        &format!("{p}-{who}"),
+                        "age_assurance:provider:adult:v1",
+                    ),
+                })
+                .await
+                .unwrap();
+        }
+    }
+
+    /// Put a capacity attestation ABOUT `ward` from `attester`.
+    async fn put_capacity(
+        backend: &MemoryBackend,
+        id: &str,
+        attester: &str,
+        ward: &str,
+        token: &str,
+    ) {
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(id, attester, ward, token),
+            })
+            .await
+            .unwrap_or_else(|e| panic!("capacity attestation {token} rejected: {e:?}"));
+    }
+
+    /// CC 3.4.12 capacity-assurance emitter discipline: witness-RESERVED (a
+    /// non-witness emitter is rejected) AND the subject MUST NOT self-emit
+    /// (attester == attested rejected even for a witness).
+    #[tokio::test]
+    async fn capacity_assurance_witness_reserved_and_no_self_emit() {
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "cap-assessor", "witness").await;
+        put_typed_key(&backend, "cap-user", "user").await;
+        put_typed_key(&backend, "cap-subj", "user").await;
+
+        // A witness assessor CAN attest another's capacity.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "cap-ok",
+                    "cap-assessor",
+                    "cap-subj",
+                    "capacity_assurance:panel:financial:incapacitated:v1",
+                ),
+            })
+            .await
+            .expect("witness assessor may attest another's capacity");
+
+        // A non-witness (plain user) may NOT emit capacity_assurance.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "cap-nonwit",
+                    "cap-user",
+                    "cap-subj",
+                    "capacity_assurance:provider:medical:incapacitated:v1",
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_reserved_prefix_emitter_mismatch");
+
+        // The SUBJECT must not self-mint their own (in)capacity, even as a
+        // witness (attester == attested).
+        put_typed_key(&backend, "cap-selfwit", "witness").await;
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "cap-self",
+                    "cap-selfwit",
+                    "cap-selfwit",
+                    "capacity_assurance:provider:financial:incapacitated:v1",
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_capacity_self_emission_rejected");
+    }
+
+    /// CC 3.4.12 adult-incapacity admission decision table (through the REAL
+    /// `put_attestation` path): presumption-of-capacity, missing legitimacy /
+    /// valid_until, cadence ceiling, scope containment, reversible exclusion,
+    /// then a valid ADMIT that makes the steward a live anchor.
+    #[tokio::test]
+    async fn adult_incapacity_binding_gate_decision_table() {
+        use crate::federation::admission::steward_bindings_of;
+        use chrono::{Duration, Utc};
+        let backend = MemoryBackend::new();
+        bootstrap_incapacity(&backend, "ai").await;
+        let future = (Utc::now() + Duration::days(30)).to_rfc3339();
+
+        // (0) presumption of capacity — an adult with NO incapacity attested is
+        // self-sovereign (the CC 3.2 un-stewardable default reasserts).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-0",
+                    "ai-S",
+                    "ai-A",
+                    &["financial"],
+                    Some("prior_will_proxy"),
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "target_is_self_sovereign");
+
+        // Attest A incapacitated for `financial` + rule out reversible mimics.
+        put_capacity(
+            &backend,
+            "aic-fin",
+            "ai-assessor",
+            "ai-A",
+            "capacity_assurance:panel:financial:incapacitated:v1",
+        )
+        .await;
+        put_capacity(
+            &backend,
+            "aic-fin-rex",
+            "ai-assessor",
+            "ai-A",
+            "capacity_assurance:reversible_excluded:financial",
+        )
+        .await;
+
+        // (1) missing legitimacy source → naked self-appointment refused.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-1",
+                    "ai-S",
+                    "ai-A",
+                    &["financial"],
+                    None,
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "missing_legitimacy_source");
+
+        // (2) missing valid_until → no fail-to-liberty expiry.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-2",
+                    "ai-S",
+                    "ai-A",
+                    &["financial"],
+                    Some("prior_will_proxy"),
+                    None,
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "missing_valid_until");
+
+        // (3) valid_until beyond the T2 review cadence (90d) → rejected.
+        let far = (Utc::now() + Duration::days(200)).to_rfc3339();
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-3",
+                    "ai-S",
+                    "ai-A",
+                    &["financial"],
+                    Some("prior_will_proxy"),
+                    Some(&far),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "valid_until_exceeds_review_cadence");
+
+        // (4) scope exceeds the attested-incapacitated domains.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-4",
+                    "ai-S",
+                    "ai-A",
+                    &["medical"],
+                    Some("prior_will_proxy"),
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "scope_exceeds_attested_domains");
+
+        // (5) attested incapacitated but reversible mimics NOT excluded.
+        put_capacity(
+            &backend,
+            "aic-res",
+            "ai-assessor",
+            "ai-A",
+            "capacity_assurance:provider:residence:incapacitated:v1",
+        )
+        .await;
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-5",
+                    "ai-S",
+                    "ai-A",
+                    &["residence"],
+                    Some("prior_will_proxy"),
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "capacity_reversible_not_excluded");
+
+        // (6) ADMIT — scope ⊆ attested loss, reversible excluded, prior-will
+        // legitimacy, bounded valid_until, independent assessor.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "ai-6",
+                    "ai-S",
+                    "ai-A",
+                    &["financial"],
+                    Some("prior_will_proxy"),
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .expect("valid adult-incapacity binding is admitted");
+
+        // A live binding makes S an anchor of A; A (an adult) also self-anchors
+        // (it is never demoted to a perpetual minor).
+        let anchors = steward_bindings_of(&backend, "ai-A").await.unwrap();
+        assert!(anchors.contains(&"ai-S".to_string()), "S is a live anchor");
+        assert!(
+            anchors.contains(&"ai-A".to_string()),
+            "the adult retains its own self-anchor (never a perpetual minor)"
+        );
+    }
+
+    /// CC 3.4.12 T1 acute path: `reversible_pending` (in lieu of `_excluded`)
+    /// is admissible ONLY for `binding_tier == T1_emergency_necessity` with the
+    /// `emergency_necessity_expedited` legitimacy source.
+    #[tokio::test]
+    async fn adult_incapacity_t1_reversible_pending_path() {
+        use crate::federation::capacity::{legitimacy_source, tier};
+        use chrono::{Duration, Utc};
+        let backend = MemoryBackend::new();
+        bootstrap_incapacity(&backend, "t1").await;
+        let soon = (Utc::now() + Duration::days(2)).to_rfc3339();
+        put_capacity(
+            &backend,
+            "t1c",
+            "t1-assessor",
+            "t1-A",
+            "capacity_assurance:provider:medical:incapacitated:v1",
+        )
+        .await;
+        put_capacity(
+            &backend,
+            "t1c-pend",
+            "t1-assessor",
+            "t1-A",
+            "capacity_assurance:reversible_pending:medical",
+        )
+        .await;
+
+        // Standard path (no T1 tier) with only `pending` → rejected.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "t1-std",
+                    "t1-S",
+                    "t1-A",
+                    &["medical"],
+                    Some(legitimacy_source::PRIOR_WILL_PROXY),
+                    Some(&soon),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "capacity_reversible_not_excluded");
+
+        // T1 acute path → admitted.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "t1-ok",
+                    "t1-S",
+                    "t1-A",
+                    &["medical"],
+                    Some(legitimacy_source::EMERGENCY_NECESSITY_EXPEDITED),
+                    Some(&soon),
+                    Some(tier::T1_EMERGENCY_NECESSITY),
+                    None,
+                ),
+            })
+            .await
+            .expect("T1 emergency-necessity + reversible_pending is admitted");
+    }
+
+    /// CC 3.4.12 apophatic floor: a protected non-transferable domain (voting)
+    /// is rejected even when incapacity + reversible exclusion are attested.
+    #[tokio::test]
+    async fn adult_incapacity_protected_domain_rejected() {
+        use chrono::{Duration, Utc};
+        let backend = MemoryBackend::new();
+        bootstrap_incapacity(&backend, "pd").await;
+        let future = (Utc::now() + Duration::days(10)).to_rfc3339();
+        put_capacity(
+            &backend,
+            "pdc",
+            "pd-assessor",
+            "pd-A",
+            "capacity_assurance:panel:voting:incapacitated:v1",
+        )
+        .await;
+        put_capacity(
+            &backend,
+            "pdc-rex",
+            "pd-assessor",
+            "pd-A",
+            "capacity_assurance:reversible_excluded:voting",
+        )
+        .await;
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "pd-b",
+                    "pd-S",
+                    "pd-A",
+                    &["voting"],
+                    Some("wa_due_process_quorum"),
+                    Some(&future),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "scope_touches_protected_domain");
+    }
+
+    /// CC 3.4.12 assessor-independence: the capacity attester may not be the
+    /// petitioner (anti-capture). The steward-is-attester case rides the same
+    /// `incapacity_attesters.contains(steward)` branch.
+    #[tokio::test]
+    async fn adult_incapacity_conflicted_attester_rejected() {
+        use chrono::{Duration, Utc};
+        let backend = MemoryBackend::new();
+        bootstrap_incapacity(&backend, "cf").await;
+        let future = (Utc::now() + Duration::days(10)).to_rfc3339();
+        put_capacity(
+            &backend,
+            "cfc",
+            "cf-assessor",
+            "cf-A",
+            "capacity_assurance:panel:financial:incapacitated:v1",
+        )
+        .await;
+        put_capacity(
+            &backend,
+            "cfc-rex",
+            "cf-assessor",
+            "cf-A",
+            "capacity_assurance:reversible_excluded:financial",
+        )
+        .await;
+        // petitioner == the assessor → conflicted.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "cf-b",
+                    "cf-S",
+                    "cf-A",
+                    &["financial"],
+                    Some("wa_due_process_quorum"),
+                    Some(&future),
+                    None,
+                    Some("cf-assessor"),
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_forbidden(&e, "attester_conflicted");
+    }
+
+    /// CC 3.4.12 fail-to-liberty: a binding whose `valid_until` has lapsed is
+    /// non-live — the steward drops out of the ward's anchors and the adult
+    /// auto-re-sovereigns (self-anchor only), with NO steward assent.
+    #[tokio::test]
+    async fn adult_incapacity_fail_to_liberty_auto_re_sovereign() {
+        use crate::federation::admission::steward_bindings_of;
+        use chrono::{Duration, Utc};
+        let backend = MemoryBackend::new();
+        bootstrap_incapacity(&backend, "fl").await;
+        put_capacity(
+            &backend,
+            "flc",
+            "fl-assessor",
+            "fl-A",
+            "capacity_assurance:panel:financial:incapacitated:v1",
+        )
+        .await;
+        put_capacity(
+            &backend,
+            "flc-rex",
+            "fl-assessor",
+            "fl-A",
+            "capacity_assurance:reversible_excluded:financial",
+        )
+        .await;
+        // Admit a binding whose valid_until is ALREADY in the past (structurally
+        // admissible: present, parseable, within the cadence ceiling).
+        let lapsed = (Utc::now() - Duration::days(1)).to_rfc3339();
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_incapacity_binding(
+                    "fl-b",
+                    "fl-S",
+                    "fl-A",
+                    &["financial"],
+                    Some("prior_will_proxy"),
+                    Some(&lapsed),
+                    None,
+                    None,
+                ),
+            })
+            .await
+            .expect("a lapsed-valid_until binding is structurally admitted");
+
+        // Fail-to-liberty at READ: the lapsed edge confers no standing. S is
+        // NOT an anchor; the adult self-anchors (auto-re-sovereign).
+        let anchors = steward_bindings_of(&backend, "fl-A").await.unwrap();
+        assert!(
+            !anchors.contains(&"fl-S".to_string()),
+            "a lapsed adult-incapacity binding must NOT confer steward standing"
+        );
+        assert_eq!(
+            anchors,
+            vec!["fl-A".to_string()],
+            "the adult auto-re-sovereigns to its own self-anchor with no steward assent"
+        );
+    }
+
     /// Minor-stewardship liveness fail-secure (CC 3.2): a minor user bound by
     /// an adult (live edge) is steward-bound; after the granter withdraws it,
     /// is_steward_bound flips to false (the minor does NOT self-anchor). A

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1320,6 +1320,17 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // key's identity_type. Backend-symmetric with SQLite + Postgres.
         crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
 
+        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
+        // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
+        // keyed on a community (`community_id` in its envelope) is a federation
+        // apply step keyed on C; it is refused if C has lost its last live
+        // `moderate`-holder (so a moderator-less community cannot continue at
+        // moderated capability). No-op for local-tier rows, rows with no
+        // community_id, and communities not locally known. Resolves the
+        // community + steward-binding via the directory (locks state itself),
+        // so it runs before the state lock. Backend-symmetric.
+        crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate (parity with the postgres + sqlite backends). A
@@ -2431,6 +2442,44 @@ impl crate::federation::FederationDirectory for MemoryBackend {
                 .cmp(&a.emitted_at)
                 .then_with(|| b.event_id.cmp(&a.event_id))
         });
+        Ok(rows)
+    }
+
+    // ─── v12.5.0 (CIRISPersist#238 / #146, CEG §8.1.11.3 / §10.1.3) —
+    //     subject-side consent revocations for the consent-SLA watcher. Memory
+    //     parity with the sqlite/postgres backends (the default trait impl
+    //     errors); the promotion-overdue check
+    //     ([`run_consent_sla_watch`]) needs local-tier rows too, so this is
+    //     NOT tier-filtered (unlike list_attestations_for, which is
+    //     federation-only).
+
+    async fn list_consent_revocations(
+        &self,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Vec<crate::federation::Attestation>, crate::federation::Error> {
+        use crate::federation::types::attestation_type;
+        let state = self.state.lock().expect("memory backend lock");
+        let mut rows: Vec<_> = state
+            .federation_attestations
+            .iter()
+            .filter(|a| {
+                // Subject-side revocations only: a `withdraws` admitted under
+                // rule 2/3/4 (rule 1 is the producer's own self-revoke, not a
+                // consent event), OR a `consent:state:revoked` stance.
+                let is_subject_withdraws = a.attestation_type == attestation_type::WITHDRAWS
+                    && matches!(a.withdraws_admission_rule, Some(2..=4));
+                let is_consent_revoked = a
+                    .attestation_envelope
+                    .get("dimension")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|d| d.starts_with("consent:state:revoked"));
+                is_subject_withdraws || is_consent_revoked
+            })
+            .filter(|a| since.is_none_or(|s| a.asserted_at >= s))
+            .cloned()
+            .collect();
+        // Match the SQL backends: ORDER BY asserted_at DESC.
+        rows.sort_by_key(|a| std::cmp::Reverse(a.asserted_at));
         Ok(rows)
     }
 
@@ -8729,6 +8778,254 @@ mod tests {
         )
         .await
         .unwrap());
+    }
+
+    /// #238 (CC 4.5.4 / §11.11) — the no-moderator-no-federate substrate gate,
+    /// decision-table style. A `community` federates ONLY while ≥1 steward-bound
+    /// authority root (a live named `moderate`-holder) exists; infrastructure
+    /// communities are EXEMPT. Enforcement lives at the federation-apply
+    /// chokepoint ([`check_no_moderator_federate_apply`]); the admission
+    /// predicate ([`check_no_moderator_federate_admission`]) is its primitive.
+    #[tokio::test]
+    async fn no_moderator_federate_gate_decision_table() {
+        use crate::federation::admission::{
+            check_no_moderator_federate_admission, check_no_moderator_federate_admission_by_id,
+            check_no_moderator_federate_apply, MEMBER_ROLE_FOUNDER,
+        };
+        use crate::federation::types::{consensus_protocol, identity_type};
+
+        // Build a community `cid` founded (founder_only) by `founder` of
+        // identity_type `founder_it`, optionally infra-labeled. Registers the
+        // community + founder keys and STORES the record (put_community itself
+        // does not gate on moderator existence — the apply path does).
+        async fn seed(
+            backend: &MemoryBackend,
+            cid: &str,
+            founder: &str,
+            founder_it: &str,
+            infra: bool,
+        ) -> crate::federation::types::Community {
+            let mut ck = fix_key(cid, "primitive", cid);
+            if infra {
+                // SecReview F2: the infra carve-out is honored only when the
+                // community's own key is the substrate_persist authority.
+                ck.identity_type = identity_type::SUBSTRATE_PERSIST.into();
+            }
+            backend
+                .put_public_key(SignedKeyRecord { record: ck })
+                .await
+                .unwrap();
+            let mut fk = fix_key(founder, "primitive", founder);
+            fk.identity_type = founder_it.into();
+            backend
+                .put_public_key(SignedKeyRecord { record: fk })
+                .await
+                .unwrap();
+            let policy_blob =
+                infra.then(|| serde_json::json!({ "cohort_subkind": "infrastructure" }));
+            let community = crate::federation::types::Community {
+                community_key_id: cid.into(),
+                community_name: "dt".into(),
+                members: vec![crate::federation::types::CommunityMember {
+                    key_id: founder.into(),
+                    joined_at: "2026-05-01T00:00:00Z".parse().unwrap(),
+                    role: Some(MEMBER_ROLE_FOUNDER.into()),
+                }],
+                founded_at: "2026-05-01T00:00:00Z".parse().unwrap(),
+                consensus_protocol: consensus_protocol::FOUNDER_ONLY.into(),
+                policy_blob,
+                persist_row_hash: String::new(),
+            };
+            backend
+                .put_community(crate::federation::SignedCommunity {
+                    community: community.clone(),
+                })
+                .await
+                .expect("record stored (put_community is not the moderator gate)");
+            community
+        }
+
+        let b = MemoryBackend::new();
+
+        // ── admission predicate (the reusable primitive) ────────────────────
+        // (1) user founder = steward-bound authority root = zero-hop named
+        //     moderator → ADMIT.
+        let c_ok = seed(&b, "dt-ok", "dt-user", identity_type::USER, false).await;
+        check_no_moderator_federate_admission(&b, &c_ok)
+            .await
+            .expect("steward-bound (user) founder ⇒ has a moderator ⇒ may federate");
+
+        // (2) primitive founder = passes the steward-binding gate (not
+        //     node/agent, out of its scope) but is NOT steward-bound ⇒ NO named
+        //     moderator ⇒ REJECT, fail-secure.
+        let c_no = seed(&b, "dt-no", "dt-prim", identity_type::PRIMITIVE, false).await;
+        let err = check_no_moderator_federate_admission(&b, &c_no)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::federation::Error::CommunityHasNoModerator { .. }
+            ),
+            "moderator-less community refused, got {err:?}"
+        );
+        assert_eq!(err.kind(), "federation_community_no_moderator");
+
+        // (3) infrastructure community with a non-steward-bound founder →
+        //     EXEMPT (trust + serve needs no moderator) → ADMIT.
+        let c_infra = seed(&b, "dt-infra", "dt-iprim", identity_type::PRIMITIVE, true).await;
+        check_no_moderator_federate_admission(&b, &c_infra)
+            .await
+            .expect("authorized infrastructure community is exempt from the moderator gate");
+
+        // ── federation-apply chokepoint (points i + ii unified) ─────────────
+        // A federation-tier row keyed on the moderator-less community → REJECT.
+        let mut row = fix_attestation("dt-apply", "dt-prim", "dt-prim", "dt-prim");
+        row.attestation_envelope = serde_json::json!({
+            "id": "dt-apply", "dimension": "identity_binding:v1", "community_id": "dt-no"
+        });
+        let err = check_no_moderator_federate_apply(&b, &row)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::federation::Error::CommunityHasNoModerator { .. }
+            ),
+            "federation-apply step keyed on a moderator-less community is refused"
+        );
+        // A LOCAL-tier row keyed on it → no-op (local writes are not a
+        // federation apply step).
+        let mut local_row = row.clone();
+        local_row.tier = crate::federation::types::attestation_tier::LOCAL.into();
+        check_no_moderator_federate_apply(&b, &local_row)
+            .await
+            .expect("local-tier row is not a federation apply step");
+        // A row keyed on the MODERATORED community → ADMIT.
+        let mut live_row = row.clone();
+        live_row.attestation_envelope = serde_json::json!({
+            "id": "dt-apply2", "dimension": "identity_binding:v1", "community_id": "dt-ok"
+        });
+        check_no_moderator_federate_apply(&b, &live_row)
+            .await
+            .expect("moderatored community may continue to federate");
+        // No community_id + unknown community_id → out of scope (Ok).
+        let mut bare = row.clone();
+        bare.attestation_envelope =
+            serde_json::json!({ "id": "x", "dimension": "identity_binding:v1" });
+        check_no_moderator_federate_apply(&b, &bare)
+            .await
+            .expect("no community_id ⇒ not keyed on a community ⇒ no-op");
+        check_no_moderator_federate_admission_by_id(&b, "no-such")
+            .await
+            .expect("unknown community ⇒ out of scope ⇒ no-op");
+    }
+
+    /// #238 / #146 (CC 5.3.2.2 / §10.1.3, AV-61 transit-not-rest) — the
+    /// consent-revocation promotion-overdue `hard_case` fires at the 24 h
+    /// window boundary for a subject-side revocation that stays local-tier
+    /// (unpromoted), is idempotent on re-scan, and stops once the row promotes.
+    #[tokio::test]
+    async fn consent_revocation_promotion_overdue_fires_at_window_boundary() {
+        use crate::federation::hard_case::{kind, HardCaseFilter};
+        use crate::federation::types::attestation_tier;
+        use crate::federation::FederationDirectory;
+        use std::time::Duration;
+        let backend = MemoryBackend::new();
+        for k in ["subject-c", "target-c"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fix_key(k, "primitive", k),
+                })
+                .await
+                .unwrap();
+        }
+        let revoked_at: chrono::DateTime<chrono::Utc> = "2026-06-01T00:00:00Z".parse().unwrap();
+        // A subject-side `consent:state:revoked` TRANSITING local-tier
+        // (unpromoted). persist's admission gate refuses to *originate* such a
+        // local row (transit-not-rest); we stage it directly to exercise the
+        // watcher's promotion-overdue detection.
+        let mut rev = fix_attestation("rev-c", "subject-c", "target-c", "subject-c");
+        rev.attestation_envelope =
+            serde_json::json!({ "id": "rev-c", "dimension": "consent:state:revoked:v1" });
+        rev.asserted_at = revoked_at;
+        rev.subject_key_ids = vec!["subject-c".into()];
+        rev.tier = attestation_tier::LOCAL.into();
+        rev.promoted_at = None;
+        backend
+            .state
+            .lock()
+            .unwrap()
+            .federation_attestations
+            .push(rev);
+
+        let window = Duration::from_secs(86_400); // 24 h
+
+        // The local-tier transit row is visible to the revocation scan.
+        assert_eq!(
+            backend.list_consent_revocations(None).await.unwrap().len(),
+            1,
+            "list_consent_revocations includes the local-tier transit row"
+        );
+
+        // Just BEFORE the boundary (24 h − 1 s) → in flight, NOT overdue.
+        let before = revoked_at + chrono::Duration::seconds(86_400 - 1);
+        let r = backend.run_consent_sla_watch(before, window).await.unwrap();
+        assert_eq!(r.revocations_scanned, 1);
+        assert_eq!(r.promotion_overdue, 0, "within the window: not yet overdue");
+        assert!(backend
+            .list_hard_case_events(HardCaseFilter::default())
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Just AFTER the boundary (24 h + 1 s) → overdue fires.
+        let after = revoked_at + chrono::Duration::seconds(86_400 + 1);
+        let r = backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 1, "past the window: overdue fires");
+        let evs = backend
+            .list_hard_case_events(HardCaseFilter {
+                kind: Some(kind::CONSENT_REVOCATION_PROMOTION_OVERDUE.into()),
+                since: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].target_key_id.as_deref(), Some("target-c"));
+        assert_eq!(evs[0].subject_key_id.as_deref(), Some("subject-c"));
+
+        // Re-scan is idempotent on the deterministic event_id.
+        let r = backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 1, "condition still active");
+        assert_eq!(
+            backend
+                .list_hard_case_events(HardCaseFilter::default())
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "no duplicate overdue row on re-scan"
+        );
+
+        // Once PROMOTED (tier=federation) it drops out of the fire condition —
+        // its only other conformant terminal state (transit-not-rest).
+        {
+            let mut st = backend.state.lock().unwrap();
+            for a in st.federation_attestations.iter_mut() {
+                if a.attestation_id == "rev-c" {
+                    a.tier = attestation_tier::FEDERATION.into();
+                    a.promoted_at = Some(after);
+                }
+            }
+        }
+        let r = backend
+            .run_consent_sla_watch(after + chrono::Duration::seconds(1), window)
+            .await
+            .unwrap();
+        assert_eq!(
+            r.promotion_overdue, 0,
+            "a promoted revocation is no longer overdue"
+        );
     }
 
     /// steward_bindings_of: an steward-bound node (live `delegates_to(user →

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2690,6 +2690,13 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         // attesting key's identity_type. Backend-symmetric with SQLite + memory.
         crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
 
+        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
+        // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
+        // keyed on a community (`community_id`) is refused if C has lost its
+        // last live `moderate`-holder. No-op for local-tier rows, no
+        // community_id, or an unknown community. Backend-symmetric.
+        crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate. A no-op for local-tier rows (CC 5.3.2.2 deferred

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2417,6 +2417,13 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // so a rejected emission leaves no trace.
         crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
 
+        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
+        // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
+        // keyed on a community (`community_id`) is refused if C has lost its
+        // last live `moderate`-holder. No-op for local-tier rows, no
+        // community_id, or an unknown community. Backend-symmetric.
+        crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
+
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
         // hybrid-verify at the federation-tier bulk store/replicate
         // ingest gate (parity with the postgres + memory backends). A
@@ -16197,6 +16204,118 @@ mod tests {
         assert_eq!(
             r3.sla_breaches, 0,
             "consent:deletion_complete suppresses the breach"
+        );
+    }
+
+    /// #238 / #146 (CC 5.3.2.2 / §10.1.3, AV-61 transit-not-rest) — the
+    /// consent-revocation promotion-overdue `hard_case` fires at the 24 h
+    /// window boundary for a subject-side revocation staged local-tier
+    /// (unpromoted), on the SQLite backend's real `list_consent_revocations`.
+    #[tokio::test]
+    async fn consent_promotion_overdue_fires_at_window_boundary_sqlite() {
+        use crate::federation::{
+            hard_case::kind, hard_case::HardCaseFilter, FederationDirectory, SignedAttestation,
+        };
+        use std::time::Duration;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        for k in ["subject-p", "target-p"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key(k, &format!("prim-{k}"), k),
+                })
+                .await
+                .unwrap();
+        }
+        let revoked_at: chrono::DateTime<chrono::Utc> = "2026-06-01T00:00:00Z".parse().unwrap();
+        // A subject-side consent:state:revoked. It is federation-tier by
+        // classification, so it admits federation-tier (signed); we then flip
+        // it to the local-tier TRANSIT state (unpromoted) directly — persist's
+        // admission gate refuses to *originate* a local subject revocation
+        // (transit-not-rest), so this simulates the #171 promote-surface
+        // staging the watcher must drive out.
+        let mut rev = fed_attestation("rev-p", "subject-p", "target-p", "subject-p");
+        rev.attestation_envelope =
+            serde_json::json!({ "id": "rev-p", "dimension": "consent:state:revoked:v1" });
+        rev.asserted_at = revoked_at;
+        rev.subject_key_ids = vec!["subject-p".into()];
+        resign_fed(&mut rev);
+        backend
+            .put_attestation(SignedAttestation { attestation: rev })
+            .await
+            .unwrap();
+        // Flip to local-tier, unpromoted (the transit staging state).
+        {
+            let conn = backend.conn.lock();
+            conn.execute(
+                "UPDATE federation_attestations SET tier = 'local', promoted_at = NULL \
+                 WHERE attestation_id = 'rev-p'",
+                [],
+            )
+            .unwrap();
+        }
+        let window = Duration::from_secs(86_400); // 24 h
+
+        // The SQLite scan surfaces the local-tier transit row.
+        let revs = backend.list_consent_revocations(None).await.unwrap();
+        assert_eq!(revs.len(), 1, "local-tier subject revocation is scanned");
+        assert_ne!(
+            revs[0].tier,
+            crate::federation::types::attestation_tier::FEDERATION,
+            "row is local-tier (transit)"
+        );
+
+        // Just BEFORE the boundary → in flight, not overdue.
+        let before = revoked_at + chrono::Duration::seconds(86_400 - 1);
+        let r = backend.run_consent_sla_watch(before, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 0, "within the window: not yet overdue");
+
+        // Just AFTER the boundary → overdue fires; recorded + idempotent.
+        let after = revoked_at + chrono::Duration::seconds(86_400 + 1);
+        let r = backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 1, "past the window: overdue fires");
+        let evs = backend
+            .list_hard_case_events(HardCaseFilter {
+                kind: Some(kind::CONSENT_REVOCATION_PROMOTION_OVERDUE.into()),
+                since: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].target_key_id.as_deref(), Some("target-p"));
+        assert_eq!(evs[0].subject_key_id.as_deref(), Some("subject-p"));
+        let r = backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 1, "still detected");
+        assert_eq!(
+            backend
+                .list_hard_case_events(HardCaseFilter {
+                    kind: Some(kind::CONSENT_REVOCATION_PROMOTION_OVERDUE.into()),
+                    since: None,
+                })
+                .await
+                .unwrap()
+                .len(),
+            1,
+            "idempotent: no duplicate overdue row"
+        );
+
+        // Promote it (tier=federation) → drops out of the fire condition.
+        {
+            let conn = backend.conn.lock();
+            conn.execute(
+                "UPDATE federation_attestations SET tier = 'federation', promoted_at = ?1 \
+                 WHERE attestation_id = 'rev-p'",
+                [after.to_rfc3339()],
+            )
+            .unwrap();
+        }
+        let r = backend
+            .run_consent_sla_watch(after + chrono::Duration::seconds(1), window)
+            .await
+            .unwrap();
+        assert_eq!(
+            r.promotion_overdue, 0,
+            "a promoted revocation is no longer overdue"
         );
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -25646,6 +25646,155 @@ mod tests {
         );
     }
 
+    /// CC 3.4.12 (CIRISPersist#309) — adult-incapacity binding + fail-to-liberty
+    /// on the SQLITE backend (pg/sqlite symmetry): the shared admission gate
+    /// admits a scoped, reversible-excluded, bounded binding; a lapsed
+    /// `valid_until` is non-live and the adult auto-re-sovereigns.
+    #[tokio::test]
+    async fn adult_incapacity_binding_and_fail_to_liberty_sqlite() {
+        use crate::federation::admission::steward_bindings_of;
+        use crate::federation::types::{attestation_type, identity_type};
+        use chrono::{Duration, Utc};
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        for (k, ity) in [
+            ("si-assessor", identity_type::WITNESS),
+            ("si-S", identity_type::USER),
+            ("si-A", identity_type::USER),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key_with_identity_type(k, k, k, ity),
+                })
+                .await
+                .unwrap();
+        }
+
+        // A capacity/age attestation ABOUT `subj` from `emitter` carrying a
+        // bare `attestation_type` token (like the age fixtures).
+        let att = |emitter: &str, subj: &str, token: &str| {
+            let mut a = topo_attestation(emitter, subj, token, None, None, &[], None, Utc::now());
+            a.attestation_envelope = serde_json::json!({ "id": token });
+            resign_fed(&mut a);
+            a
+        };
+        for (subj, token) in [
+            ("si-S", "age_assurance:provider:adult:v1"),
+            ("si-A", "age_assurance:provider:adult:v1"),
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: att("si-assessor", subj, token),
+                })
+                .await
+                .unwrap();
+        }
+        for token in [
+            "capacity_assurance:panel:financial:incapacitated:v1",
+            "capacity_assurance:reversible_excluded:financial",
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: att("si-assessor", "si-A", token),
+                })
+                .await
+                .expect("witness capacity attestation admitted on sqlite");
+        }
+
+        // An adult-incapacity binding with the CC 3.4.12 envelope fields.
+        let binding = |id: &str, valid_until: &str| {
+            let mut a = topo_attestation(
+                "si-S",
+                "si-A",
+                attestation_type::DELEGATES_TO,
+                None,
+                None,
+                &[],
+                None,
+                Utc::now(),
+            );
+            a.attestation_envelope = serde_json::json!({
+                "id": id,
+                "scope": ["financial"],
+                "binding_legitimacy_source": "prior_will_proxy",
+                "valid_until": valid_until,
+            });
+            resign_fed(&mut a);
+            a
+        };
+
+        // LIVE binding (future valid_until) → S is a live anchor of A.
+        let future = (Utc::now() + Duration::days(30)).to_rfc3339();
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: binding("si-live", &future),
+            })
+            .await
+            .expect("valid adult-incapacity binding admitted on sqlite");
+        assert!(steward_bindings_of(&backend, "si-A")
+            .await
+            .unwrap()
+            .contains(&"si-S".to_string()));
+
+        // Fail-to-liberty: a fresh ward whose ONLY binding has lapsed.
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key_with_identity_type("si-B", "si-B", "si-B", identity_type::USER),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: att("si-assessor", "si-B", "age_assurance:provider:adult:v1"),
+            })
+            .await
+            .unwrap();
+        for token in [
+            "capacity_assurance:panel:financial:incapacitated:v1",
+            "capacity_assurance:reversible_excluded:financial",
+        ] {
+            backend
+                .put_attestation(SignedAttestation {
+                    attestation: att("si-assessor", "si-B", token),
+                })
+                .await
+                .unwrap();
+        }
+        let lapsed = (Utc::now() - Duration::days(1)).to_rfc3339();
+        let mut b = topo_attestation(
+            "si-S",
+            "si-B",
+            attestation_type::DELEGATES_TO,
+            None,
+            None,
+            &[],
+            None,
+            Utc::now(),
+        );
+        b.attestation_envelope = serde_json::json!({
+            "id": "si-lapsed",
+            "scope": ["financial"],
+            "binding_legitimacy_source": "prior_will_proxy",
+            "valid_until": lapsed,
+        });
+        resign_fed(&mut b);
+        backend
+            .put_attestation(SignedAttestation { attestation: b })
+            .await
+            .expect("lapsed-valid_until binding structurally admitted");
+        let anchors = steward_bindings_of(&backend, "si-B").await.unwrap();
+        assert!(
+            !anchors.contains(&"si-S".to_string()),
+            "a lapsed binding confers no standing (fail-to-liberty)"
+        );
+        assert_eq!(
+            anchors,
+            vec!["si-B".to_string()],
+            "adult auto-re-sovereigns"
+        );
+    }
+
     /// SecReview F3: a WITHDRAWN `delegates_to(user → node)` no longer
     /// confers steward-binding (sqlite parity) — admitted while live, REJECTED
     /// after the granter withdraws the edge.

--- a/tests/fountain_content.rs
+++ b/tests/fountain_content.rs
@@ -26,6 +26,9 @@ use base64::Engine as _;
 use ciris_keyring::{MlDsa65SoftwareSigner, PqcSigner};
 use ed25519_dalek::{Signer as _, SigningKey};
 
+use ciris_persist::fountain::storage_contention::{
+    assemble_storage_budget_wire, storage_budget_preimage, verify_storage_budget_wire,
+};
 use ciris_persist::fountain::{
     symbol_sha256_hex, FountainContent, FountainManifestV1, FountainSymbolV1, FountainTier,
     MANIFEST_VERSION_V1,
@@ -134,6 +137,40 @@ async fn build_manifest_and_symbols(
     // classical-only: leave signature_ml_dsa_65 empty (the hard cut).
 
     (manifest, symbols)
+}
+
+/// §Q B6/N5 (CIRISPersist#359): build + VERIFY a signed `StorageBudgetV1`
+/// whose `pinned_class` covers `corpus_kind` with a non-zero
+/// `pin_reserve_bytes`. Returns the verified wire JSON. This proves a *valid,
+/// aggregator-signed* pin advertisement covering the subject_kind exists — the
+/// exact state B6 says must NOT shield content from revocation.
+async fn build_and_verify_trace_pin(corpus_kind: &str) -> String {
+    let (ed_sk, ed_pk_b64, mldsa) = producer_pubkeys();
+    let mldsa_pk_b64 = BASE64.encode(mldsa.public_key().await.unwrap());
+
+    // A budget that PINS `corpus_kind` (in pinned_class) with a real byte
+    // reserve — i.e. the strongest pin the §Q surface can express.
+    let payload = format!(
+        r#"{{"node_id":"n-pin","epoch_id":"e1","revision":1,
+            "scopes":[{{"cohort_scope":"community","budget_bytes":100000,"pin_reserve_bytes":50000}}],
+            "pinned_class":["{corpus_kind}"]}}"#
+    );
+
+    // Bound-hybrid sign: Ed25519 over the preimage, ML-DSA-65 over
+    // (preimage || ed_sig) — the same shape the engine's signer emits.
+    let preimage = storage_budget_preimage(&payload).expect("valid pin payload");
+    let ed_sig = ed_sk.sign(&preimage).to_bytes();
+    let mut bound = preimage.clone();
+    bound.extend_from_slice(&ed_sig);
+    let pqc_sig = mldsa.sign(&bound).await.unwrap();
+    let wire =
+        assemble_storage_budget_wire(&payload, BASE64.encode(ed_sig), BASE64.encode(&pqc_sig))
+            .expect("assemble signed budget");
+
+    // The pin is genuinely valid (PQC-mandatory bound-hybrid verifies).
+    verify_storage_budget_wire(&wire, &ed_pk_b64, &mldsa_pk_b64)
+        .expect("(j) the pin advertisement is a valid, verified StorageBudgetV1");
+    wire
 }
 
 /// The shared body: assertions (a)–(g) against a migrated backend.
@@ -337,6 +374,60 @@ async fn run_fountain_assertions<B: Backend>(backend: &B, suffix: &str) {
         revoked.present(),
         0,
         "(i) zero symbols survive revocation HardDelete"
+    );
+
+    // (j) §Q B6/N5 (CIRISPersist#359): PINNING NEVER DEFEATS REVOCATION.
+    //     A *verified*, aggregator-signed StorageBudgetV1 whose pinned_class
+    //     covers `corpus` ("trace") with pin_reserve_bytes > 0 does NOT shield
+    //     that content from hard-delete. The pin is a verified-at-ingest
+    //     advertisement, not stored pin STATE — there is no pin table and
+    //     evict_fountain_content_hard_delete has no §Q pin parameter, so the
+    //     pin structurally cannot reach the deletion path. B6: a pin holds
+    //     content above the floor against CAPACITY pressure only, never
+    //     against revocation.
+    let pin_wire = build_and_verify_trace_pin(corpus).await;
+    assert!(
+        pin_wire.contains(corpus),
+        "(j) the verified pin advertisement covers the subject_kind being revoked"
+    );
+    let pcid = format!("c-pinned-revoke-{suffix}");
+    let (pman, psyms) =
+        build_manifest_and_symbols(&pcid, n_source, k_repair, symbol_size, true).await;
+    backend
+        .put_fountain_content(&pman, &psyms)
+        .await
+        .expect("(j) admit pinned-class content");
+    assert!(
+        matches!(
+            backend.get_fountain_content(&pcid, corpus).await.unwrap(),
+            Some(FountainContent::Full { .. })
+        ),
+        "(j) full before revoke, despite the pin"
+    );
+    // Revocation runs unconditionally — the pin over `corpus` is never
+    // consulted (the delete takes only content_id + corpus_kind).
+    let pdropped = backend
+        .evict_fountain_content_hard_delete(&pcid, corpus)
+        .await
+        .expect("(j) hard delete over pinned class");
+    assert_eq!(
+        pdropped,
+        u64::from(total),
+        "(j) HardDelete drops ALL symbols even when a valid pin covers the class"
+    );
+    let pin_revoked = backend
+        .get_fountain_content(&pcid, corpus)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        pin_revoked.present(),
+        0,
+        "(j) pinning never defeats revocation — zero symbols survive (§Q B6)"
+    );
+    assert!(
+        matches!(pin_revoked, FountainContent::EnvelopeOnly { .. }),
+        "(j) pinned content → EnvelopeOnly after revocation, got {pin_revoked:?}"
     );
 
     // (#227 publisher view) list_held_fountain_content — the publisher sees


### PR DESCRIPTION
Read against the standalone **CIRISConstitution v0.9.3**. Three conformance issues, one release. Closes #309, #238, #359.

## #309 — 4-band age + capacity assurance + adult-incapacity steward-binding + fail-to-liberty (CC 3.4.11–13 / 3.2)
- 4-band `AgeBandFine` (`under_13`/`13_15`/`16_17`/`adult`; `minor` = union) + resolver; binary `AgeBand` preserved (CC 3.2 gate unbroken); `age_band_fine_json` FFI.
- New `src/federation/capacity.rs`: `capacity_assurance:{level}:{domain}:{band}:v1` ingestion, witness-reserved (subject/steward can't emit), `capacity_state()` resolver, `capacity_state_json` FFI.
- `check_adult_incapacity_binding`: admits an adult target only under incapacity attestation + `reversible_excluded` (or T1 `reversible_pending`), attester ∉ {steward, petitioner}, scope ⊆ attested ∧ ∩ PROTECTED_NON_TRANSFERABLE = ∅, mandatory `binding_legitimacy_source` ∈ {prior_will_proxy, wa_due_process_quorum, emergency_necessity_expedited} + `valid_until` ≤ `T2_REVIEW_CADENCE_DAYS`(90). Never steward-self-signature.
- Fail-to-liberty: lapsed `valid_until` → binding non-live → auto-re-sovereign (wired into all 3 liveness resolvers).
- Deferred to higher layers (documented): panel M-of-N counting, T1 audit-deadline timer, ward's-champion shapes, `moderation:capacity_misattestation`, `content_class:adult` gate.

## #238 — no-moderator-no-federate gate + consent SLA (CC 4.5.4 / 5.3.2.2)
- §11.11 (now explicitly **substrate**): `check_no_moderator_federate_apply` in `put_attestation` (all 3 backends) refuses to federate a `community` with no live `moderate`-holder — `Error::CommunityHasNoModerator`, fail-secure. One federation-apply chokepoint covers admission + continue-to-federate re-check; infra exempt. Merit-promotion/48h are signed ceremonies (higher layer).
- §10.1.3 (AV-61 **resolved**, transit-not-rest): consent-revocation 24h SLA → `hard_case:consent_revocation_promotion_overdue`; closed the memory-backend `list_consent_revocations` asymmetry.

## #359 — §Q pin-never-defeats-revocation (CC 6.1.5.2 §Q B6/N5)
Spec mandates the invariant, not a stored-pin override. persist stores no pin state → `evict_fountain_content_hard_delete` structurally can't consult a pin. Proven + locked with a both-backend test (verified `StorageBudgetV1` pin over `"trace"` does not block hard-delete). Constitution pins no dominance `min_ratio` → persist's 0.5 stands.

## Verification
**1306 pg+sqlite lib tests / 0 failed** (clean DB); full-feature clippy `-D warnings` clean; no pg/sqlite asymmetry. Verify pin unchanged (v8.7.0), `Requires-Dist` unchanged.

## Downstream (adoption issues to follow)
CIRISEdge + CIRISServer (re-pin v12.5.0; new age/capacity/moderator/consent surfaces), CIRISConformance (capacity/adult-incapacity, no-moderator, consent-overdue, test_530 gates flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)