### PR TITLE
feat(v12.6.0): single-owner node invariant — admission gate + owner_of (closes #363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [12.6.0] — 2026-07-04 — single-owner node invariant (CIRISConstitution#23)
+
+The `self` cohort boundary (CC 1.13.3.3 / CC 3.2) is defined by a node's owner,
+so it is only well-defined if a node has **exactly one** owner. That invariant
+was assumed at read time (`is_steward_bound(..).next()` on a *sorted* set —
+grindable) but never enforced at bind time, and `steward_bindings_of` conflates
+ownership with *any* `delegates_to` (act-on-behalf, hierarchy). This cut makes
+single-ownership a substrate invariant, enforced where the objects live.
+
+### Added — #363 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2): single-owner admission gate + `owner_of`
+
+- **`owner_binding` dimension** (`src/federation/types.rs`): the
+  substrate-normative discriminator for a node owner-binding —
+  `delegates_to(user → node)` carrying `dimension:
+  "ownership:responsible_party:node:v1"` + `delegation_purpose: "responsible_for"`,
+  infra:*-only. Byte-identical to CIRISServer's `DIMENSION_OWNER_BINDING` /
+  `OWNER_BINDING_PURPOSE` (the wire is the contract). This is what separates the
+  **single-valued ownership** relation from the general (multi-parent)
+  `delegates_to` grammar (CC 4.5.13 hierarchy / act-on-behalf).
+- **`check_single_node_owner_admission`** (`src/federation/admission.rs`): the
+  node-target companion to `check_node_agency_admission`. Rejects a second,
+  distinct-owner owner-binding on an already-owned node
+  (`Error::NodeAlreadyOwned`); a same-owner refresh is idempotent; ownership is
+  transferable once the incumbent `withdraws`/`recants` or the binding lapses.
+  Wired into every backend's `put_attestation` (memory/sqlite/postgres),
+  verify-before-mutation (AV-9), keyed on the ownership dimension so
+  act-on-behalf / hierarchy delegations are untouched.
+- **`owner_of(node) -> Option<String>`** (`src/federation/admission.rs`): the
+  dimension-precise single-owner projection (a subset of `steward_bindings_of`
+  restricted to owner-bindings) — the reader consumers MUST use to resolve "the
+  owner of a node" for the `self` boundary. Returns `Error::AmbiguousNodeOwner`
+  on a multi-owner node (a pre-gate anomaly) so consumers **fail closed** instead
+  of silently picking a sorted `.next()`.
+- **Errors**: `NodeAlreadyOwned` (`federation_node_already_owned`) +
+  `AmbiguousNodeOwner` (`federation_ambiguous_node_owner`).
+
+Downstream: CIRISEdge widens its `SelfOnly` cohort-scope enforcement from
+"recipient == my key" to "recipient ∈ my owner's nodes" on top of this
+(cross-device self-replication); CIRISServer's `is_steward_bound` should adopt
+`owner_of` + fail-closed. See CIRISConstitution#23 for the normative text.
+
 ## [12.5.0] — 2026-07-04 — CC 0.9.3 conformance batch
 
 Read against the now-standalone **CIRISConstitution v0.9.3**. Three conformance

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.5.0"
+version = "12.6.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -2402,6 +2402,139 @@ pub async fn nodes_stewarded_by(
     Ok(out)
 }
 
+/// The distinct set of **live owner-binding granters** of `node` — the users
+/// `U` with a live `delegates_to(U → node)` carrying the CC 1.13.3.3 / CC 3.2
+/// owner-binding dimension ([`super::types::owner_binding::DIMENSION`]). The raw
+/// set behind [`owner_of`] + [`check_single_node_owner_admission`]; it applies
+/// the SAME liveness/retraction predicate as [`steward_bindings_of`]'s clause
+/// (3) — not-expired, not adult-incapacity-lapsed, live `user`-role granter, not
+/// `withdraws`/`recants`-retracted — restricted to the ownership dimension, so
+/// `owner_of(node)` is always a subset of `steward_bindings_of(node)`.
+async fn live_owner_binding_granters(
+    directory: &dyn super::FederationDirectory,
+    node: &str,
+) -> Result<std::collections::BTreeSet<String>, Error> {
+    let mut out: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let now = chrono::Utc::now();
+    for r in directory.list_attestations_for(node).await? {
+        if r.attestation_type != attestation_type::DELEGATES_TO {
+            continue;
+        }
+        // Only OWNER-BINDING edges — the versioned ownership dimension. This is
+        // what keeps ownership single-valued WITHOUT constraining act-on-behalf
+        // / hierarchy delegations (multi-parent per CC 4.5.13).
+        if envelope_dimension(&r.attestation_envelope)
+            != Some(super::types::owner_binding::DIMENSION)
+        {
+            continue;
+        }
+        if let Some(exp) = r.expires_at {
+            if exp <= now {
+                continue;
+            }
+        }
+        // Fail-to-liberty (CC 3.4.12): a lapsed adult-incapacity `valid_until`
+        // is non-live.
+        if delegation_valid_until_lapsed(&r.attestation_envelope, now) {
+            continue;
+        }
+        // A non-`user` granter cannot steward — mirror steward_bindings_of.
+        let Some(granter) = directory.lookup_public_key(&r.attesting_key_id).await? else {
+            continue;
+        };
+        if !identity_type::set_contains(&granter.identity_type, identity_type::USER) {
+            continue;
+        }
+        let granter_retracted = directory
+            .list_attestations_by(&r.attesting_key_id)
+            .await?
+            .into_iter()
+            .any(|g| {
+                (g.attestation_type == attestation_type::WITHDRAWS
+                    || g.attestation_type == attestation_type::RECANTS)
+                    && g.attested_key_id == node
+            });
+        if granter_retracted {
+            continue;
+        }
+        out.insert(r.attesting_key_id);
+    }
+    Ok(out)
+}
+
+/// **CIRISConstitution#23 (CC 1.13.3.3 / CC 3.2) — the single responsible owner
+/// of `node`, or `None` when the node is unowned.** The dimension-precise
+/// ownership projection (a subset of [`steward_bindings_of`] restricted to
+/// owner-binding edges), and the reader consumers MUST use to resolve "the owner
+/// of a node" for the `self` cohort boundary.
+///
+/// Returns [`Error::AmbiguousNodeOwner`] when the node carries **more than one**
+/// distinct live owner — a pre-gate anomaly the single-owner admission gate
+/// [`check_single_node_owner_admission`] prevents going forward. Consumers
+/// (CIRISEdge's `SelfOnly` widening, CIRISServer's node switcher) MUST treat the
+/// error as **fail-closed**: an ambiguous owner is not a resolvable `self`
+/// boundary. NEVER silently pick one (unlike the historical
+/// `is_steward_bound(..).next()` on a sorted set).
+pub async fn owner_of(
+    directory: &dyn super::FederationDirectory,
+    node: &str,
+) -> Result<Option<String>, Error> {
+    let owners = live_owner_binding_granters(directory, node).await?;
+    match owners.len() {
+        0 => Ok(None),
+        1 => Ok(owners.into_iter().next()),
+        _ => Err(Error::AmbiguousNodeOwner {
+            node_key_id: node.to_owned(),
+            owners: owners.into_iter().collect(),
+        }),
+    }
+}
+
+/// **CIRISConstitution#23 (CC 1.13.3.3 / CC 3.2) — the single-owner admission
+/// gate.** The node-target companion to [`check_node_agency_admission`]: a node
+/// has **at most one** responsible steward (the `self` cohort boundary is
+/// undefined otherwise). Rejects a `delegates_to(U → node)` owner-binding when
+/// the node already carries a LIVE owner-binding from a DIFFERENT granter `U'`
+/// ([`Error::NodeAlreadyOwned`]) — the incumbent must first `withdraws` /
+/// `recants` it (or it must lapse). A refresh by the SAME owner is idempotently
+/// admitted; a first owner is admitted.
+///
+/// Keyed on the versioned owner-binding dimension
+/// ([`super::types::owner_binding::DIMENSION`]) so it constrains ONLY the
+/// ownership relation; act-on-behalf / hierarchy `delegates_to` (multi-parent
+/// per CC 4.5.13) are untouched. A no-op for any non-`delegates_to` row or any
+/// `delegates_to` lacking the ownership dimension.
+///
+/// Verify-before-mutation (AV-9): wired into every backend's `put_attestation`
+/// immediately AFTER [`check_user_target_steward_binding_admission`], so a
+/// rejected second-owner emission leaves no trace. Backend-agnostic.
+pub async fn check_single_node_owner_admission(
+    directory: &dyn super::FederationDirectory,
+    row: &super::Attestation,
+) -> Result<(), Error> {
+    if row.attestation_type != attestation_type::DELEGATES_TO {
+        return Ok(());
+    }
+    if envelope_dimension(&row.attestation_envelope) != Some(super::types::owner_binding::DIMENSION)
+    {
+        return Ok(());
+    }
+    // The incoming row is NOT yet stored (this runs pre-insert), so every
+    // granter here is a pre-existing incumbent. Any incumbent that is NOT the
+    // attesting owner blocks admission — a node cannot accrue a second steward.
+    let incumbents = live_owner_binding_granters(directory, &row.attested_key_id).await?;
+    for incumbent in incumbents {
+        if incumbent != row.attesting_key_id {
+            return Err(Error::NodeAlreadyOwned {
+                node_key_id: row.attested_key_id.clone(),
+                incumbent_owner: incumbent,
+                attempted_owner: row.attesting_key_id.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// #249 Cut B — the steward-binding **PATH** for audit: the actual delegation
 /// chain `user → … → key_id` that steward-binds `key_id`, anchor-first (the
 /// human `user`-role key at index 0, `key_id` last). Where

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -3573,6 +3573,49 @@ pub enum Error {
         offending_scopes: Vec<String>,
     },
 
+    /// v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — a **second,
+    /// distinct-owner** node owner-binding was REJECTED: the node already
+    /// carries a LIVE owner-binding from `incumbent_owner`, and a node has at
+    /// most ONE responsible steward (the `self` cohort boundary is undefined
+    /// otherwise). The incumbent must first `withdraws`/`recants` (or the
+    /// binding must lapse) before a different owner can bind. A refresh by the
+    /// SAME owner is idempotently admitted. The row is NOT stored (verify-
+    /// before-mutation, AV-9). Stable `kind()` token
+    /// `federation_node_already_owned`. See
+    /// [`admission::check_single_node_owner_admission`] / [`admission::owner_of`].
+    #[error(
+        "node {node_key_id:?} is already owner-bound by {incumbent_owner:?}; a node has \
+         at most one responsible steward (CC 1.13.3.3 / CC 3.2) — {attempted_owner:?} may \
+         not bind until the incumbent withdraws/recants or the binding lapses"
+    )]
+    NodeAlreadyOwned {
+        /// The node whose ownership is already claimed.
+        node_key_id: String,
+        /// The live incumbent owner (a different `user`-role granter).
+        incumbent_owner: String,
+        /// The rejected would-be owner (the incoming `attesting_key_id`).
+        attempted_owner: String,
+    },
+
+    /// v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — [`admission::owner_of`]
+    /// found **more than one** distinct live owner for a node (a pre-gate
+    /// anomaly; [`admission::check_single_node_owner_admission`] prevents new
+    /// occurrences). This is a READ-path fail-closed signal: an ambiguous owner
+    /// is NOT a resolvable `self` boundary, so consumers MUST refuse rather than
+    /// silently pick one. Stable `kind()` token `federation_ambiguous_node_owner`.
+    #[error(
+        "node {node_key_id:?} has {} distinct live owners {owners:?}; ownership is \
+         single-valued (CC 1.13.3.3 / CC 3.2) — cannot resolve a `self` boundary \
+         (fail closed)",
+        .owners.len()
+    )]
+    AmbiguousNodeOwner {
+        /// The node with an ambiguous (multi-owner) binding state.
+        node_key_id: String,
+        /// The distinct live owners (sorted).
+        owners: Vec<String>,
+    },
+
     /// v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — a **federation-tier**
     /// attestation was REJECTED at the bulk store/replicate ingest gate
     /// because its envelope hybrid signature could not be verified
@@ -3820,6 +3863,8 @@ impl Error {
             Error::WithdrawsNotAdmitted { .. } => "federation_withdraws_not_admitted",
             Error::DelegatedScopeUnauthorized { .. } => "federation_delegated_scope_unauthorized",
             Error::NodeAgencyForbidden { .. } => "federation_node_agency_forbidden",
+            Error::NodeAlreadyOwned { .. } => "federation_node_already_owned",
+            Error::AmbiguousNodeOwner { .. } => "federation_ambiguous_node_owner",
             Error::UnstewardedCommunityMember { .. } => "federation_unstewarded_community_member",
             Error::UserTargetStewardBindingForbidden { .. } => {
                 "federation_user_target_steward_binding_forbidden"

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -262,6 +262,30 @@ pub mod attestation_type {
     pub const RECANTS: &str = "recants";
 }
 
+/// v12.6.0 (CIRISPersist#363 / CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — the
+/// substrate-normative discriminator for the **node owner-binding**: the
+/// `delegates_to(user → node)` edge that names a node's single responsible
+/// steward and thereby *defines* the node's `self` cohort boundary.
+///
+/// An owner-binding is a [`attestation_type::DELEGATES_TO`] carrying
+/// [`DIMENSION`] as its envelope `dimension` (and, on the producer side,
+/// [`PURPOSE`] as `delegation_purpose`, with `infra:*`-only `scope`). This is
+/// what separates the **ownership** relation — which is **single-valued** (a
+/// node has at most one owner, [`super::super::admission::owner_of`]) — from
+/// the general (multi-parent) `delegates_to` grammar (act-on-behalf, hierarchy
+/// per CC 4.5.13). CIRISServer's `auth::ownership` builds these; the two
+/// constants MUST stay byte-identical to server's `DIMENSION_OWNER_BINDING` /
+/// `OWNER_BINDING_PURPOSE` (the wire is the contract).
+pub mod owner_binding {
+    /// The versioned owner-binding `dimension` — the substrate keys the
+    /// single-owner admission gate + [`super::super::admission::owner_of`] on
+    /// this exact string. Versioned (`:v1`) per the dimension gate.
+    pub const DIMENSION: &str = "ownership:responsible_party:node:v1";
+    /// The owner-binding `delegation_purpose` (producer-side marker; the
+    /// substrate gate keys on [`DIMENSION`], this documents the pair).
+    pub const PURPOSE: &str = "responsible_for";
+}
+
 /// v8.9.0 (CIRISPersist#236, CC 4.4.3.4.3 / CC 1.13.5) — the reserved
 /// **two-prefix delegation scope split** that makes "infrastructure
 /// must not have agency" wire-checkable.

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -24434,6 +24434,12 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // node-only key is caller-side authorization failure; ValueError
         // (4xx). "Infrastructure must not have agency."
         crate::federation::Error::NodeAgencyForbidden { .. } => PyValueError::new_err(kind),
+        // v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — a rejected
+        // second-owner binding (single-owner gate) is a caller-side conflict,
+        // and an ambiguous-owner read is a fail-closed state rejection; both are
+        // ValueError (4xx / 409-shaped, like `Conflict`).
+        crate::federation::Error::NodeAlreadyOwned { .. }
+        | crate::federation::Error::AmbiguousNodeOwner { .. } => PyValueError::new_err(kind),
         // v9.0.0 (CC 3.2 / CC 3.4.7.1) — admitting an unstewarded node/agent to
         // a non-infrastructure community is a caller-side authorization
         // failure (non-infra membership is an authority act that must root

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1315,6 +1315,13 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
             .await?;
 
+        // v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — the single-owner
+        // gate: a node has AT MOST ONE responsible steward, so a second,
+        // distinct-owner owner-binding `delegates_to(U → node)` is rejected. This
+        // is what makes the `self` cohort boundary well-defined. Backend-symmetric
+        // with SQLite + Postgres; verify-before-mutation.
+        crate::federation::admission::check_single_node_owner_admission(self, &row).await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace, keyed on the attesting
         // key's identity_type. Backend-symmetric with SQLite + Postgres.
@@ -9112,6 +9119,210 @@ mod tests {
         assert_eq!(
             nodes_stewarded_by(&backend, "ob-owner").await.unwrap(),
             vec!["ob-node".to_string(), "ob-owner".to_string()]
+        );
+    }
+
+    // ── CIRISConstitution#23 (CC 1.13.3.3 / CC 3.2) — single-owner gate ──
+
+    /// Build an OWNER-BINDING `delegates_to(owner → node)` carrying the CC
+    /// 1.13.3.3 / CC 3.2 ownership dimension (what the single-owner gate +
+    /// `owner_of` key on) with infra-only scope, re-signed for the
+    /// federation-tier ingest gate. Distinct from [`fix_node_delegates_to`],
+    /// which builds a plain (non-ownership) infra delegation.
+    fn fix_owner_binding(id: &str, owner: &str, node: &str) -> Attestation {
+        use crate::federation::types::{attestation_type, delegation_scope as ds, owner_binding};
+        let mut att = fix_attestation(id, owner, node, owner);
+        att.attestation_type = attestation_type::DELEGATES_TO.into();
+        att.attestation_envelope = serde_json::json!({
+            "id": id,
+            "kind": "delegates_to",
+            "dimension": owner_binding::DIMENSION,
+            "delegation_purpose": owner_binding::PURPOSE,
+            "scope": [ds::INFRA_SERVE, ds::INFRA_NETWORK_PRESENCE],
+        });
+        resign_fix(&mut att); // envelope changed → re-sign (CC 5.3.2.4.3.1)
+        att
+    }
+
+    /// Register a SECOND `user`-role key — a distinct would-be owner.
+    async fn seed_second_owner(backend: &MemoryBackend, key_id: &str) {
+        let mut u = fix_key(key_id, key_id, key_id);
+        u.identity_type = crate::federation::types::identity_type::USER.into();
+        backend
+            .put_public_key(SignedKeyRecord { record: u })
+            .await
+            .unwrap();
+    }
+
+    /// A node cannot accrue a SECOND, distinct owner: the first owner-binding
+    /// admits; a second from a DIFFERENT user is rejected `NodeAlreadyOwned`
+    /// and leaves no trace (verify-before-mutation). This is what keeps the
+    /// `self` cohort boundary single-valued.
+    #[tokio::test]
+    async fn single_owner_gate_rejects_second_distinct_owner() {
+        use crate::federation::admission::owner_of;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await; // ob-owner (user), ob-node (node)
+        seed_second_owner(&backend, "ob-owner2").await;
+
+        // First owner-binding admits; owner_of resolves ob-owner.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b1", "ob-owner", "ob-node"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            owner_of(&backend, "ob-node").await.unwrap(),
+            Some("ob-owner".to_string())
+        );
+
+        // A second, DIFFERENT owner is rejected.
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b2", "ob-owner2", "ob-node"),
+            })
+            .await
+            .unwrap_err();
+        match err {
+            crate::federation::Error::NodeAlreadyOwned {
+                ref node_key_id,
+                ref incumbent_owner,
+                ref attempted_owner,
+            } => {
+                assert_eq!(node_key_id, "ob-node");
+                assert_eq!(incumbent_owner, "ob-owner");
+                assert_eq!(attempted_owner, "ob-owner2");
+            }
+            other => panic!("expected NodeAlreadyOwned, got {other:?}"),
+        }
+        assert_eq!(err.kind(), "federation_node_already_owned");
+        // The rejected binding left no trace — owner unchanged.
+        assert_eq!(
+            owner_of(&backend, "ob-node").await.unwrap(),
+            Some("ob-owner".to_string())
+        );
+    }
+
+    /// A refresh by the SAME owner (new attestation id, same granter) is
+    /// idempotently admitted — re-binding your own node is not a second owner.
+    #[tokio::test]
+    async fn single_owner_gate_admits_same_owner_refresh() {
+        use crate::federation::admission::owner_of;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await;
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b1", "ob-owner", "ob-node"),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b2", "ob-owner", "ob-node"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            owner_of(&backend, "ob-node").await.unwrap(),
+            Some("ob-owner".to_string())
+        );
+    }
+
+    /// Ownership is transferable, not permanent: after the incumbent binding
+    /// lapses (expiry → non-live), a DIFFERENT owner may bind. The gate honors
+    /// the same liveness predicate as `steward_bindings_of`.
+    #[tokio::test]
+    async fn single_owner_gate_admits_new_owner_after_incumbent_expires() {
+        use crate::federation::admission::owner_of;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await;
+        seed_second_owner(&backend, "ob-owner2").await;
+
+        // An already-expired incumbent binding (expires_at is a row field, not
+        // in the signed envelope, so the ingest signature is unaffected).
+        let mut expired = fix_owner_binding("ob-b1", "ob-owner", "ob-node");
+        expired.expires_at = Some("2020-01-01T00:00:00Z".parse().unwrap());
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: expired,
+            })
+            .await
+            .unwrap();
+        // Expired → non-live → node reads as unowned.
+        assert_eq!(owner_of(&backend, "ob-node").await.unwrap(), None);
+
+        // A different owner may now bind.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b2", "ob-owner2", "ob-node"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            owner_of(&backend, "ob-node").await.unwrap(),
+            Some("ob-owner2".to_string())
+        );
+    }
+
+    /// The gate + `owner_of` key on the OWNERSHIP dimension, NOT any
+    /// `delegates_to`. A plain infra delegation (act-on-behalf shape, no
+    /// ownership dimension) is not an owner-binding: it neither trips the gate
+    /// nor counts toward `owner_of` — even though `steward_bindings_of` (the
+    /// broader relation) does count it. This is the ownership-vs-delegation
+    /// distinction the single-owner invariant rests on.
+    #[tokio::test]
+    async fn owner_of_ignores_non_ownership_delegations() {
+        use crate::federation::admission::{owner_of, steward_bindings_of};
+        use crate::federation::types::delegation_scope as ds;
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await;
+        seed_second_owner(&backend, "ob-owner2").await;
+
+        // A non-ownership infra delegation (no ownership dimension).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_node_delegates_to(
+                    "ob-plain",
+                    "ob-owner",
+                    "ob-node",
+                    "ob-owner",
+                    &[ds::INFRA_SERVE],
+                ),
+            })
+            .await
+            .unwrap();
+        // Not an owner-binding → owner_of sees no owner…
+        assert_eq!(owner_of(&backend, "ob-node").await.unwrap(), None);
+        // …but steward_bindings_of (broader) DOES count the granter.
+        assert_eq!(
+            steward_bindings_of(&backend, "ob-node").await.unwrap(),
+            vec!["ob-owner".to_string()]
+        );
+        // A real owner-binding from a DIFFERENT user still admits — the plain
+        // delegation never claimed ownership, so it does not block.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_owner_binding("ob-b1", "ob-owner2", "ob-node"),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            owner_of(&backend, "ob-node").await.unwrap(),
+            Some("ob-owner2".to_string())
+        );
+    }
+
+    /// `owner_of` on an unowned node is `None` (not an error, not a guess).
+    #[tokio::test]
+    async fn owner_of_unowned_node_is_none() {
+        let backend = MemoryBackend::new();
+        seed_ob_keys(&backend).await;
+        assert_eq!(
+            crate::federation::admission::owner_of(&backend, "ob-node")
+                .await
+                .unwrap(),
+            None
         );
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2683,6 +2683,12 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
             .await?;
 
+        // v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — the single-owner
+        // gate: a node has AT MOST ONE responsible steward, so a second,
+        // distinct-owner owner-binding `delegates_to(U → node)` is rejected.
+        // Backend-symmetric with SQLite + memory; verify-before-mutation.
+        crate::federation::admission::check_single_node_owner_admission(self, &row).await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace (accord:* → accord_holder;
         // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2409,6 +2409,13 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         crate::federation::admission::check_user_target_steward_binding_admission(self, &row)
             .await?;
 
+        // v12.6.0 (CIRISConstitution#23, CC 1.13.3.3 / CC 3.2) — the single-owner
+        // gate: a node has AT MOST ONE responsible steward, so a second,
+        // distinct-owner owner-binding `delegates_to(U → node)` is rejected. Runs
+        // BEFORE persist_row_hash + INSERT so a rejected emission leaves no trace.
+        // Backend-symmetric with memory + Postgres.
+        crate::federation::admission::check_single_node_owner_admission(self, &row).await?;
+
         // v10.3.0 (CIRISPersist#288, CC 3.4.1/3.4.3/3.4.5) — reserved-prefix
         // admission on the attestation_TYPE namespace (accord:* → accord_holder;
         // system:*/audit_chain:*/… → substrate-self-report; hard_case:* →


### PR DESCRIPTION
Closes #363. Normative text: CIRISConstitution#23 (CC 1.13.3.3 / CC 3.2).

## Why
The `self` cohort boundary is defined by a node's owner, so it is well-defined only if a node has **exactly one** owner. That was assumed at read time (`is_steward_bound().next()` on a *sorted* set — grindable) but never enforced at bind time, and `steward_bindings_of` conflates ownership with *any* `delegates_to` (act-on-behalf, hierarchy — CC 4.5.13). This unblocks CIRISEdge's `SelfOnly` widening (cross-device self-replication needs an unambiguous "my owner").

## What
- **`types::owner_binding::{DIMENSION, PURPOSE}`** — the owner-binding discriminator (`ownership:responsible_party:node:v1`), byte-identical to CIRISServer's constants.
- **`admission::check_single_node_owner_admission`** — rejects a 2nd distinct-owner owner-binding (`Error::NodeAlreadyOwned`); same-owner refresh idempotent; transferable after incumbent withdraws/recants/lapses. Wired into all three backends' `put_attestation`, verify-before-mutation, keyed on the ownership dimension so act-on-behalf/hierarchy delegations are untouched.
- **`admission::owner_of(node) -> Option<String>`** — dimension-precise single-owner projection (subset of `steward_bindings_of`); `Error::AmbiguousNodeOwner` on a multi-owner node → consumers fail closed (no silent `.next()`).
- pyo3 error mapping; 5 memory-backend tests.

## Tests
`store::memory::tests::single_owner_gate_*` (3) + `owner_of_*` (2) green; steward (2) + admission (43) regression-clean; zero new clippy warnings.

## Downstream
- **CIRISEdge** — widen `SelfOnly` on `owner_of` (fail-closed).
- **CIRISServer** — adopt `owner_of` + fail-closed in `is_steward_bound`; verify no test binds two owners to one node (now correctly rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)