### PR TITLE
v13.0.0 — CC 1.0 RC1 compliance cut (9 issues: #171 #227 #365 #366 #367 #368 #369 #370 #371 #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [13.0.0] — 2026-07-04 — CC 1.0 RC1 compliance cut
+
+Nine conformance issues, read against the standalone **CIRISConstitution v0.9.3**,
+landed as one major cut. This closes the remaining CC 1.0 RC1 substrate gaps.
+
+### ⚠ BREAKING (Rust-crate consumers only — wire/JSON stable)
+- **`KeyRecord` gained `consent_role: Option<String>`** (#365). Any Rust code that
+  constructs a `KeyRecord { .. }` literal must add `consent_role: None` (or a role).
+  `#[serde(default)]` — deserialization of pre-13 JSON is unchanged. **CIRISEdge
+  constructs `KeyRecord` literals and MUST update** (see the adoption issue).
+- **`check_local_tier_eligibility` now returns `Result<LocalTierDisposition, Error>`**
+  (`Durable | TransitRevocation`) and **`check_consent_record_admission`** returns the
+  same disposition (#171). `LocalAttestationInput` gained optional
+  `scrub_signature_classical` / `scrub_signature_pqc` fields (`#[serde(default)]`).
+- **`federation::Error` gained variants** (`CommunityHasNoModerator`,
+  `CanonicalRoleNotAccordConferred`, `AgeAssuranceSelfEmissionRejected`) and
+  `StorageContentionError::RevisionRollback`; `EvictionCandidate` gained `media_type`.
+  Exhaustive matchers must add arms.
+- **Reserved-prefix admission is now SET-membership** on `identity_type`, not scalar
+  equality (#366) — required by CC 3.4.7.1. Behavior-preserving for single-role keys;
+  newly ADMITS conformant folded multi-role keys (e.g. `{agent, lenscore_detector}`).
+
+verify pin **unchanged (v8.7.0)**; `Requires-Dist: ciris-verify>=8.0.0,<9` unchanged.
+
+### Added / Fixed
+- **#171** (CC 5.3.2.2 / §10.1.3) — crypto-gated **transit-write acceptance**: a
+  subject-side revocation (`consent:state:revoked` / subject `withdraws`) is accepted
+  as a non-durable transit local-tier row **iff its bound-hybrid signature verifies**,
+  making the `hard_case:consent_revocation_promotion_overdue` SLA fire end-to-end.
+  Also closed a `put_attestation` local-tier signature bypass.
+- **#227** (CC 4.4.3.5.1/5.6) — fountain **consent-decay eviction** (`sweep_consent_decay_once`):
+  disk-independent 14-day/90-day decay clock reusing the eviction mechanism.
+- **#365** (CC 3.4.7.2) — **`consent_role`** on the wire (Counter-RII): field + resolver
+  + `set_consent_role` (OQ-1 overwrite) + `consent_role_json`; hash-excluded.
+- **#366** (CC 3.4.8) — **`detection:*` admission gate** (`lenscore_detector`-only) + the
+  set-membership fix above; `truth_grounding:detection:*` cross-attestations stay ungated.
+- **#367 + #368** (CC 3.4.11–13 / 3.2) — **witness-targets-subject age_assurance** (a
+  witness graduates ANOTHER subject's I1 band via `attested_key_id`), which makes the CC
+  3.2 minor-guardianship admit drivable end-to-end; self-graduation rejected.
+- **#369** (CC 4.5.4 / §11.11) — **broadened no-moderator federate-apply gate keying** to
+  every substrate community-reference shape + `check_no_moderator_federate_json` probe.
+- **#370** (CC 6.1.5.2 §Q B2/B3/B5) — **pin-install surface** (`install_storage_budget_v1`,
+  V093 table, atomic anti-rollback) + B5 cache-before-pinned capacity-eviction ordering;
+  B6 hard-delete stays pin-blind (revocation still wins — the #359 test holds).
+- **#371** — **`apply_replicated_key_record`** (`owner_of`-gated upgrade-aware Key-plane
+  apply): an anchor-scrubbed record can auto-upgrade a stale self-signed row over
+  replication; monotonic, fail-closed on ambiguous owner.
+- **#372** (CC 3.4.7.1) — accord-conferred **`canonical`** identity_type role: admitted
+  only on an anchor-scrub-signed record, else `canonical_role_not_accord_conferred`
+  (fail-closed, monotonic across all write paths) + `is_canonical`/`list_canonical_servers`.
+
+Migrations V092 (`consent_role` index) + V093 (`storage_budget_installed`). Full suite
+green: **1355 pg+sqlite lib + integration + wheel + FFI smoke, 0 failed** (clean DB).
+
 ## [12.6.0] — 2026-07-04 — single-owner node invariant (CIRISConstitution#23)
 
 The `self` cohort boundary (CC 1.13.3.3 / CC 3.2) is defined by a node's owner,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "12.6.0"
+version = "13.0.0"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/migrations/postgres/lens/V092__federation_keys_consent_role.sql
+++ b/migrations/postgres/lens/V092__federation_keys_consent_role.sql
@@ -1,0 +1,58 @@
+-- V092 — Counter-RII `consent_role` consumer-query index
+-- (CIRISPersist#365, CC 3.4.7.2 `consent-counter`, v12.7.0).
+--
+-- # No new column — the substrate already shipped in V020
+--
+-- CC 3.4.7.2 ratified `federation_keys.consent_role` (the Counter-RII
+-- consent gate; RATCHET `FSD/COUNTER_RII_DETECTION.md`, Lean
+-- `ConsentGate.lean`) and declared it buildable — but the COLUMN
+-- already exists: V020 (v1.3.0, the CIRISAgent#760 §RC "consent role
+-- lock") added `consent_role TEXT NOT NULL DEFAULT 'unregistered'` with
+-- the CHECK vocabulary (unregistered / temporary / partnered /
+-- anonymous / authorized_review / peer). CC 3.4.7.2's "non-breaking
+-- against the shipped flat soft-delete substrate" wording is literal:
+-- the ratified OQ-1 semantics (a subsequent revocation OVERWRITES the
+-- prior record; flat, bounded, NO recursive chain embedded in the
+-- field) are exactly the V020 column's natural UPDATE semantics.
+--
+-- v12.7.0 therefore adds NO schema change to the column itself — it
+-- puts the field on the wire (`KeyRecord.consent_role`, `None` ⇔ the
+-- stored 'unregistered' default), adds the resolver
+-- (`consent_role_of` / Engine.consent_role_json) and the OQ-1
+-- overwrite surface (`set_consent_role`), and ships this index.
+--
+-- # What persist owns vs the consumer
+--
+--   * OQ-1 (non-recursive overwrite-on-revoke) — SUBSTRATE:
+--     `set_consent_role` is a flat single-column UPDATE; revoke = reset
+--     to 'unregistered'. Chain history, if a deployment wants it, lives
+--     in a separate audit surface — never in this field.
+--   * OQ-2 (`peer` escapes detection at any trust_mode) and OQ-3
+--     (`authorized_review` signal-eligible immediately post-window,
+--     no grace) — CONSUMER-applied detection signals (edge
+--     `ProbePatternObserver` / RATCHET) on the field persist carries.
+--
+-- # Excluded from persist_row_hash
+--
+-- `consent_role` is a MUTABLE operational role marker, not part of the
+-- signed registration content — `compute_persist_row_hash` drops it
+-- before hashing, so the OQ-1 overwrite never invalidates the
+-- registration hash, and pre-existing rows' hashes are untouched.
+
+-- ── Index ───────────────────────────────────────────────────────────
+--
+-- Partial index on rows that carry an assigned role. A Counter-RII
+-- consumer querying "which keys hold the `peer` (OQ-2) /
+-- `authorized_review` (OQ-3) role?" wants a focused index, not a
+-- full-table scan over a column that is 'unregistered' almost
+-- everywhere. Cardinality is small; the partial index documents the
+-- access intent.
+
+CREATE INDEX IF NOT EXISTS federation_keys_consent_role
+    ON cirislens.federation_keys (consent_role)
+    WHERE consent_role <> 'unregistered';
+
+-- ── Comment (V020's column, updated for the CC 3.4.7.2 ratification) ─
+
+COMMENT ON COLUMN cirislens.federation_keys.consent_role IS
+    'V020 (CIRISAgent#760 §RC lock) ratified by CC 3.4.7.2 consent-counter (CIRISPersist#365, v12.7.0) — Counter-RII consent_role. Single flat role token (unregistered / temporary / partnered / anonymous / authorized_review / peer) gating Counter-RII probe detection applied by a consumer (edge ProbePatternObserver / RATCHET). Mutable, overwrite-on-revoke (OQ-1) via Engine.set_consent_role; ''unregistered'' = no assigned role (wire None). Excluded from persist_row_hash — NOT part of the signed registration content.';

--- a/migrations/postgres/lens/V093__storage_budget_install.sql
+++ b/migrations/postgres/lens/V093__storage_budget_install.sql
@@ -1,0 +1,55 @@
+-- V092 — #370 §Q pin-INSTALL surface (CC 6.1.5.2 B2/B3/B5) (Postgres dialect).
+--
+-- #356 shipped `build_storage_budget_v1` / `verify_storage_budget_v1` as
+-- wire-negotiation objects only (verified-at-ingest, nothing stored), so a
+-- verified `StorageBudgetV1` could not GOVERN eviction. This migration adds
+-- the one small table that makes an owner's accepted budget durable pin
+-- STATE: `Engine::install_storage_budget_v1` verifies the bound-hybrid
+-- signature (PQC-mandatory, CC 5.3.2.4.3.1 store-path — verify BEFORE
+-- persistence) and upserts here; the disk-pressure eviction sweep reads it
+-- back to order candidates CACHE-BEFORE-PINNED (B5) and to hold the
+-- `pin_reserve_bytes` floor.
+--
+-- # Shape
+--
+-- One row per owner `node_id` (the budget is a single-owner
+-- self-declaration, CC 5.3.2.3 anti-rollback aspect). `revision` is
+-- monotonic: the upsert is CONDITIONAL (`WHERE installed.revision <
+-- EXCLUDED.revision`) so a lower-or-equal revision from the same node_id is
+-- refused ATOMICALLY at the row — §Q B3 anti-rollback cannot be raced past
+-- the Engine-side check. `scopes` / `pinned_class` are denormalized copies
+-- of the wire fields (queryability); `wire` is the signed wire JSON
+-- VERBATIM so any consumer can re-verify the installed budget end-to-end
+-- (persist never re-derives signed bytes).
+--
+-- # What this table is NOT (§Q B6 / N5 — CIRISPersist#359)
+--
+-- Pin state governs CAPACITY eviction only. The revocation path
+-- (`evict_fountain_content_hard_delete`) takes `(content_id, corpus_kind)`
+-- and reads NOTHING from this table — pinning never defeats revocation.
+-- That pin-blindness is locked by tests/fountain_content.rs (j)/(k).
+--
+-- No TimescaleDB (operator directive): plain postgres:16, ordinary table.
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+CREATE TABLE IF NOT EXISTS cirislens.storage_budget_installed (
+    -- The owner node this budget binds (StorageBudgetV1.node_id).
+    node_id       TEXT PRIMARY KEY,
+    -- Monotonic revision; higher supersedes, lower/equal is refused
+    -- (§Q B3 anti-rollback).
+    revision      BIGINT NOT NULL CHECK (revision >= 0),
+    -- Epoch keying (CC 5.1).
+    epoch_id      TEXT NOT NULL,
+    -- Denormalized per-cohort_scope allotments:
+    -- [{cohort_scope, budget_bytes, pin_reserve_bytes}, ...].
+    -- NEVER self/family (B3 suppression — enforced at verify).
+    scopes        JSONB NOT NULL,
+    -- Denormalized corpus subject_kinds the owner elects to pin (B2-ii).
+    pinned_class  JSONB NOT NULL,
+    -- The signed StorageBudgetV1 wire JSON VERBATIM (payload + both
+    -- signature halves) — re-verifiable at any time.
+    wire          JSONB NOT NULL,
+    -- When this revision was accepted locally (caller-supplied so both
+    -- dialects agree byte-for-byte on the row).
+    installed_at  TIMESTAMPTZ NOT NULL
+);

--- a/migrations/sqlite/lens/V092__federation_keys_consent_role.sql
+++ b/migrations/sqlite/lens/V092__federation_keys_consent_role.sql
@@ -1,0 +1,36 @@
+-- V092 — Counter-RII `consent_role` consumer-query index,
+-- SQLite dialect (CIRISPersist#365, CC 3.4.7.2 `consent-counter`,
+-- v12.7.0).
+--
+-- Postgres parity (postgres/lens/V092): same index + same intent, with
+-- the following dialect translations:
+--
+--   PostgreSQL                          → SQLite
+--   ─────────────────────────────────────────────────────────────────
+--   COMMENT ON COLUMN ...               → (no equivalent — SQLite has no
+--                                          column-comment facility; docs
+--                                          live in source + the PG twin)
+--
+-- # No new column — the substrate already shipped in V020
+--
+-- See postgres/lens/V092 for the full rationale. Summary: CC 3.4.7.2
+-- ratified `federation_keys.consent_role`, but V020 (the CIRISAgent#760
+-- §RC "consent role lock") already added the column (`TEXT NOT NULL
+-- DEFAULT 'unregistered'`; vocabulary unregistered / temporary /
+-- partnered / anonymous / authorized_review / peer — SQLite's ALTER
+-- cannot add a CHECK, so the vocabulary is enforced at the Rust
+-- admission layer on BOTH backends for symmetry). v12.7.0 puts the
+-- field on the wire (`KeyRecord.consent_role`, `None` ⇔ 'unregistered'),
+-- adds the resolver + the OQ-1 overwrite surface (`set_consent_role`),
+-- and ships this index. OQ-2 / OQ-3 detection signals are
+-- consumer-applied (edge `ProbePatternObserver` / RATCHET).
+
+-- ── Index ───────────────────────────────────────────────────────────
+--
+-- Partial index on rows that carry an assigned role — same intent as
+-- the PG twin (a Counter-RII consumer querying by role). SQLite partial
+-- indexes use `WHERE` exactly like Postgres.
+
+CREATE INDEX IF NOT EXISTS federation_keys_consent_role
+    ON federation_keys (consent_role)
+    WHERE consent_role <> 'unregistered';

--- a/migrations/sqlite/lens/V093__storage_budget_install.sql
+++ b/migrations/sqlite/lens/V093__storage_budget_install.sql
@@ -1,0 +1,33 @@
+-- V092 — #370 §Q pin-INSTALL surface (CC 6.1.5.2 B2/B3/B5) (SQLite dialect).
+--
+-- Postgres parity: postgres/lens/V092. See that file for the full design
+-- rationale. One row per owner node_id; conditional monotonic-revision
+-- upsert = §Q B3 anti-rollback enforced atomically at the row; `wire` is
+-- the signed StorageBudgetV1 wire JSON VERBATIM (re-verifiable). Pin state
+-- governs CAPACITY eviction only — the revocation path
+-- (`evict_fountain_content_hard_delete`) never reads this table (§Q B6/N5,
+-- CIRISPersist#359).
+--
+-- SQLite dialect: bare table name (no schema), TEXT RFC-3339 timestamp,
+-- `json_valid()` CHECKs in place of JSONB.
+--
+-- No explicit BEGIN/COMMIT — refinery wraps each migration in a transaction.
+
+CREATE TABLE IF NOT EXISTS storage_budget_installed (
+    -- The owner node this budget binds (StorageBudgetV1.node_id).
+    node_id       TEXT PRIMARY KEY,
+    -- Monotonic revision; higher supersedes, lower/equal is refused
+    -- (§Q B3 anti-rollback).
+    revision      INTEGER NOT NULL CHECK (revision >= 0),
+    -- Epoch keying (CC 5.1).
+    epoch_id      TEXT NOT NULL,
+    -- Denormalized per-cohort_scope allotments (JSON array; never
+    -- self/family — B3 suppression, enforced at verify).
+    scopes        TEXT NOT NULL CHECK (json_valid(scopes)),
+    -- Denormalized corpus subject_kinds the owner elects to pin (B2-ii).
+    pinned_class  TEXT NOT NULL CHECK (json_valid(pinned_class)),
+    -- The signed StorageBudgetV1 wire JSON VERBATIM.
+    wire          TEXT NOT NULL CHECK (json_valid(wire)),
+    -- RFC-3339; caller-supplied for cross-dialect parity.
+    installed_at  TEXT NOT NULL
+);

--- a/python/ciris_persist/ciris_persist.pyi
+++ b/python/ciris_persist/ciris_persist.pyi
@@ -333,6 +333,61 @@ class Engine:
         read (`revocations_for` + the key's `valid_until`).
         """
 
+    def adopt_scrub_upgrade(
+        self,
+        signed_key_record_json: str,
+    ) -> str:
+        """v12.2.0 (CIRISPersist#351) — adopt-scrub-**upgrade** this node's
+        own key row: replace its self-signed record with the
+        accord-anchor-scrubbed one (same `key_id` + pubkey) so it can root.
+        FFI mirror of the Rust `Engine.adopt_scrub_upgrade`.
+
+        `signed_key_record_json` is the granting-authority-scrubbed
+        `SignedKeyRecord` (`scrub_key_id` = an accord holder). Verifies the
+        scrub-signature (Strict, same gate as `register_federation_key`)
+        THEN the backend's monotonic gated UPDATE.
+
+        Returns:
+            ``"upgraded"`` or ``"already_adopted"``.
+
+        Raises:
+            ValueError: JSON decode failure, verification failure, pubkey
+                change, anchored-to-a-different-record, or missing row.
+            RuntimeError: backend / IO error.
+        """
+
+    def apply_replicated_key_record(
+        self,
+        signed_key_record_json: str,
+    ) -> str:
+        """v12.7.0 (CIRISPersist#371) — **upgrade-aware replicated
+        Key-plane apply**. FFI mirror of the Rust
+        `Engine.apply_replicated_key_record` — the apply the replication
+        bridge routes `apply_key` to instead of raw `put_public_key`
+        (which keeps its insert-only semantics for direct registration).
+
+        `signed_key_record_json` is the replicated `SignedKeyRecord`.
+
+        Returns:
+            ``"inserted"`` — new key_id, stored with every put_public_key
+            admission gate intact; ``"upgraded"`` — the existing
+            self-signed row adopted the anchor-scrubbed record (same
+            hybrid pubkeys, scrub Strict-verified against the
+            directory-resolved scrubber, and the v12.6.0
+            ``owner_of(key_id)`` gate resolved exactly one live owner);
+            ``"unchanged"`` — byte-identical re-apply; ``"refused"`` —
+            pubkey swap / anchored-to-self downgrade / re-scrub /
+            conflicting version / unverifiable scrub / unowned or
+            ambiguous owner (fail-closed; the existing row is untouched).
+            Refusals are outcomes, not exceptions, so an apply loop stays
+            total over unsolicited records.
+
+        Raises:
+            ValueError: SignedKeyRecord JSON decode failure or a
+                malformed record no policy can classify.
+            RuntimeError: backend / IO error.
+        """
+
     def register_self_federation_key(
         self,
         identity_type: str,

--- a/src/cirisnode/postgres.rs
+++ b/src/cirisnode/postgres.rs
@@ -2325,6 +2325,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::SignedKeyRecord { record })
@@ -2531,6 +2532,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         // Tolerate an exact-content idempotent re-seed on a reused PG (the
         // lead's local docker DB persists across runs); a genuine
@@ -3508,6 +3510,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         use crate::federation::FederationDirectory;
         backend

--- a/src/cirisnode/sqlite.rs
+++ b/src/cirisnode/sqlite.rs
@@ -2695,6 +2695,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::SignedKeyRecord { record })
@@ -3288,6 +3289,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         use crate::federation::FederationDirectory;
         backend
@@ -3549,6 +3551,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::types::SignedKeyRecord { record: rec })
@@ -3681,6 +3684,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::types::SignedKeyRecord { record: rec })

--- a/src/cirisnode/takedown_handler.rs
+++ b/src/cirisnode/takedown_handler.rs
@@ -345,6 +345,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1754,6 +1754,7 @@ impl Engine {
             persist_row_hash: String::new(),
             roles,
             attestation_evidence: None,
+            consent_role: None,
         };
         let signed = crate::federation::SignedKeyRecord { record };
 
@@ -5803,6 +5804,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         sq.put_public_key(SignedKeyRecord {
             record: suspect_key,
@@ -6157,6 +6159,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         pg.put_public_key(SignedKeyRecord { record: suspect })
             .await
@@ -6819,6 +6822,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         pg.put_public_key(crate::federation::SignedKeyRecord { record: key_record })
             .await
@@ -6909,6 +6913,7 @@ mod tests {
                 persist_row_hash: String::new(),
                 roles: Vec::new(),
                 attestation_evidence: None,
+                consent_role: None,
             },
         }
     }
@@ -7590,6 +7595,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         sq.put_public_key(SignedKeyRecord { record }).await.unwrap();
     }
@@ -7758,6 +7764,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         pg.put_public_key(SignedKeyRecord { record }).await.unwrap();
 
@@ -8195,6 +8202,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         sq.put_public_key(SignedKeyRecord { record })
             .await
@@ -9851,6 +9859,7 @@ mod tests {
                 persist_row_hash: String::new(),
                 roles: Vec::new(),
                 attestation_evidence: None,
+                consent_role: None,
             },
         })
         .await

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1884,6 +1884,22 @@ impl Engine {
     /// `attested_key_id` defaults to the derived key_id (self-attestation)
     /// when [`EmitAttestationInput::attested_key_id`] is `None`.
     ///
+    /// v12.7.0 (CIRISPersist#368, CC 3.4.11/3.4.13) —
+    /// [`EmitAttestationInput::attested_key_id`] names the row's **SUBJECT**
+    /// (the natural CEG cross-subject edge target, exactly how
+    /// [`Self::grant_delegation`] keys a `delegates_to` by its recipient).
+    /// This is the **witness-targets-subject** age-assurance surface: a
+    /// `witness`-role signer emits `attestation_type =
+    /// "age_assurance:{level}:{band}:v1"` with `attested_key_id =
+    /// Some(subject)` and the SUBJECT's
+    /// [`age_band`](crate::federation::age::age_band) graduates (the witness
+    /// rung outranks the subject's `age_self_declared:*`). The identity gate
+    /// is unchanged (only `identity_type ⊇ {witness}` may emit the prefix),
+    /// and a subject cannot graduate ITSELF: attester==attested on
+    /// `age_assurance:*` is rejected at admission
+    /// ([`Error::AgeAssuranceSelfEmissionRejected`](crate::federation::Error::AgeAssuranceSelfEmissionRejected),
+    /// CC 3.4.11 "a subject MUST NOT emit on `age_assurance:`").
+    ///
     /// This is the single correct implementation consumers (Node / Lens /
     /// Registry / Server, and persist's own withdraws producer) compose
     /// against instead of hand-rolling the ~50-line recipe. For the
@@ -2080,6 +2096,20 @@ impl Engine {
     /// emitted row: a node-ONLY recipient may carry only `infra:*` scopes —
     /// use [`Self::steward_bind`] for that case. `#247`-derived
     /// `attesting_key_id` is internal.
+    ///
+    /// v12.7.0 (CIRISPersist#367, CC 3.2) — a **`user`-role recipient** is
+    /// governed by the user-target steward-binding gate
+    /// ([`check_user_target_steward_binding_admission`](crate::federation::admission::check_user_target_steward_binding_admission)):
+    /// the ONLY admissible user-target shapes are **minor-guardianship**
+    /// (recipient is a PROVEN minor — a witness `age_assurance:*:minor`
+    /// about it, emittable cross-subject per #368 — and the signer is a
+    /// PROVEN adult `user`) and the narrow CC 3.4.12 adult-incapacity
+    /// aperture. Everything else rejects
+    /// (`federation_user_target_steward_binding_forbidden`). Withdrawing the
+    /// guardianship edge ([`Self::revoke_delegation`]) leaves the minor
+    /// steward-less and
+    /// [`is_steward_bound`](crate::federation::admission::is_steward_bound)
+    /// fails secure (`false`).
     #[cfg(any(feature = "postgres", feature = "sqlite"))]
     pub async fn grant_delegation(
         &self,
@@ -8510,6 +8540,433 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.kind(), "federation_node_agency_forbidden");
+    }
+
+    // ── v12.7.0 (CIRISPersist#368 + #367, CC 3.4.11/3.4.13 + CC 3.2) ──
+    // Witness-targets-subject age graduation over the REAL emit path, and
+    // the minor-guardianship admit + steward-less-minor fail-secure driven
+    // end-to-end over `emit_attestation` / `grant_delegation` /
+    // `revoke_delegation`.
+
+    /// A `witness`-role `federation_keys` row keyed by `derived_key_id` with
+    /// `pubkey_label`'s REAL deterministic hybrid pubkeys — the registered
+    /// age-assurance verifier shape the `age_assurance:` reserved-prefix
+    /// rule requires of the emitter.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    fn witness_test_key_derived_for(
+        derived_key_id: &str,
+        pubkey_label: &str,
+    ) -> crate::federation::SignedKeyRecord {
+        let mut signed = sweeper_test_key_derived_for(derived_key_id, pubkey_label);
+        signed.record.identity_type = crate::federation::types::identity_type::WITNESS.into();
+        signed
+    }
+
+    /// #368 — the witness-targets-subject age flow over the REAL
+    /// `Engine::emit_attestation` path (sqlite): a witness names a DIFFERENT
+    /// subject via `EmitAttestationInput::attested_key_id` and THAT subject's
+    /// `age_band` graduates (witness outranks the subject's own
+    /// self-declared rung); the witness CANNOT graduate itself
+    /// (attester==attested rejected); a non-witness emitter is still
+    /// refused by the unchanged identity gate.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn witness_targets_subject_age_graduation_over_emit_sqlite() {
+        use crate::federation::age::{age_band, age_band_fine, AgeBand, AgeBandFine};
+        use crate::federation::FederationDirectory;
+
+        let w_signer = crate::federation::tier_ingest::test_support::local_signer("age-witness");
+        let t_signer = crate::federation::tier_ingest::test_support::local_signer("age-subject");
+        let w = w_signer.derived_key_id();
+        let t = t_signer.derived_key_id();
+        let engine = Engine::with_signer(w_signer.clone(), "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        sq.put_public_key(witness_test_key_derived_for(&w, "age-witness"))
+            .await
+            .expect("seed witness");
+        sq.put_public_key(user_test_key_derived_for(&t, "age-subject"))
+            .await
+            .expect("seed subject");
+
+        // The subject self-declares MINOR (self rung; attested defaults to
+        // the emitter — subject-signed by design).
+        let self_minor = crate::federation::EmitAttestationInput::with_envelope(
+            "age_self_declared:minor:v1",
+            serde_json::json!({ "id": "wtse-self-minor" }),
+        );
+        engine
+            .emit_attestation(&t_signer, self_minor)
+            .await
+            .expect("self-declared minor admits");
+        assert_eq!(engine.age_band(&t).await.unwrap(), AgeBand::Minor);
+
+        // WITNESS-TARGETS-SUBJECT: the witness emits `age_assurance:*` ABOUT
+        // the subject by carrying it in `attested_key_id` — the #368 surface.
+        let mut cross = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:government:adult:v1",
+            serde_json::json!({ "id": "wtse-w-adult" }),
+        );
+        cross.attested_key_id = Some(t.clone());
+        let att_id = engine
+            .emit_attestation(&w_signer, cross)
+            .await
+            .expect("witness-targets-subject age_assurance admitted");
+        let row = sq.get_attestation(&att_id).await.unwrap().expect("row");
+        assert_eq!(row.attesting_key_id, w, "attester = the witness");
+        assert_eq!(row.attested_key_id, t, "subject rides attested_key_id");
+        // The SUBJECT's band graduates (witness outranks its self-minor).
+        assert_eq!(
+            engine.age_band(&t).await.unwrap(),
+            AgeBand::Adult,
+            "a witness row ABOUT the subject graduates the SUBJECT's band",
+        );
+        assert_eq!(
+            age_band_fine(&*sq, &t).await.unwrap(),
+            AgeBandFine::Adult,
+            "the finer resolution graduates too",
+        );
+
+        // SELF-graduation via the witness prefix is refused: the same
+        // witness emitting with the default (self) attested_key_id.
+        let selfie = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:provider:adult:v1",
+            serde_json::json!({ "id": "wtse-w-self" }),
+        );
+        let e = engine
+            .emit_attestation(&w_signer, selfie)
+            .await
+            .expect_err("a subject must not emit its own age assurance");
+        assert_eq!(e.kind(), "federation_age_assurance_self_emission_rejected");
+        assert_eq!(
+            age_band(&*sq, &w).await.unwrap(),
+            AgeBand::Unknown,
+            "the witness's own band is untouched",
+        );
+
+        // Identity gate unchanged: the (non-witness) SUBJECT cross-attesting
+        // the witness's age is refused (reserved prefix needs a witness).
+        let mut bad = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:provider:adult:v1",
+            serde_json::json!({ "id": "wtse-t-cross" }),
+        );
+        bad.attested_key_id = Some(w.clone());
+        let e = engine
+            .emit_attestation(&t_signer, bad)
+            .await
+            .expect_err("a non-witness emitter is refused");
+        assert_eq!(e.kind(), "federation_reserved_prefix_emitter_mismatch");
+    }
+
+    /// #368 PG twin of
+    /// [`witness_targets_subject_age_graduation_over_emit_sqlite`] — the
+    /// cross-subject graduation + self-graduation rejection over the live
+    /// Postgres `put_attestation` gates (pg/sqlite symmetry). Skips when
+    /// `CIRIS_PERSIST_TEST_PG_URL` is unset.
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn witness_targets_subject_age_graduation_over_emit_postgres() {
+        use crate::federation::age::{age_band, AgeBand};
+        use crate::federation::FederationDirectory;
+
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let run = uuid::Uuid::new_v4().simple().to_string();
+        let w_label = format!("age-w-{run}");
+        let t_label = format!("age-t-{run}");
+        let w_signer = crate::federation::tier_ingest::test_support::local_signer(&w_label);
+        let t_signer = crate::federation::tier_ingest::test_support::local_signer(&t_label);
+        let w = w_signer.derived_key_id();
+        let t = t_signer.derived_key_id();
+        let engine = Engine::with_signer(w_signer.clone(), &dsn)
+            .await
+            .expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend");
+        pg.put_public_key(witness_test_key_derived_for(&w, &w_label))
+            .await
+            .expect("seed witness");
+        pg.put_public_key(user_test_key_derived_for(&t, &t_label))
+            .await
+            .expect("seed subject");
+
+        // Subject self-declares minor.
+        engine
+            .emit_attestation(
+                &t_signer,
+                crate::federation::EmitAttestationInput::with_envelope(
+                    "age_self_declared:minor:v1",
+                    serde_json::json!({ "id": format!("pgw-self-{run}") }),
+                ),
+            )
+            .await
+            .expect("self-declared minor admits");
+        assert_eq!(engine.age_band(&t).await.unwrap(), AgeBand::Minor);
+
+        // Witness graduates the SUBJECT cross-subject.
+        let mut cross = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:government:adult:v1",
+            serde_json::json!({ "id": format!("pgw-adult-{run}") }),
+        );
+        cross.attested_key_id = Some(t.clone());
+        engine
+            .emit_attestation(&w_signer, cross)
+            .await
+            .expect("witness-targets-subject admitted on postgres");
+        assert_eq!(engine.age_band(&t).await.unwrap(), AgeBand::Adult);
+
+        // Self-graduation via the witness prefix rejected on PG too.
+        let e = engine
+            .emit_attestation(
+                &w_signer,
+                crate::federation::EmitAttestationInput::with_envelope(
+                    "age_assurance:provider:adult:v1",
+                    serde_json::json!({ "id": format!("pgw-self-adult-{run}") }),
+                ),
+            )
+            .await
+            .expect_err("self-emission rejected on postgres");
+        assert_eq!(e.kind(), "federation_age_assurance_self_emission_rejected");
+        assert_eq!(age_band(&**pg, &w).await.unwrap(), AgeBand::Unknown);
+    }
+
+    /// #367 — the FULL CC 3.2 minor-guardianship flow over the REAL paths
+    /// (sqlite): a witness attests T minor (cross-subject, #368) → the
+    /// steward-less minor fails secure → S's binding is refused until S is a
+    /// PROVEN adult → witness attests S adult → `grant_delegation(S → T)` is
+    /// ADMITTED → `revoke_delegation` leaves the minor steward-less again
+    /// (fail-secure). An age-unverified user target stays rejected.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn minor_guardianship_grant_and_withdraw_end_to_end_sqlite() {
+        use crate::federation::admission::{is_steward_bound, steward_bindings_of};
+        use crate::federation::age::AgeBand;
+        use crate::federation::types::delegation_scope;
+        use crate::federation::FederationDirectory;
+
+        let w_signer = crate::federation::tier_ingest::test_support::local_signer("mg-witness");
+        let s_signer = crate::federation::tier_ingest::test_support::local_signer("mg-steward");
+        let w = w_signer.derived_key_id();
+        let s = s_signer.derived_key_id();
+        let engine = Engine::with_signer(w_signer.clone(), "sqlite::memory:")
+            .await
+            .expect("engine");
+        let sq = engine.sqlite_backend().expect("sqlite").clone();
+        sq.put_public_key(witness_test_key_derived_for(&w, "mg-witness"))
+            .await
+            .expect("seed witness");
+        sq.put_public_key(user_test_key_derived_for(&s, "mg-steward"))
+            .await
+            .expect("seed steward");
+        // The ward T and an age-unverified control U (emit nothing; plain
+        // registered user-role keys).
+        let mut t_key = sweeper_test_key("mg-ward");
+        t_key.record.identity_type = crate::federation::types::identity_type::USER.into();
+        sq.put_public_key(t_key).await.expect("seed ward");
+        let mut u_key = sweeper_test_key("mg-unverified");
+        u_key.record.identity_type = crate::federation::types::identity_type::USER.into();
+        sq.put_public_key(u_key).await.expect("seed unverified");
+
+        // Age-unverified user self-anchors (presumption of sovereignty).
+        assert!(is_steward_bound(&*sq, "mg-ward").await.unwrap());
+
+        // Witness attests T MINOR (the #368 cross-subject emit).
+        let mut minor = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:provider:minor:v1",
+            serde_json::json!({ "id": "mg-w-minor" }),
+        );
+        minor.attested_key_id = Some("mg-ward".to_owned());
+        engine
+            .emit_attestation(&w_signer, minor)
+            .await
+            .expect("witness attests the ward minor");
+        assert_eq!(engine.age_band("mg-ward").await.unwrap(), AgeBand::Minor);
+        // A PROVEN minor with no steward fails secure.
+        assert!(
+            !is_steward_bound(&*sq, "mg-ward").await.unwrap(),
+            "a steward-less proven minor must not self-anchor",
+        );
+        assert!(steward_bindings_of(&*sq, "mg-ward")
+            .await
+            .unwrap()
+            .is_empty());
+
+        // S is not yet a PROVEN adult → the binding is refused.
+        let e = engine
+            .grant_delegation(
+                &s_signer,
+                "mg-ward",
+                vec![delegation_scope::AGENCY_ACT_ON_BEHALF.into()],
+                false,
+            )
+            .await
+            .expect_err("an unproven granter cannot steward a minor");
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(reason, "granter_not_adult_user");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden, got {other:?}"),
+        }
+
+        // Witness attests S ADULT (cross-subject again).
+        let mut adult = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:government:adult:v1",
+            serde_json::json!({ "id": "mg-w-adult" }),
+        );
+        adult.attested_key_id = Some(s.clone());
+        engine
+            .emit_attestation(&w_signer, adult)
+            .await
+            .expect("witness attests the steward adult");
+        assert_eq!(engine.age_band(&s).await.unwrap(), AgeBand::Adult);
+
+        // The CC 3.2 positive case: adult user S → proven-minor T ADMITTED
+        // over the REAL `grant_delegation` path.
+        let grant_id = engine
+            .grant_delegation(
+                &s_signer,
+                "mg-ward",
+                vec![delegation_scope::AGENCY_ACT_ON_BEHALF.into()],
+                false,
+            )
+            .await
+            .expect("adult-user → proven-minor guardianship is ADMITTED (CC 3.2)");
+        assert!(is_steward_bound(&*sq, "mg-ward").await.unwrap());
+        assert_eq!(
+            steward_bindings_of(&*sq, "mg-ward").await.unwrap(),
+            vec![s.clone()],
+            "the minor is steward-bound to exactly S",
+        );
+
+        // Withdraw the guardianship → the minor is steward-less again and
+        // the liveness predicates fail secure.
+        engine
+            .revoke_delegation(&s_signer, &grant_id, "mg-ward")
+            .await
+            .expect("revoke_delegation");
+        assert!(
+            !is_steward_bound(&*sq, "mg-ward").await.unwrap(),
+            "a minor whose only guardianship edge was withdrawn fails secure",
+        );
+        assert!(
+            steward_bindings_of(&*sq, "mg-ward")
+                .await
+                .unwrap()
+                .is_empty(),
+            "no anchors remain after the withdraw",
+        );
+
+        // An age-UNVERIFIED user target is still rejected (presumption of
+        // sovereignty — nothing in this cut widened the wall).
+        let e = engine
+            .grant_delegation(
+                &s_signer,
+                "mg-unverified",
+                vec![delegation_scope::AGENCY_ACT_ON_BEHALF.into()],
+                false,
+            )
+            .await
+            .expect_err("an unverified user target stays rejected");
+        match e {
+            crate::federation::Error::UserTargetStewardBindingForbidden { reason, .. } => {
+                assert_eq!(reason, "target_age_unverified");
+            }
+            other => panic!("expected UserTargetStewardBindingForbidden, got {other:?}"),
+        }
+    }
+
+    /// #367 PG twin of
+    /// [`minor_guardianship_grant_and_withdraw_end_to_end_sqlite`] — the
+    /// witness→minor attest → adult-steward grant → withdraw → fail-secure
+    /// arc over the live Postgres gates. Skips when
+    /// `CIRIS_PERSIST_TEST_PG_URL` is unset.
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn minor_guardianship_grant_and_withdraw_end_to_end_postgres() {
+        use crate::federation::admission::{is_steward_bound, steward_bindings_of};
+        use crate::federation::age::AgeBand;
+        use crate::federation::types::delegation_scope;
+        use crate::federation::FederationDirectory;
+
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let run = uuid::Uuid::new_v4().simple().to_string();
+        let w_label = format!("mg-w-{run}");
+        let s_label = format!("mg-s-{run}");
+        let ward = format!("mg-ward-{run}");
+        let w_signer = crate::federation::tier_ingest::test_support::local_signer(&w_label);
+        let s_signer = crate::federation::tier_ingest::test_support::local_signer(&s_label);
+        let w = w_signer.derived_key_id();
+        let s = s_signer.derived_key_id();
+        let engine = Engine::with_signer(w_signer.clone(), &dsn)
+            .await
+            .expect("pg engine");
+        let pg = engine.postgres_backend().expect("pg backend");
+        pg.put_public_key(witness_test_key_derived_for(&w, &w_label))
+            .await
+            .expect("seed witness");
+        pg.put_public_key(user_test_key_derived_for(&s, &s_label))
+            .await
+            .expect("seed steward");
+        let mut t_key = sweeper_test_key(&ward);
+        t_key.record.identity_type = crate::federation::types::identity_type::USER.into();
+        pg.put_public_key(t_key).await.expect("seed ward");
+
+        // Witness attests T minor + S adult (cross-subject, #368).
+        let mut minor = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:provider:minor:v1",
+            serde_json::json!({ "id": format!("mgp-minor-{run}") }),
+        );
+        minor.attested_key_id = Some(ward.clone());
+        engine
+            .emit_attestation(&w_signer, minor)
+            .await
+            .expect("witness attests ward minor");
+        let mut adult = crate::federation::EmitAttestationInput::with_envelope(
+            "age_assurance:government:adult:v1",
+            serde_json::json!({ "id": format!("mgp-adult-{run}") }),
+        );
+        adult.attested_key_id = Some(s.clone());
+        engine
+            .emit_attestation(&w_signer, adult)
+            .await
+            .expect("witness attests steward adult");
+        assert_eq!(engine.age_band(&ward).await.unwrap(), AgeBand::Minor);
+        assert_eq!(engine.age_band(&s).await.unwrap(), AgeBand::Adult);
+        assert!(
+            !is_steward_bound(&**pg, &ward).await.unwrap(),
+            "steward-less proven minor fails secure on postgres",
+        );
+
+        // Adult user → proven minor: ADMITTED; withdraw → fail-secure.
+        let grant_id = engine
+            .grant_delegation(
+                &s_signer,
+                &ward,
+                vec![delegation_scope::AGENCY_ACT_ON_BEHALF.into()],
+                false,
+            )
+            .await
+            .expect("guardianship admitted on postgres");
+        assert_eq!(
+            steward_bindings_of(&**pg, &ward).await.unwrap(),
+            vec![s.clone()],
+        );
+        engine
+            .revoke_delegation(&s_signer, &grant_id, &ward)
+            .await
+            .expect("revoke_delegation");
+        assert!(
+            !is_steward_bound(&**pg, &ward).await.unwrap(),
+            "withdrawn guardianship leaves the minor steward-less (fail-secure)",
+        );
+        assert!(steward_bindings_of(&**pg, &ward).await.unwrap().is_empty());
     }
 
     /// #249 — the add_moderator ↔ is_named_moderator round-trip: an

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3997,6 +3997,37 @@ impl Engine {
         }
     }
 
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — is `key_id` a **canonical /
+    /// founding bootstrap server**? True iff its `federation_keys` row's
+    /// `identity_type` set contains `canonical`. Because the admission gate
+    /// [`check_canonical_role_admission`](crate::federation::check_canonical_role_admission)
+    /// only ever admits `canonical` on an anchor-scrub-conferred record, a
+    /// `true` here means the node was conferred the role by a HUMANITY_ACCORD
+    /// holder — it cannot be self-claimed. `false` for an unknown key or a
+    /// non-canonical row.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn is_canonical(&self, key_id: &str) -> Result<bool, crate::federation::Error> {
+        let directory = self.federation_directory();
+        crate::federation::is_canonical(directory.as_ref(), key_id).await
+    }
+
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — enumerate the **canonical /
+    /// founding bootstrap servers**: all `federation_keys` rows whose
+    /// `identity_type` set contains `canonical`, stable-sorted by `key_id`.
+    /// Every returned row is (by the admission gate) anchor-scrub-conferred —
+    /// none is self-claimed. Dispatches to the backend's inherent enumerator.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn list_canonical_servers(
+        &self,
+    ) -> Result<Vec<crate::federation::KeyRecord>, crate::federation::Error> {
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.list_canonical_servers().await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.list_canonical_servers().await,
+        }
+    }
+
     /// v8.8.0 (CIRISPersist#234, CEG 1.0-RC28/RC29 §5.6.8.15) — the
     /// symmetric **deregister** path: the revocation teeth a withdrawn
     /// `consent:replication` relies on.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2873,6 +2873,8 @@ impl Engine {
                 ),
                 subject_key_ids: Vec::new(),
                 cohort_scope: cohort_scope::SELF.to_owned(),
+                scrub_signature_classical: None,
+                scrub_signature_pqc: None,
             })
             .await?;
         let accept_id = directory
@@ -2888,6 +2890,8 @@ impl Engine {
                 ),
                 subject_key_ids: Vec::new(),
                 cohort_scope: cohort_scope::SELF.to_owned(),
+                scrub_signature_classical: None,
+                scrub_signature_pqc: None,
             })
             .await?;
 
@@ -2912,6 +2916,8 @@ impl Engine {
                 ),
                 subject_key_ids: Vec::new(),
                 cohort_scope: cohort_scope::SELF.to_owned(),
+                scrub_signature_classical: None,
+                scrub_signature_pqc: None,
             })
             .await?;
 
@@ -7625,6 +7631,8 @@ mod tests {
             }),
             subject_key_ids: vec![],
             cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+            scrub_signature_classical: None,
+            scrub_signature_pqc: None,
         };
         let att_id = sq.attestation_upsert_local(input).await.unwrap();
 
@@ -7765,6 +7773,8 @@ mod tests {
             }),
             subject_key_ids: vec![],
             cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+            scrub_signature_classical: None,
+            scrub_signature_pqc: None,
         };
         let att_id = pg.attestation_upsert_local(input).await.unwrap();
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3637,6 +3637,51 @@ impl Engine {
         }
     }
 
+    /// v12.7.0 (CIRISPersist#371) — **upgrade-aware replicated Key-plane
+    /// apply**: the anti-entropy apply the edge replication bridge routes
+    /// `apply_key` to instead of raw
+    /// [`put_public_key`](crate::federation::FederationDirectory::put_public_key)
+    /// (which keeps its insert-only semantics for direct
+    /// claim/peering/registration — no behavior change there). With this,
+    /// an accord-holder-scrubbed record for a node the receiver already
+    /// holds a **self-signed** row for auto-upgrades that row in place, so
+    /// the genesis-mesh seed becomes pure owned-node replication and stale
+    /// self-signed copies on sibling nodes heal — no per-node
+    /// `adopt-scrubbed` endpoint call ([`adopt_scrub_upgrade`](Self::adopt_scrub_upgrade)
+    /// itself is unchanged and remains available; consumers retire the
+    /// endpoint separately).
+    ///
+    /// Decision table + gate composition live in the shared
+    /// [`plan_replicated_key_apply`](crate::federation::register::plan_replicated_key_apply):
+    /// fresh `key_id` ⇒ insert with every `put_public_key` admission gate
+    /// intact; existing self-signed row + incoming anchor-scrubbed record ⇒
+    /// upgrade iff same hybrid pubkeys AND the scrub verifies through the
+    /// [`verify_key_registration`](crate::federation::verify_key_registration)
+    /// `Strict` gate (scrubber resolved from the directory — the seeded
+    /// HUMANITY_ACCORD anchor) AND
+    /// [`owner_of`](crate::federation::admission::owner_of) resolves exactly
+    /// one live owner (v12.6.0; unowned/ambiguous ⇒ fail-closed);
+    /// byte-identical ⇒ `Unchanged`; anything else (downgrade, re-scrub,
+    /// pubkey swap, conflicting version) ⇒ `Refused`, row untouched.
+    ///
+    /// Unlike [`adopt_scrub_upgrade`](Self::adopt_scrub_upgrade)'s
+    /// Engine-layer verify split, the verification is INSIDE the backend
+    /// method (it only binds on the upgrade transition — a fresh insert
+    /// keeps `put_public_key`'s as-today semantics), so no caller can reach
+    /// the upgrade unverified. This wrapper is pure dispatch.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn apply_replicated_key_record(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, crate::federation::Error> {
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.apply_replicated_key_record(record).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.apply_replicated_key_record(record).await,
+        }
+    }
+
     /// v8.8.0 (CIRISPersist#234, CEG 1.0-RC28/RC29 §5.6.8.15) — the
     /// symmetric **deregister** path: the revocation teeth a withdrawn
     /// `consent:replication` relies on.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -841,14 +841,77 @@ impl Engine {
             }
         };
 
+        // v12.7.0 (§Q B5 / CIRISPersist#370) — fold the INSTALLED
+        // StorageBudgetV1 state (V092; written only after the PQC-mandatory
+        // verify + B3 anti-rollback in `install_storage_budget_v1`) into
+        // this cycle's pin classification:
+        //   * `pinned_classes` — the union of every installed budget's
+        //     `pinned_class` set (a node typically installs exactly one —
+        //     its own; folding the union + summed reserve is the
+        //     most-protective composition when several owners' budgets are
+        //     present: ambiguity fails toward retention, mirroring how
+        //     B4 dedup retains while ANY scope pins).
+        //   * `pin_reserve_floor` — the summed `pin_reserve_bytes` over all
+        //     scopes: the byte floor the pinned classes hold under CAPACITY
+        //     pressure.
+        // A candidate is PINNED iff its `media_type` (the substrate's
+        // per-blob corpus-class token) is in `pinned_classes`. With no
+        // installed budget both are empty ⇒ this entire block is inert and
+        // the pre-#370 ordering is byte-identical.
+        let installed_budgets = self.list_installed_storage_budgets().await.map_err(|e| {
+            crate::federation::BlobError::Backend(format!(
+                "sweeper: list_installed_storage_budgets failed: {e}"
+            ))
+        })?;
+        let mut pinned_classes: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut pin_reserve_floor: u64 = 0;
+        for budget in &installed_budgets {
+            pinned_classes.extend(budget.pinned_class.iter().cloned());
+            pin_reserve_floor = pin_reserve_floor.saturating_add(budget.pin_reserve_total());
+        }
+        let is_pinned = |candidate: &crate::federation::EvictionCandidate| -> bool {
+            candidate
+                .media_type
+                .as_deref()
+                .is_some_and(|m| pinned_classes.contains(m))
+        };
+        // §Q B5 consumption accounting: recomputed from HELD content (the
+        // full table, not just this batch), never trusted from the wire.
+        // Decremented as pinned rows are shed so the reserve floor holds
+        // within the cycle.
+        let mut pinned_bytes_held: u64 = if pinned_classes.is_empty() {
+            0
+        } else {
+            let media_types: Vec<String> = pinned_classes.iter().cloned().collect();
+            self.pinned_blob_bytes(&media_types).await?
+        };
+
         // Rust-side re-rank applies on both backends. PG already ranks
         // in SQL by full decay score; SQLite ranks by the monotone
         // bound. Re-ranking is idempotent on PG (no-op reorder) and
         // load-bearing on SQLite. Sorting ascending so lowest-score
-        // evicts first. When `force_evict_proxy_first` is set (crit/stop
-        // disk-pressure tiers), proxy candidates sort entirely ahead of
-        // local/family ones regardless of decay score.
+        // evicts first.
+        //
+        // Key order (outermost first):
+        //   1. §Q B5 CACHE BEFORE PINNED (#370) — unpinned candidates sort
+        //      entirely ahead of pinned ones; pinned content is reached
+        //      only once unpinned is exhausted. This is the NORMATIVE
+        //      descent order (CC 6.1.2.3), so it outranks…
+        //   2. …the #149 force-evict-proxy-first hint (crit/stop
+        //      disk-pressure tiers): a local operational reordering that
+        //      applies WITHIN a pin class only.
+        //   3. Decay score (popularity × freshness), ascending — the
+        //      standing rarity stand-in within each (pin, proxy) band
+        //      (blob-level rarity scoring is PIN-AS-RECOMMENDATION /
+        //      edge-internal per CC 6.1.3; the decay order is persist's
+        //      deterministic local proxy for "lowest rarity first").
         candidates.sort_by(|a, b| {
+            // unpinned/cache (false) sorts before pinned (true).
+            match is_pinned(a).cmp(&is_pinned(b)) {
+                std::cmp::Ordering::Equal => {}
+                non_eq => return non_eq,
+            }
             if force_evict_proxy_first {
                 let pa = is_proxy(a);
                 let pb = is_proxy(b);
@@ -871,6 +934,21 @@ impl Engine {
         for candidate in candidates {
             if bytes_freed >= target_freed {
                 break;
+            }
+            // §Q B5 (#370): a PINNED candidate is evictable under CAPACITY
+            // pressure only down to the `pin_reserve_bytes` floor — the
+            // reserve the owner elected to hold for the pinned classes.
+            // Skipping (not breaking) lets a smaller pinned row later in
+            // the batch still fit above the floor. The sweep may therefore
+            // end short of `target_freed`: that is the pin doing its job
+            // (B6 keeps REVOCATION unconditional on its separate path —
+            // `evict_fountain_content_hard_delete` never consults any of
+            // this state).
+            let candidate_pinned = is_pinned(&candidate);
+            if candidate_pinned
+                && pinned_bytes_held.saturating_sub(candidate.size_bytes) < pin_reserve_floor
+            {
+                continue;
             }
             // Try to emit a withdraws attestation for this SHA. If
             // the local signer never emitted a holds_bytes for it
@@ -901,6 +979,12 @@ impl Engine {
             if deleted {
                 rows_evicted += 1;
                 bytes_freed = bytes_freed.saturating_add(candidate.size_bytes);
+                if candidate_pinned {
+                    // §Q B5 (#370): keep the held-pinned accounting live so
+                    // the reserve-floor check above stays correct as pinned
+                    // rows are shed within this cycle.
+                    pinned_bytes_held = pinned_bytes_held.saturating_sub(candidate.size_bytes);
+                }
             }
             match withdraws_outcome {
                 Some(Ok(())) => withdraws_emitted += 1,
@@ -1261,6 +1345,147 @@ impl Engine {
                 .await
         } else {
             Ok(0)
+        }
+    }
+
+    // ─── v12.7.0 — §Q pin-INSTALL surface (CC 6.1.5.2 / CIRISPersist#370) ──
+
+    /// v12.7.0 (CC 6.1.5.2 §Q B2/B3 / CIRISPersist#370) — **install** a
+    /// signed `StorageBudgetV1` so it GOVERNS this node's capacity
+    /// eviction (#356 shipped build/verify as wire-negotiation only).
+    /// Three gates, in order:
+    ///
+    /// 1. **PQC-mandatory bound-hybrid verify at ingest, BEFORE
+    ///    persistence** (CC 5.3.2.4.3.1 store-path / CC 6.1.3): the wire's
+    ///    Ed25519 + ML-DSA-65 halves must verify against the owner pubkeys
+    ///    — reuses [`verify_storage_budget_wire`]. This also re-runs the
+    ///    structural validation (no `self`/`family` scope, `pin_reserve ≤
+    ///    budget`, sorted + deduped lists).
+    /// 2. **§Q B3 anti-rollback**: a candidate whose `revision` does not
+    ///    STRICTLY supersede the installed one for the same `node_id` is
+    ///    rejected with
+    ///    [`StorageContentionError::RevisionRollback`](crate::fountain::storage_contention::StorageContentionError)
+    ///    — enforced atomically inside the backend's conditional upsert
+    ///    ([`Backend::put_installed_storage_budget`](crate::store::Backend::put_installed_storage_budget)),
+    ///    so racing installs cannot roll back either.
+    /// 3. Persist (V093 `storage_budget_installed`, both backends): the
+    ///    signed wire VERBATIM + denormalized `revision`/`scopes`/
+    ///    `pinned_class`.
+    ///
+    /// The installed budget is what [`Self::sweep_evictions_once`] reads to
+    /// order candidates CACHE-BEFORE-PINNED (§Q B5) and to hold the
+    /// `pin_reserve_bytes` floor. It is **capacity-only** state: the
+    /// revocation path ([`Self::evict_fountain_content_hard_delete`])
+    /// never reads it — §Q B6, pinning never defeats revocation.
+    ///
+    /// Returns the accepted `revision`.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn install_storage_budget_v1(
+        &self,
+        wire_json: &str,
+        ed25519_pubkey_base64: &str,
+        ml_dsa_65_pubkey_base64: &str,
+    ) -> Result<u64, crate::store::Error> {
+        use crate::fountain::storage_contention::{
+            verify_storage_budget_wire, InstalledStorageBudget, StorageContentionError,
+        };
+        use crate::store::Backend;
+        // Gate 1 — verify at the gate; nothing persists on failure.
+        verify_storage_budget_wire(wire_json, ed25519_pubkey_base64, ml_dsa_65_pubkey_base64)?;
+        let budget = InstalledStorageBudget::from_wire_json(wire_json, chrono::Utc::now())?;
+        // Gates 2+3 — the backend's conditional upsert IS the anti-rollback
+        // check (atomic at the row).
+        let written = match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.put_installed_storage_budget(&budget).await?,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.put_installed_storage_budget(&budget).await?,
+        };
+        if !written {
+            // Refused: read the incumbent revision back for the typed error
+            // (best-effort — the row existed a moment ago).
+            let installed = self
+                .get_installed_storage_budget(&budget.node_id)
+                .await?
+                .map(|b| b.revision)
+                .unwrap_or(budget.revision);
+            return Err(StorageContentionError::RevisionRollback {
+                node_id: budget.node_id,
+                installed,
+                candidate: budget.revision,
+            }
+            .into());
+        }
+        Ok(budget.revision)
+    }
+
+    /// #370 — read back the installed budget for `node_id` (typed).
+    /// `Ok(None)` when none installed. Dispatches to
+    /// [`Backend::get_installed_storage_budget`](crate::store::Backend::get_installed_storage_budget).
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn get_installed_storage_budget(
+        &self,
+        node_id: &str,
+    ) -> Result<
+        Option<crate::fountain::storage_contention::InstalledStorageBudget>,
+        crate::store::Error,
+    > {
+        use crate::store::Backend;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.get_installed_storage_budget(node_id).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.get_installed_storage_budget(node_id).await,
+        }
+    }
+
+    /// #370 — the installed budget's signed wire JSON, VERBATIM as accepted
+    /// (re-verifiable end-to-end with
+    /// [`verify_storage_budget_wire`](crate::fountain::storage_contention::verify_storage_budget_wire)).
+    /// `Ok(None)` when none installed for `node_id`.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn get_installed_storage_budget_json(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<String>, crate::store::Error> {
+        Ok(self
+            .get_installed_storage_budget(node_id)
+            .await?
+            .map(|b| b.wire_json))
+    }
+
+    /// #370 (§Q B5) — every installed budget. The capacity sweep folds
+    /// these into the effective `pinned_class` set + `pin_reserve_bytes`
+    /// floor once per cycle.
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    async fn list_installed_storage_budgets(
+        &self,
+    ) -> Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, crate::store::Error>
+    {
+        use crate::store::Backend;
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.list_installed_storage_budgets().await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.list_installed_storage_budgets().await,
+        }
+    }
+
+    /// #370 (§Q B5) — backend-dispatched pinned-consumption accounting:
+    /// total `federation_blobs` bytes whose `media_type` is in the
+    /// installed `pinned_class` set. Recomputed from held content (§Q:
+    /// consumption accounting is edge-internal, never trusted from the
+    /// wire).
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    async fn pinned_blob_bytes(
+        &self,
+        media_types: &[String],
+    ) -> Result<u64, crate::federation::BlobError> {
+        match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.pinned_blob_bytes(media_types).await,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.pinned_blob_bytes(media_types).await,
         }
     }
 
@@ -7384,6 +7609,472 @@ mod tests {
             proxy_present > 0,
             "standard sweep should keep HOT proxy rows (no proxy-first ordering)"
         );
+    }
+
+    // ─── v12.7.0 (CC 6.1.5.2 §Q / CIRISPersist#370) — pin-install + B5 ───
+
+    /// §Q signer for the budget wires: a deterministic-enough hybrid pair
+    /// (fresh per test; the pubkeys ride along). Built + used SYNCHRONOUSLY
+    /// so no multi-KiB signer is ever held across an await (the ML-DSA-65
+    /// test-stack rule).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    struct QShapeId {
+        ed: ciris_crypto::Ed25519Signer,
+        pqc: ciris_crypto::MlDsa65Signer,
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    fn qshape_id() -> QShapeId {
+        QShapeId {
+            ed: ciris_crypto::Ed25519Signer::random().unwrap(),
+            pqc: ciris_crypto::MlDsa65Signer::new().unwrap(),
+        }
+    }
+
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    fn qshape_pubs(id: &QShapeId) -> (String, String) {
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        use ciris_crypto::{ClassicalSigner, PqcSigner};
+        (
+            B64.encode(id.ed.public_key().unwrap()),
+            B64.encode(id.pqc.public_key().unwrap()),
+        )
+    }
+
+    /// Build + bound-hybrid sign a `StorageBudgetV1` wire: one `community`
+    /// scope with `budget_bytes = 100_000` and the given
+    /// `pin_reserve_bytes`, pinning `pinned_class` (MUST be pre-sorted).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    fn qshape_budget_wire(
+        id: &QShapeId,
+        node_id: &str,
+        revision: u64,
+        pinned_class: &[&str],
+        pin_reserve_bytes: u64,
+    ) -> String {
+        use crate::fountain::storage_contention::{
+            assemble_storage_budget_wire, storage_budget_preimage,
+        };
+        use base64::engine::general_purpose::STANDARD as B64;
+        use base64::Engine as _;
+        use ciris_crypto::{ClassicalSigner, PqcSigner};
+        let payload = serde_json::json!({
+            "node_id": node_id,
+            "epoch_id": "e1",
+            "revision": revision,
+            "scopes": [{
+                "cohort_scope": "community",
+                "budget_bytes": 100_000u64,
+                "pin_reserve_bytes": pin_reserve_bytes,
+            }],
+            "pinned_class": pinned_class,
+        })
+        .to_string();
+        let preimage = storage_budget_preimage(&payload).expect("valid §Q payload");
+        let ed_sig = id.ed.sign(&preimage).unwrap();
+        let mut bound = preimage.clone();
+        bound.extend_from_slice(&ed_sig);
+        let pqc_sig = id.pqc.sign(&bound).unwrap();
+        assemble_storage_budget_wire(&payload, B64.encode(&ed_sig), B64.encode(&pqc_sig))
+            .expect("assemble signed budget wire")
+    }
+
+    /// #370 shared body — install happy path, getter read-back, and §Q B3
+    /// anti-rollback (equal + lower revision rejected; higher supersedes;
+    /// a tampered wire never reaches the store). `node_id` must be unique
+    /// per run on shared databases (the PG twin).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn run_install_budget_assertions(engine: &Engine, node_id: &str) {
+        use crate::fountain::storage_contention::verify_storage_budget_wire;
+        let id = qshape_id();
+        let (ed_pub, mldsa_pub) = qshape_pubs(&id);
+
+        // Happy path: revision 3 installs.
+        let wire3 = qshape_budget_wire(&id, node_id, 3, &["trace"], 2048);
+        let rev = engine
+            .install_storage_budget_v1(&wire3, &ed_pub, &mldsa_pub)
+            .await
+            .expect("install revision 3");
+        assert_eq!(rev, 3);
+
+        // Getter: the stored wire re-verifies end-to-end (PQC-mandatory)
+        // against the same owner pubkeys — the budget stays provable after
+        // install, not just at ingest.
+        let got = engine
+            .get_installed_storage_budget_json(node_id)
+            .await
+            .expect("getter")
+            .expect("a budget is installed");
+        verify_storage_budget_wire(&got, &ed_pub, &mldsa_pub)
+            .expect("stored wire re-verifies (bound-hybrid)");
+
+        // §Q B3 anti-rollback: EQUAL revision refused…
+        let err = engine
+            .install_storage_budget_v1(&wire3, &ed_pub, &mldsa_pub)
+            .await
+            .expect_err("equal revision must be refused");
+        assert_eq!(err.kind(), "storage_contention_revision_rollback");
+        // …and LOWER revision refused.
+        let wire2 = qshape_budget_wire(&id, node_id, 2, &["trace"], 2048);
+        let err = engine
+            .install_storage_budget_v1(&wire2, &ed_pub, &mldsa_pub)
+            .await
+            .expect_err("lower revision must be refused");
+        assert_eq!(err.kind(), "storage_contention_revision_rollback");
+
+        // Strictly-higher revision supersedes.
+        let wire5 = qshape_budget_wire(&id, node_id, 5, &["av_chunk", "trace"], 4096);
+        assert_eq!(
+            engine
+                .install_storage_budget_v1(&wire5, &ed_pub, &mldsa_pub)
+                .await
+                .expect("higher revision supersedes"),
+            5
+        );
+        let installed = engine
+            .get_installed_storage_budget(node_id)
+            .await
+            .expect("typed getter")
+            .expect("installed");
+        assert_eq!(installed.revision, 5);
+        assert_eq!(installed.pinned_class, vec!["av_chunk", "trace"]);
+        assert_eq!(installed.pin_reserve_total(), 4096);
+
+        // A tampered wire (revision bumped without re-signing) fails the
+        // PQC-mandatory verify AT THE GATE — nothing persists; the
+        // installed revision is unchanged.
+        let mut tampered: serde_json::Value = serde_json::from_str(&wire5).unwrap();
+        tampered["revision"] = serde_json::json!(9);
+        let err = engine
+            .install_storage_budget_v1(&tampered.to_string(), &ed_pub, &mldsa_pub)
+            .await
+            .expect_err("tampered wire must fail signature verify");
+        assert_eq!(err.kind(), "storage_contention_signature_failed");
+        assert_eq!(
+            engine
+                .get_installed_storage_budget(node_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .revision,
+            5,
+            "verify-before-mutation: the tampered wire wrote nothing"
+        );
+    }
+
+    /// #370 — install surface on SQLite.
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn install_storage_budget_v1_happy_and_anti_rollback_sqlite() {
+        let engine = Engine::with_signer(test_signer(), "sqlite::memory:")
+            .await
+            .expect("construct engine");
+        run_install_budget_assertions(&engine, "n-370-sqlite").await;
+    }
+
+    /// #370 — install surface on Postgres (shared twin; uuid node_id keeps
+    /// runs self-isolating). Skips when `CIRIS_PERSIST_TEST_PG_URL` unset.
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn install_storage_budget_v1_happy_and_anti_rollback_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let engine = Engine::with_signer(test_signer(), &dsn)
+            .await
+            .expect("construct postgres engine");
+        let node_id = format!("n-370-pg-{}", uuid::Uuid::new_v4().simple());
+        run_install_budget_assertions(&engine, &node_id).await;
+    }
+
+    /// Seed `n` blobs of 1 KiB through `put_blob_signing` with the given
+    /// `media_type` (the §Q corpus-class token), attested by the local
+    /// signer's DERIVED key (which the caller must have registered).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn seed_typed_blobs(
+        engine: &Engine,
+        media_type: Option<&str>,
+        fill_base: u8,
+        n: usize,
+    ) -> Vec<[u8; 32]> {
+        use crate::federation::BlobBody;
+        let derived = test_signer().derived_key_id();
+        let mut shas = Vec::with_capacity(n);
+        for i in 0..n {
+            let bytes = vec![fill_base + i as u8; 1024];
+            let sha = {
+                use sha2::{Digest, Sha256};
+                let mut out = [0u8; 32];
+                out.copy_from_slice(&Sha256::digest(&bytes));
+                out
+            };
+            engine
+                .put_blob_signing(
+                    &sha,
+                    BlobBody::Inline(bytes),
+                    media_type,
+                    &derived,
+                    chrono::Utc::now(),
+                    uuid::Uuid::new_v4(),
+                )
+                .await
+                .expect("put_blob_signing typed blob");
+            shas.push(sha);
+        }
+        shas
+    }
+
+    /// Backend-agnostic `has_blob`.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn blob_present(engine: &Engine, sha: &[u8; 32]) -> bool {
+        use crate::federation::BlobStorage;
+        #[cfg(feature = "sqlite")]
+        if let Some(sq) = engine.sqlite_backend() {
+            return sq.has_blob(sha).await.expect("has_blob");
+        }
+        #[cfg(feature = "postgres")]
+        if let Some(pg) = engine.postgres_backend() {
+            return pg.has_blob(sha).await.expect("has_blob");
+        }
+        panic!("no durable backend on this engine");
+    }
+
+    /// Backend-agnostic access-count heater (each `get_blob` bumps V053
+    /// access tracking, raising the decay score).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn heat_blob(engine: &Engine, sha: &[u8; 32], hits: usize) {
+        use crate::federation::BlobStorage;
+        for _ in 0..hits {
+            #[cfg(feature = "sqlite")]
+            if let Some(sq) = engine.sqlite_backend() {
+                let _ = sq.get_blob(sha).await.expect("get_blob");
+                continue;
+            }
+            #[cfg(feature = "postgres")]
+            if let Some(pg) = engine.postgres_backend() {
+                let _ = pg.get_blob(sha).await.expect("get_blob");
+                continue;
+            }
+            #[allow(unreachable_code)]
+            {
+                panic!("no durable backend on this engine");
+            }
+        }
+    }
+
+    /// #370 §Q B5 shared body — CACHE BEFORE PINNED. 3 COLD pinned
+    /// (`media_type = "trace"`) + 3 HOT unpinned blobs: under the standard
+    /// decay order the cold pinned rows would be the victims; with the
+    /// budget installed, the sweep must shed all 3 unpinned (hot!) rows
+    /// first and hold every pinned row above the `pin_reserve_bytes` floor.
+    ///
+    /// Budget math: 6 × 1 KiB stored, watermark = 4 KiB × 0.5 = 2 KiB ⇒
+    /// target_freed = 4 KiB. Unpinned frees 3 KiB, then the pinned floor
+    /// (3 KiB reserve == pinned bytes held) blocks every pinned eviction —
+    /// the sweep deliberately ends SHORT of target (the pin doing its job).
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn run_b5_unpinned_before_pinned(engine: &Engine) {
+        let pinned = seed_typed_blobs(engine, Some("trace"), 0x10, 3).await;
+        let unpinned = seed_typed_blobs(engine, None, 0x40, 3).await;
+        for sha in &unpinned {
+            heat_blob(engine, sha, 20).await;
+        }
+        let id = qshape_id();
+        let (ed_pub, mldsa_pub) = qshape_pubs(&id);
+        let wire = qshape_budget_wire(&id, "n-b5-order", 1, &["trace"], 3 * 1024);
+        engine
+            .install_storage_budget_v1(&wire, &ed_pub, &mldsa_pub)
+            .await
+            .expect("install the pin");
+
+        let report = engine.sweep_evictions_once().await.expect("B5 sweep");
+        assert_eq!(
+            report.rows_evicted, 3,
+            "exactly the 3 unpinned rows evicted: {report:?}"
+        );
+        for sha in &unpinned {
+            assert!(
+                !blob_present(engine, sha).await,
+                "unpinned (cache) content evicts FIRST, even when hot (§Q B5)"
+            );
+        }
+        for sha in &pinned {
+            assert!(
+                blob_present(engine, sha).await,
+                "pinned content survives capacity pressure above the reserve floor (§Q B5)"
+            );
+        }
+    }
+
+    /// #370 §Q B5 shared body — once unpinned is exhausted, pinned content
+    /// DOES descend under continued capacity pressure, but only down to the
+    /// `pin_reserve_bytes` floor.
+    ///
+    /// Budget math: 3 pinned + 2 unpinned × 1 KiB = 5 KiB stored, watermark
+    /// = 1 KiB × 0.5 = 512 B ⇒ target_freed ≈ 4.5 KiB. Unpinned frees
+    /// 2 KiB; pinned then sheds until held-pinned would drop below the
+    /// 1 KiB reserve ⇒ exactly 2 of 3 pinned evicted, 1 held at the floor.
+    #[cfg(any(feature = "sqlite", feature = "postgres"))]
+    async fn run_b5_reserve_floor(engine: &Engine) {
+        let pinned = seed_typed_blobs(engine, Some("trace"), 0x10, 3).await;
+        let unpinned = seed_typed_blobs(engine, None, 0x40, 2).await;
+        let id = qshape_id();
+        let (ed_pub, mldsa_pub) = qshape_pubs(&id);
+        let wire = qshape_budget_wire(&id, "n-b5-floor", 1, &["trace"], 1024);
+        engine
+            .install_storage_budget_v1(&wire, &ed_pub, &mldsa_pub)
+            .await
+            .expect("install the pin");
+
+        let report = engine.sweep_evictions_once().await.expect("B5 sweep");
+        for sha in &unpinned {
+            assert!(
+                !blob_present(engine, sha).await,
+                "unpinned evicts before any pinned row (§Q B5)"
+            );
+        }
+        let mut pinned_surviving = 0usize;
+        for sha in &pinned {
+            if blob_present(engine, sha).await {
+                pinned_surviving += 1;
+            }
+        }
+        assert_eq!(
+            pinned_surviving, 1,
+            "pinned descends only to the pin_reserve_bytes floor (1 KiB): {report:?}"
+        );
+        assert_eq!(report.rows_evicted, 4, "2 unpinned + 2 pinned: {report:?}");
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sweeper_b5_evicts_unpinned_before_pinned_sqlite() {
+        let cfg = crate::federation::ReplicationConfig {
+            storage_budget_bytes: 4 * 1024,
+            steady_state_utilization: 0.5,
+            eviction_decay_half_life_days: 365.0,
+            ..Default::default()
+        };
+        let (engine, _shas) = sweeper_seed_blobs(cfg, 0).await;
+        run_b5_unpinned_before_pinned(&engine).await;
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sweeper_b5_holds_pin_reserve_floor_sqlite() {
+        let cfg = crate::federation::ReplicationConfig {
+            storage_budget_bytes: 1024,
+            steady_state_utilization: 0.5,
+            eviction_decay_half_life_days: 365.0,
+            ..Default::default()
+        };
+        let (engine, _shas) = sweeper_seed_blobs(cfg, 0).await;
+        run_b5_reserve_floor(&engine).await;
+    }
+
+    /// Create an ISOLATED database on the PG twin (the sweep ranks the
+    /// WHOLE `federation_blobs` table, so byte-exact ordering assertions
+    /// cannot self-isolate by uuid the way row-keyed tests do). Returns
+    /// `(dsn, db_name)`; `None` (skip) when the twin is unset.
+    #[cfg(feature = "postgres")]
+    async fn pg_isolated_db(tag: &str) -> Option<(String, String)> {
+        let Ok(base) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return None;
+        };
+        let db = format!("persist_370_{}_{}", tag, uuid::Uuid::new_v4().simple());
+        let (client, conn) = tokio_postgres::connect(&base, tokio_postgres::NoTls)
+            .await
+            .expect("admin connect to PG twin");
+        let conn_handle = tokio::spawn(conn);
+        client
+            .execute(format!("CREATE DATABASE {db}").as_str(), &[])
+            .await
+            .expect("create isolated database");
+        drop(client);
+        conn_handle.abort();
+        let (prefix, _) = base.rsplit_once('/').expect("dsn has a database path");
+        Some((format!("{prefix}/{db}"), db))
+    }
+
+    /// Best-effort drop of the isolated database (FORCE terminates any
+    /// pool connection the dropped Engine hasn't torn down yet).
+    #[cfg(feature = "postgres")]
+    async fn pg_drop_isolated_db(db: &str) {
+        let Ok(base) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            return;
+        };
+        if let Ok((client, conn)) = tokio_postgres::connect(&base, tokio_postgres::NoTls).await {
+            let conn_handle = tokio::spawn(conn);
+            let _ = client
+                .execute(format!("DROP DATABASE {db} WITH (FORCE)").as_str(), &[])
+                .await;
+            drop(client);
+            conn_handle.abort();
+        }
+    }
+
+    /// PG twin of `sweeper_seed_blobs`'s engine setup: replication config +
+    /// the local signer's DERIVED federation key registered.
+    #[cfg(feature = "postgres")]
+    async fn sweeper_engine_pg(cfg: crate::federation::ReplicationConfig, dsn: &str) -> Engine {
+        use crate::federation::FederationDirectory;
+        let signer = test_signer();
+        let derived = signer.derived_key_id();
+        let engine = Engine::with_replication_config(signer, dsn, cfg)
+            .await
+            .expect("construct postgres engine");
+        let pg = engine.postgres_backend().expect("postgres present");
+        pg.put_public_key(sweeper_test_key_derived_for(
+            &derived,
+            "test-engine-steward",
+        ))
+        .await
+        .expect("seed signer key");
+        engine
+    }
+
+    /// #370 §Q B5 on Postgres — same shared body as the SQLite twin, on an
+    /// isolated database (whole-table sweep). Skips when the twin is unset.
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn sweeper_b5_evicts_unpinned_before_pinned_postgres() {
+        let Some((dsn, db)) = pg_isolated_db("b5order").await else {
+            return;
+        };
+        {
+            let cfg = crate::federation::ReplicationConfig {
+                storage_budget_bytes: 4 * 1024,
+                steady_state_utilization: 0.5,
+                eviction_decay_half_life_days: 365.0,
+                ..Default::default()
+            };
+            let engine = sweeper_engine_pg(cfg, &dsn).await;
+            run_b5_unpinned_before_pinned(&engine).await;
+        }
+        pg_drop_isolated_db(&db).await;
+    }
+
+    /// #370 §Q B5 reserve floor on Postgres (isolated database).
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn sweeper_b5_holds_pin_reserve_floor_postgres() {
+        let Some((dsn, db)) = pg_isolated_db("b5floor").await else {
+            return;
+        };
+        {
+            let cfg = crate::federation::ReplicationConfig {
+                storage_budget_bytes: 1024,
+                steady_state_utilization: 0.5,
+                eviction_decay_half_life_days: 365.0,
+                ..Default::default()
+            };
+            let engine = sweeper_engine_pg(cfg, &dsn).await;
+            run_b5_reserve_floor(&engine).await;
+        }
+        pg_drop_isolated_db(&db).await;
     }
 
     // ─── v6.8.0 (CIRISPersist#149) — proactive disk-pressure ENFORCEMENT ───

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1489,6 +1489,66 @@ impl Engine {
         }
     }
 
+    /// #227 (residual) — the **consent-decay sweep**: the time-driven twin
+    /// of the disk-pressure sweeper
+    /// ([`sweep_evictions_once`](Self::sweep_evictions_once)). Enumerate
+    /// EVERY fountain content unit
+    /// ([`list_fountain_decay_candidates`](crate::store::Backend::list_fountain_decay_candidates)),
+    /// read each unit's consent-decay class from its signed envelope, map
+    /// `now - admitted_at` through the per-class decay schedule
+    /// ([`consent_decay_target_tier`](crate::fountain::consent_decay_target_tier)
+    /// — TEMPORARY 14-day, pattern 90-day), and drive any unit whose clock
+    /// says it should be below its current tier down via the SAME eviction
+    /// mechanism the disk-pressure trigger uses
+    /// ([`evict_fountain_content_to_tier`](Self::evict_fountain_content_to_tier)).
+    ///
+    /// **Disk-INDEPENDENT** — fires regardless of free bytes (no watermark,
+    /// no `ReplicationConfig` gate). **Idempotent** — the eviction
+    /// mechanism only removes symbols down to a keep-count and is a no-op
+    /// once a unit is already at/below its decay tier, so re-running the
+    /// sweep at the same `now` evicts nothing further. Units that declare
+    /// no decay class in their envelope are left untouched (fail-safe).
+    ///
+    /// `now` is threaded for deterministic testing; the FFI wrapper passes
+    /// wall-clock `Utc::now()`. Manifests are NEVER touched (the
+    /// always-retained provenance).
+    #[cfg(any(feature = "postgres", feature = "sqlite"))]
+    pub async fn sweep_consent_decay_once(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<crate::fountain::ConsentDecaySweepReport, crate::store::Error> {
+        use crate::store::Backend;
+        let candidates = match &self.backend {
+            #[cfg(feature = "postgres")]
+            BackendDispatch::Postgres(b) => b.list_fountain_decay_candidates().await?,
+            #[cfg(feature = "sqlite")]
+            BackendDispatch::Sqlite(b) => b.list_fountain_decay_candidates().await?,
+        };
+        let mut report = crate::fountain::ConsentDecaySweepReport::default();
+        for c in candidates {
+            report.content_scanned += 1;
+            let Some(tier) =
+                crate::fountain::consent_decay_target_tier(&c.envelope, c.admitted_at, now)
+            else {
+                // No declared decay class ⇒ the time-clock opts out.
+                continue;
+            };
+            report.content_with_decay_class += 1;
+            if tier == crate::fountain::FountainTier::Full {
+                // Clock hasn't reached the first breakpoint yet.
+                continue;
+            }
+            let evicted = self
+                .evict_fountain_content_to_tier(&c.content_id, &c.corpus_kind, tier)
+                .await?;
+            report.symbols_evicted += evicted;
+            if evicted > 0 {
+                report.content_decayed += 1;
+            }
+        }
+        Ok(report)
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     /// v8.3.0 (CEG 1.0-RC12 §19.7 / CIRISPersist#230) — admit an aggregate

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -3884,6 +3884,15 @@ pub async fn check_adult_incapacity_binding(
 /// - `capacity:*` → MUST NOT be self-emitted (`attesting_key_id ==
 ///   attested_key_id`) — CC 3.4.5's "Critical enforcement" anti-Goodhart rule
 ///   (an `identity_type`-independent attester==attested check).
+/// - `age_assurance:*` → MUST NOT be self-emitted either (v12.7.0,
+///   CIRISPersist#368) — CC 3.4.11 "A subject MUST NOT emit on
+///   `age_assurance:`". The witness-RESERVED half rides the rule table; this
+///   attester==attested half stops a `witness`-typed key from graduating
+///   ITSELF. A witness graduates a DIFFERENT subject by naming it as
+///   `attested_key_id` (the cross-subject edge
+///   [`crate::Engine::emit_attestation`] carries via
+///   [`EmitAttestationInput::attested_key_id`](crate::federation::EmitAttestationInput::attested_key_id)),
+///   which [`super::age::age_band`] then resolves for that subject.
 ///
 /// Structural primitives (`scores` / `delegates_to` / `supersedes` /
 /// `withdraws` / `recants`) and any non-reserved type fast-exit with no
@@ -3914,6 +3923,25 @@ pub async fn check_reserved_prefix_admission(
         && row.attesting_key_id == row.attested_key_id
     {
         return Err(Error::CapacitySelfEmissionRejected {
+            key_id: row.attesting_key_id.clone(),
+            attestation_type: at.to_owned(),
+        });
+    }
+
+    // v12.7.0 (CIRISPersist#368) — CC 3.4.11: "A subject MUST NOT emit on
+    // `age_assurance:`". The witness rung is an attestation ABOUT a subject
+    // (`attested_key_id` = the subject, the same cross-subject edge shape
+    // `delegates_to` uses); the SUBJECT-must-not-emit half is an
+    // attester==attested check independent of identity_type — without it a
+    // key carrying the `witness` identity_type could self-mint its own
+    // `adult` graduation. The witness-RESERVED half (only `identity_type ⊇
+    // {witness}` may emit) rides the reserved-prefix rule table below,
+    // unchanged. Exact sibling of the CC 3.4.12 `capacity_assurance:` check
+    // above. NB: the self rung stays on the distinct NON-reserved
+    // `age_self_declared:` prefix (subject-signed by design), which this
+    // check never touches.
+    if at.starts_with("age_assurance:") && row.attesting_key_id == row.attested_key_id {
+        return Err(Error::AgeAssuranceSelfEmissionRejected {
             key_id: row.attesting_key_id.clone(),
             attestation_type: at.to_owned(),
         });

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -355,18 +355,23 @@ impl Default for DimensionAdmissionPolicy {
 /// - `licensure:*` (CEG §7.3) is co-owned — the admission gate
 ///   doesn't reject single-source emissions; per §7.3, consumers
 ///   mark them `confidence ≤ 0.5` until the second co-owner attests.
-/// - `detection:correlated_action:*` / `detection:distributive:*`
-///   (CEG §7.4) are LensCore-only emission but the substrate accepts
-///   cross-attestations under a different prefix per §7.4's last
-///   sentence; mapping this to a substrate-admission rule requires
-///   knowing whether the row is a primary detection-emission vs a
-///   cross-attestation, which lives in the envelope shape. Deferred
-///   to consumer-side check pending CEG-side rule clarification.
+/// - `detection:correlated_action:*` / `detection:distributive:access:*`
+///   (CC 3.4.8) ARE gated here (v12.7.0, CIRISPersist#366): they are
+///   LensCore-only emission — emitter rule `lenscore_detector ∈
+///   attesting_key.identity_type`. Per CC 3.4.8 a cross-attestation by a
+///   non-LensCore peer MUST use the DISTINCT `truth_grounding:detection:*`
+///   prefix (which does not start with `detection:` and so stays ungated),
+///   so anything landing on `detection:*` is a **primary detector
+///   emission** — gate-able with NO envelope field, resolving the earlier
+///   "which shape is this?" ambiguity. Only these two exact families are
+///   gated; a bare `detection:` prefix is NOT (CC 3.4.8 names exactly
+///   these two).
 pub fn default_reserved_prefix_rules() -> Vec<ReservedPrefixRule> {
     use super::types::identity_type;
     let substrate_persist = identity_type::SUBSTRATE_PERSIST.to_owned();
     let witness = identity_type::WITNESS.to_owned();
     let trusted_publisher = identity_type::TRUSTED_PUBLISHER.to_owned();
+    let lenscore_detector = identity_type::LENSCORE_DETECTOR.to_owned();
     vec![
         ReservedPrefixRule {
             pattern_prefix: "system:".into(),
@@ -429,6 +434,24 @@ pub fn default_reserved_prefix_rules() -> Vec<ReservedPrefixRule> {
         ReservedPrefixRule {
             pattern_prefix: crate::federation::capacity::CAPACITY_ASSURANCE_PREFIX.into(),
             required_identity_types: vec![witness],
+        },
+        // v12.7.0 (CIRISPersist#366, CC 3.4.8) — the detector-only
+        // prefixes. `detection:correlated_action:*` and
+        // `detection:distributive:access:*` are LensCore-only emission:
+        // emitter rule `lenscore_detector ∈ attesting_key.identity_type`.
+        // Set-membership (not scalar equality) is the load-bearing test
+        // (CC 3.4.7.1) so a folded `{agent, lenscore_detector}` key passes.
+        // A non-detector peer wishing to cross-check the detector's verdict
+        // emits under the DISTINCT `truth_grounding:detection:*` prefix
+        // (ungated — it does not start with `detection:`), so every row on
+        // these two families is a primary detector emission.
+        ReservedPrefixRule {
+            pattern_prefix: "detection:correlated_action:".into(),
+            required_identity_types: vec![lenscore_detector.clone()],
+        },
+        ReservedPrefixRule {
+            pattern_prefix: "detection:distributive:access:".into(),
+            required_identity_types: vec![lenscore_detector],
         },
     ]
 }
@@ -496,10 +519,17 @@ impl DimensionAdmissionPolicy {
         // operator owns.
         for rule in &self.reserved_prefix_rules {
             if dim.starts_with(rule.pattern_prefix.as_str()) {
+                // CC 3.4.7.1 — `identity_type` is a SET; the gate is
+                // satisfied iff a required role is a MEMBER of the
+                // attester's role-set (not scalar equality). For a
+                // single-role key `X ∈ {X}` ≡ `X == X`, so this is
+                // behavior-preserving for every legacy single-role key;
+                // it only newly-admits conformant folded keys (e.g. a
+                // `{agent, lenscore_detector}` LensCore fold — CC 3.4.8).
                 if !rule
                     .required_identity_types
                     .iter()
-                    .any(|t| t == attesting_identity_type)
+                    .any(|t| identity_type::set_contains(attesting_identity_type, t))
                 {
                     let mut required = rule.required_identity_types.clone();
                     required.sort();
@@ -4082,7 +4112,17 @@ pub async fn check_reserved_prefix_admission(
         });
     }
     if let Some(rule) = matched_rule {
-        if !rule.required_identity_types.contains(&got) {
+        // CC 3.4.7.1 — set membership, not scalar equality: `got` is the
+        // stored (possibly comma-joined) `identity_type` set; the rule is
+        // satisfied iff a required role is one of its members. Single-role
+        // keys encode identically to scalar (`X ∈ {X}` ≡ `X == X`), so this
+        // is behavior-preserving for every existing reserved prefix and
+        // only newly-admits conformant folded keys (CC 3.4.8 detector fold).
+        if !rule
+            .required_identity_types
+            .iter()
+            .any(|t| identity_type::set_contains(&got, t))
+        {
             let mut required = rule.required_identity_types.clone();
             required.sort();
             return Err(Error::ReservedPrefixEmitterMismatch {
@@ -4203,14 +4243,84 @@ mod tests {
     #[test]
     fn admission_accepts_correlated_action_rights_asymmetry_v1() {
         // The v1.2 rename target itself — mechanism-descriptive
-        // + version-pinned. Should pass.
+        // + version-pinned. As of CC 3.4.8 (CIRISPersist#366) this is a
+        // detector-only prefix, so the emitter must hold `lenscore_detector`.
         let p = default_policy();
         p.check(
             attestation_type::SCORES,
             Some("detection:correlated_action:rights_asymmetry:v1"),
-            identity_type::STEWARD,
+            identity_type::LENSCORE_DETECTOR,
         )
         .unwrap();
+    }
+
+    // ── CC 3.4.8 (CIRISPersist#366) — detector-only prefix decision table
+    //    (dimension side; `DimensionAdmissionPolicy::check`) ────────────
+
+    #[test]
+    fn detector_prefix_decision_table_dimension_side() {
+        let p = default_policy();
+        let detector_dims = [
+            "detection:correlated_action:rights_asymmetry:v1",
+            "detection:distributive:access:disparity:v1",
+        ];
+
+        // 1. A plain `lenscore_detector` key is ADMITTED.
+        for dim in detector_dims {
+            p.check(
+                attestation_type::SCORES,
+                Some(dim),
+                identity_type::LENSCORE_DETECTOR,
+            )
+            .unwrap_or_else(|e| panic!("detector must admit {dim}: {e:?}"));
+        }
+
+        // 2. A folded `{agent, lenscore_detector}` key is ADMITTED by set
+        //    membership (CC 3.4.8 LensCore-fold worked example). Encode the
+        //    set as the canonical sorted comma-joined form.
+        let folded =
+            identity_type::join_set([identity_type::AGENT, identity_type::LENSCORE_DETECTOR]);
+        for dim in detector_dims {
+            p.check(attestation_type::SCORES, Some(dim), &folded)
+                .unwrap_or_else(|e| panic!("folded detector must admit {dim}: {e:?}"));
+        }
+
+        // 3. A plain `agent`/`steward` key is REJECTED — the cohabiting
+        //    non-detector role neither grants nor blocks; only the held
+        //    `lenscore_detector` role does.
+        for role in [identity_type::AGENT, identity_type::STEWARD] {
+            for dim in detector_dims {
+                let err = p
+                    .check(attestation_type::SCORES, Some(dim), role)
+                    .unwrap_err();
+                match err {
+                    Error::ReservedPrefixEmitterMismatch {
+                        required,
+                        got_identity_type,
+                        ..
+                    } => {
+                        assert_eq!(required, vec![identity_type::LENSCORE_DETECTOR.to_owned()]);
+                        assert_eq!(got_identity_type, role);
+                    }
+                    other => panic!("expected ReservedPrefixEmitterMismatch, got {other:?}"),
+                }
+            }
+        }
+
+        // 4. A `truth_grounding:detection:*` cross-attestation from ANY key
+        //    is ADMITTED (ungated — a DIFFERENT prefix, shadowing-free).
+        for role in [
+            identity_type::AGENT,
+            identity_type::STEWARD,
+            identity_type::LENSCORE_DETECTOR,
+        ] {
+            p.check(
+                attestation_type::SCORES,
+                Some("truth_grounding:detection:correlated_action:rights_asymmetry:v1"),
+                role,
+            )
+            .unwrap_or_else(|e| panic!("cross-attestation must be ungated for {role}: {e:?}"));
+        }
     }
 
     // ── Ask 3 exemption: structural primitives bypass the gate ─────

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -3041,16 +3041,47 @@ pub async fn check_no_moderator_federate_admission_by_id(
 
 /// v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — the `put_attestation` entry
 /// point for the §11.11 federation-apply re-check (point ii). A
-/// **federation-tier** attestation carrying a `community_id` in its envelope is
-/// a "federation apply step keyed on C"; it is refused if `C` has no live
-/// `moderate`-holder ([`check_no_moderator_federate_admission_by_id`]).
+/// **federation-tier** attestation keyed on a community `C` is a "federation
+/// apply step keyed on C"; it is refused if `C` has no live `moderate`-holder
+/// ([`check_no_moderator_federate_admission_by_id`]).
+///
+/// # Keying — what "keyed on C" means for an attestation row (v12.7.0, #369)
+///
+/// §11.11 requires the re-check on **every** federation apply step keyed on
+/// `C`, not only rows that ride one envelope convention. A federation-tier
+/// row is keyed on `C` when it references `C` under ANY of the substrate's
+/// own community-reference shapes:
+///
+/// 1. **Envelope fields** — `community_id` (the CEG §11.10 moderation-gate
+///    shape, [`check_delegated_duty_scores_admission`]'s keying),
+///    `community_key_id` (the [`Community`](crate::federation::types::Community)
+///    record / CC 3.2 steward-binding-gate field name), and `cohort_key_id`
+///    (the #249 Cut G4 membership-change event field name). Each is honored
+///    when present as a string.
+/// 2. **Row endpoints** — `attesting_key_id` / `attested_key_id` resolving as
+///    a stored community (`lookup_community` hit). This is how
+///    community-MEMBERSHIP attestations reference their community with no
+///    literal envelope field: a community's own key IS a `federation_keys`
+///    row, and the scope read-gate already treats the attestation *subject*
+///    as the membership target ("`federation_attestations` carries
+///    `cohort_scope` but no separate `cohort_target_id`, so the subject
+///    doubles as the membership target" — `list_attestations_for`). A row
+///    attested TO `C` (membership / scores-on-community) or emitted BY `C`
+///    (community-signed roster claims) is a federation apply step keyed on
+///    `C`.
+/// 3. **`subject_key_ids` entries** resolving as stored communities — the
+///    CEG 0.6 §4.2 consent-subject shape (the same subject set the §11.10
+///    duty-holder composition folds community moderators into).
 ///
 /// A no-op (`Ok(())`) for:
 /// - **local-tier** rows — a local-tier write is private to the producing
 ///   occurrence and not a federation apply step (CC 5.3.2.2), and
-/// - rows carrying **no** `community_id` (not keyed on a community), and
-/// - a `community_id` **not locally known** (out of scope — fail-open, per
-///   [`check_no_moderator_federate_admission_by_id`]).
+/// - rows referencing **no** community under any shape above (not keyed on a
+///   community: every candidate either absent or **not locally known** —
+///   out of scope, fail-open, per
+///   [`check_no_moderator_federate_admission_by_id`]; an ordinary
+///   key-to-key attestation costs two `lookup_community` misses and passes
+///   untouched).
 ///
 /// A founder appointment (`delegates_to(moderate)` keyed on C) is NOT
 /// chicken-and-egg-blocked: a steward-bound founder is already a zero-hop named
@@ -3067,12 +3098,66 @@ pub async fn check_no_moderator_federate_apply(
     if row.tier != crate::federation::types::attestation_tier::FEDERATION {
         return Ok(());
     }
-    let community_id = row
-        .attestation_envelope
-        .get("community_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    check_no_moderator_federate_admission_by_id(directory, community_id).await
+    // Collect every community reference the row carries (deduplicated —
+    // a row naming C under several shapes re-checks it once).
+    let mut candidates: Vec<&str> = Vec::new();
+    for field in ["community_id", "community_key_id", "cohort_key_id"] {
+        if let Some(cid) = row.attestation_envelope.get(field).and_then(|v| v.as_str()) {
+            if !cid.is_empty() && !candidates.contains(&cid) {
+                candidates.push(cid);
+            }
+        }
+    }
+    for endpoint in [row.attesting_key_id.as_str(), row.attested_key_id.as_str()] {
+        if !endpoint.is_empty() && !candidates.contains(&endpoint) {
+            candidates.push(endpoint);
+        }
+    }
+    for sid in &row.subject_key_ids {
+        if !sid.is_empty() && !candidates.contains(&sid.as_str()) {
+            candidates.push(sid);
+        }
+    }
+    for cid in candidates {
+        check_no_moderator_federate_admission_by_id(directory, cid).await?;
+    }
+    Ok(())
+}
+
+/// v12.7.0 (CIRISPersist#369, CC 4.5.4 / §11.11) — the directly drivable
+/// federate-admission **verdict** over one community id: exactly the decision
+/// [`check_no_moderator_federate_apply`] takes for a federation apply step
+/// keyed on `community_id`, returned as data instead of an error so a
+/// conformance/consumer layer can stage the gate without constructing a full
+/// federation flow. Verdict JSON:
+///
+/// - `{"admitted": true, "community_known": false}` — not locally known ⇒
+///   out of scope, fail-open (the peer's own admission gate governs it);
+/// - `{"admitted": true, "community_known": true}` — a live `moderate`-holder
+///   resolves (or the authorized-infrastructure carve-out applies) ⇒ `C` may
+///   federate at moderated capability;
+/// - `{"admitted": false, "community_known": true, "reason":
+///   "federation_community_no_moderator"}` — §11.11 rule-3 fail-secure: no
+///   live steward-bound authority root ⇒ MUST NOT federate at moderated
+///   capability.
+///
+/// Read-only — never mutates; substrate read errors propagate as `Err`.
+pub async fn no_moderator_federate_verdict(
+    directory: &dyn super::FederationDirectory,
+    community_id: &str,
+) -> Result<serde_json::Value, Error> {
+    let Some(community) = directory.lookup_community(community_id).await? else {
+        return Ok(serde_json::json!({ "admitted": true, "community_known": false }));
+    };
+    match check_no_moderator_federate_admission(directory, &community).await {
+        Ok(()) => Ok(serde_json::json!({ "admitted": true, "community_known": true })),
+        Err(err @ Error::CommunityHasNoModerator { .. }) => Ok(serde_json::json!({
+            "admitted": false,
+            "community_known": true,
+            "reason": err.kind(),
+        })),
+        Err(other) => Err(other),
+    }
 }
 
 /// v8.7.1 (CIRISPersist#233, CEG RC25/RC26 §11.11) — is key `k` a **named

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -851,10 +851,15 @@ pub fn envelope_subject_kind(envelope: &serde_json::Value) -> Option<&str> {
 ///      substrate's `valid_until`-passed emission, never a wire input).
 ///   3. **Tier eligibility** (rule 3, §10.1.3): a `stance: revoked`
 ///      `consent_record` carries subject revocation authority over
-///      another party's content → it is **NOT local-tier-eligible** and
-///      is rejected at `tier = "local"`. A `stance: granted` self-consent
-///      MAY be local (no tier restriction here; the §10.1.5.2 self-tier
-///      eligibility is enforced by [`check_local_tier_eligibility`]).
+///      another party's content. It is federation-tier by classification
+///      but MAY **transit** the local tier (v12.6.0, resolving AV-61): a
+///      `revoked` consent_record at `tier = "local"` returns
+///      [`LocalTierDisposition::TransitRevocation`] so the caller
+///      (`put_attestation`) hybrid-verifies its signature before storing
+///      (accept on VALID crypto only) and never lets it rest durable. A
+///      `stance: granted` self-consent MAY be local durable (the
+///      §10.1.5.2 self-tier eligibility is enforced by
+///      [`check_local_tier_eligibility`]).
 ///
 /// Rule 4 (composition with the §3.2.3 `withdraws` gate / no quorum) is
 /// not a *field* check — it is the single-subject authority already baked
@@ -866,19 +871,22 @@ pub fn envelope_subject_kind(envelope: &serde_json::Value) -> Option<&str> {
 ///
 /// `tier` is the row's [`crate::federation::types::Attestation::tier`]
 /// (`"local"` / `"federation"`). Returns [`Error::InvalidArgument`] on
-/// any rule violation; the row is not stored.
+/// any rule violation (the row is not stored); otherwise the
+/// [`LocalTierDisposition`] — [`LocalTierDisposition::TransitRevocation`]
+/// for a `revoked` consent_record at local tier (caller MUST hybrid-verify
+/// before storing), else [`LocalTierDisposition::Durable`].
 pub fn check_consent_record_admission(
     attestation_type: &str,
     envelope: &serde_json::Value,
     tier: &str,
-) -> Result<(), Error> {
+) -> Result<LocalTierDisposition, Error> {
     use crate::federation::types::consent_record;
     // No-op unless this is a `scores` carrying the consent_record
     // discriminator. (A `consent_record` MUST ride `scores` — §5.6.8.7
     // "Rides existing scores attestation_type"; a non-scores row bearing
     // the discriminator is malformed.)
     if envelope_subject_kind(envelope) != Some(consent_record::SUBJECT_KIND) {
-        return Ok(());
+        return Ok(LocalTierDisposition::Durable);
     }
     if attestation_type != attestation_type::SCORES {
         return Err(Error::InvalidArgument(format!(
@@ -917,49 +925,209 @@ pub fn check_consent_record_admission(
         ));
     }
     // Rule 3 — tier eligibility (§10.1.3): a `revoked` consent_record is
-    // subject revocation authority → never local-tier-eligible.
+    // subject revocation authority. It is federation-tier by classification
+    // but MAY *transit* the local tier — the caller (`put_attestation`)
+    // hybrid-verifies the signature before storing (accept on VALID crypto
+    // only; transit-not-rest). Pre-v12.6.0 this was a hard `Err`.
     if stance == consent_record::stance::REVOKED
         && tier == crate::federation::types::attestation_tier::LOCAL
     {
-        return Err(Error::InvalidArgument(
-            "a consent_record with stance 'revoked' is NOT local-tier-eligible \
-             (CEG §10.1.3 / §5.6.8.7 admission rule 3): it carries subject \
-             revocation authority — it must be federation-tier (hybrid-signed) \
-             or promoted within the §10.1.3 bounded window"
-                .to_string(),
-        ));
+        return Ok(LocalTierDisposition::TransitRevocation);
     }
-    Ok(())
+    Ok(LocalTierDisposition::Durable)
+}
+
+/// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — the
+/// `put_attestation` ingest gate for subject-side consent revocations at
+/// local tier. Two classifiers feed it:
+///
+/// 1. [`check_consent_record_admission`] (field / stance / substrate-only
+///    `expired` checks) — a `revoked` consent_record ceremony at
+///    `tier = local`;
+/// 2. [`is_subject_side_revocation`] — a *bare* subject-side revocation
+///    (`withdraws`, or a `consent:state:revoked` dimension with writer ∈
+///    `subject_key_ids`) at `tier = local`. Without this arm,
+///    `put_attestation(tier = local)` would be a trivial bypass of the
+///    crypto gate the local-write path
+///    ([`verify_local_transit_revocation`]) enforces.
+///
+/// Either way the row MAY transit the local tier only on VALID crypto: its
+/// bound-hybrid signature is verified via
+/// [`verify_row_hybrid_signature`](crate::federation::verify_row_hybrid_signature)
+/// against the attester's REGISTERED pubkeys **before** any store
+/// (Ed25519 + ML-DSA-65, Strict, PQC-mandatory). An unsigned /
+/// classical-only / forged one is rejected
+/// [`Error::FederationTierUnverified`], fail-secure. A no-op (`Ok(())`) for
+/// every other row (durable consent_records; federation-tier rows are gated
+/// by `verify_federation_tier_ingest`; non-revocations). Must run BEFORE the
+/// backend acquires its write lock (it resolves pubkeys via the directory,
+/// which locks itself).
+pub async fn verify_consent_record_transit_ingest<F>(
+    directory: &F,
+    row: &crate::federation::types::Attestation,
+) -> Result<(), Error>
+where
+    F: super::FederationDirectory + ?Sized,
+{
+    let ceremony_disposition = check_consent_record_admission(
+        &row.attestation_type,
+        &row.attestation_envelope,
+        &row.tier,
+    )?;
+    let bare_transit = row.tier == crate::federation::types::attestation_tier::LOCAL
+        && is_subject_side_revocation(
+            &row.attestation_type,
+            envelope_dimension(&row.attestation_envelope),
+            &row.attesting_key_id,
+            &row.subject_key_ids,
+        );
+    if ceremony_disposition == LocalTierDisposition::TransitRevocation || bare_transit {
+        crate::federation::verify_row_hybrid_signature(directory, row).await
+    } else {
+        Ok(())
+    }
+}
+
+/// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — the local-write
+/// path's transit gate, shared by all three backends. Given the
+/// [`LocalTierDisposition`] from [`check_local_tier_eligibility`] and the
+/// caller's [`LocalAttestationInput`](crate::federation::types::LocalAttestationInput):
+///
+/// - [`LocalTierDisposition::Durable`] ⇒ `Ok(None)` (ordinary
+///   producer-authority row; signature deferred — written as the
+///   empty-sentinel scrub envelope).
+/// - [`LocalTierDisposition::TransitRevocation`] ⇒ the subject-side
+///   revocation MUST carry a bound-hybrid signature that verifies against
+///   the attester's REGISTERED pubkeys (Ed25519 + ML-DSA-65, Strict,
+///   PQC-mandatory). On success returns `Ok(Some((original_content_hash,
+///   scrub_signature_classical, scrub_signature_pqc)))` so the backend
+///   builds the signed transit row
+///   ([`LocalAttestationInput::into_transit_revocation_row`](crate::federation::types::LocalAttestationInput::into_transit_revocation_row)).
+///   A missing signature ⇒ [`Error::InvalidArgument`]; an invalid one ⇒
+///   [`Error::FederationTierUnverified`]. Either way the row is NOT stored —
+///   persist accepts the transit write ONLY on VALID crypto (never an
+///   unsigned/forged revocation), and never rests it as a durable local row.
+///
+/// MUST run BEFORE the backend acquires its write lock (it resolves pubkeys
+/// via the directory, which locks itself).
+#[allow(clippy::type_complexity)]
+pub async fn verify_local_transit_revocation<F>(
+    directory: &F,
+    disposition: LocalTierDisposition,
+    input: &crate::federation::types::LocalAttestationInput,
+) -> Result<Option<(String, String, Option<String>)>, Error>
+where
+    F: super::FederationDirectory + ?Sized,
+{
+    match disposition {
+        LocalTierDisposition::Durable => Ok(None),
+        LocalTierDisposition::TransitRevocation => {
+            let sig_classical = input.scrub_signature_classical.as_deref().ok_or_else(|| {
+                Error::InvalidArgument(
+                    "a subject-side revocation transiting the local tier requires a bound-hybrid \
+                     signature (§10.1.3, AV-61): scrub_signature_classical + scrub_signature_pqc \
+                     must be present and verify against the attester's registered pubkeys"
+                        .to_string(),
+                )
+            })?;
+            let sig_pqc = input.scrub_signature_pqc.as_deref();
+            let hash = crate::federation::verify_envelope_hybrid_signature(
+                directory,
+                &input.attesting_key_id,
+                &input.attestation_envelope,
+                sig_classical,
+                sig_pqc,
+            )
+            .await?;
+            Ok(Some((
+                hash,
+                sig_classical.to_string(),
+                sig_pqc.map(str::to_string),
+            )))
+        }
+    }
+}
+
+/// v12.6.0 (CIRISPersist#171, CEG §10.1.3 transit-not-rest) — how a
+/// local-tier write is admitted. The subject-side revocation resolution of
+/// AV-61: a subject revocation is federation-tier *by classification* but
+/// MAY **transit** the local write path (never *rest* as a durable local
+/// row). [`check_local_tier_eligibility`] /
+/// [`check_consent_record_admission`] classify the row; the backend then
+/// acts on the disposition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalTierDisposition {
+    /// Ordinary producer-only-authority local row — signature deferred
+    /// (CC 5.3.2.2), written as an empty-sentinel scrub envelope.
+    Durable,
+    /// A subject-side consent revocation **transiting** the local tier
+    /// (§10.1.3). The backend MUST verify its bound-hybrid signature
+    /// (Ed25519 + ML-DSA-65, Strict, PQC-mandatory) against the attester's
+    /// REGISTERED pubkeys before storing; a signature that does not verify
+    /// (or is absent) is rejected. The accepted row carries the REAL
+    /// signature at `tier = local`, `promoted_at = None` — never a durable
+    /// unsigned local row: the consent-SLA watcher drives it to promotion
+    /// (federation-tier) or flags it overdue within the bounded window.
+    TransitRevocation,
+}
+
+/// True iff `(attestation_type, dimension, writer, subjects)` is a
+/// **subject-side** consent revocation (CEG §10.1.3, AV-61): a `withdraws`
+/// (structural) or a `consent:state:revoked` dimension whose writer
+/// (`attesting_key_id`) is a member of `subject_key_ids` — the subject
+/// exercising its own revocation right. The transit-not-rest classifier.
+#[must_use]
+pub fn is_subject_side_revocation(
+    attestation_type: &str,
+    dimension: Option<&str>,
+    attesting_key_id: &str,
+    subject_key_ids: &[String],
+) -> bool {
+    let is_revocation = attestation_type == crate::federation::types::attestation_type::WITHDRAWS
+        || dimension.is_some_and(|d| d.starts_with("consent:state:revoked"));
+    is_revocation && subject_key_ids.iter().any(|s| s == attesting_key_id)
 }
 
 /// v4.4.0 (CIRISPersist#171, CEG §10.1.3/§10.1.5/§7.5) — gate a row's
 /// eligibility for the **local tier** (signature-deferred,
 /// producer-only-authority). Local-tier eligibility is producer
 /// authority — NOT empty `subject_key_ids` (CEG §4.2.6: producer-
-/// authority rows legitimately name subjects). Exactly two classes are
-/// **refused** at local tier (they MUST be federation-tier, signed):
+/// authority rows legitimately name subjects).
+///
+/// One class is **hard-refused** at local tier:
 ///
 ///   1. **`capacity:*` (CEG §7.5 anti-Goodhart, AV-62).** A `capacity:*`
 ///      dimension rejects self-emission; the local tier's self-write →
 ///      self-read → deferred-sig shape is precisely the §7.5 forbidden
 ///      loop. Capacity is inherently third-party-attested.
+///
+/// A second class is **admitted as transit, not durable** (v12.6.0,
+/// resolving AV-61 per the §10.1.3 transit-not-rest ratification):
+///
 ///   2. **Subject-side revocation (CEG §10.1.3, AV-61).** A `withdraws`
 ///      (structural) or a `consent:state:revoked` dimension whose
 ///      **writer (`attesting_key_id`) is a member of `subject_key_ids`**
-///      — the subject exercising its own revocation right. Subject-side
-///      revocation is the federation-observability primitive peers
-///      depend on; it cannot ride the deferral path.
+///      — the subject exercising its own revocation right. It is
+///      federation-tier by classification but MAY *transit* the local
+///      write path: this returns [`LocalTierDisposition::TransitRevocation`]
+///      so the backend verifies the bound-hybrid signature before storing
+///      (accept on VALID crypto only) and marks the row transit (signed,
+///      `tier = local`, promotable/flaggable — never a durable local row).
+///      Pre-v12.6.0 this was a hard `Err`, which left the consent-SLA
+///      watcher firing on nothing (persist refused to originate any row for
+///      it to observe).
 ///
 /// `dimension` is the envelope dimension ([`envelope_dimension`]);
 /// `attestation_type` is the §3 structural primitive. Returns
-/// [`Error::InvalidArgument`] on an ineligible row; `Ok(())` otherwise.
+/// [`Error::InvalidArgument`] on an ineligible row (bad cohort_scope /
+/// capacity:*); otherwise the [`LocalTierDisposition`].
 pub fn check_local_tier_eligibility(
     attestation_type: &str,
     dimension: Option<&str>,
     attesting_key_id: &str,
     subject_key_ids: &[String],
     cohort_scope: &str,
-) -> Result<(), Error> {
+) -> Result<LocalTierDisposition, Error> {
     // (0) local rows are `self`-scoped (private to the producing
     // occurrence). The v4.0 `self`-cohort read-gate then IS the tier
     // read-gate (FSD §3 / CEG §10.1.5, AV-59); promotion widens scope.
@@ -979,18 +1147,18 @@ pub fn check_local_tier_eligibility(
                 .to_string(),
         ));
     }
-    // (2) subject-side revocation — never local (§10.1.3 / AV-61).
-    let is_revocation = attestation_type == crate::federation::types::attestation_type::WITHDRAWS
-        || dimension.is_some_and(|d| d.starts_with("consent:state:revoked"));
-    if is_revocation && subject_key_ids.iter().any(|s| s == attesting_key_id) {
-        return Err(Error::InvalidArgument(
-            "a subject-side revocation (the writer is a member of subject_key_ids) is NOT \
-             local-tier-eligible (CEG §10.1.3, AV-61): it must be federation-tier signed / \
-             promoted within the bounded window"
-                .to_string(),
-        ));
+    // (2) subject-side revocation — admitted as TRANSIT (§10.1.3, AV-61):
+    // the backend hybrid-verifies before storing, marks it transit, and the
+    // consent-SLA watcher drives it to promotion / overdue-flag.
+    if is_subject_side_revocation(
+        attestation_type,
+        dimension,
+        attesting_key_id,
+        subject_key_ids,
+    ) {
+        return Ok(LocalTierDisposition::TransitRevocation);
     }
-    Ok(())
+    Ok(LocalTierDisposition::Durable)
 }
 
 /// v4.4.0 (CIRISPersist#171, CEG §7.5 / AV-62) — the federation-path

--- a/src/federation/admission.rs
+++ b/src/federation/admission.rs
@@ -2733,6 +2733,135 @@ pub async fn check_single_node_owner_admission(
     Ok(())
 }
 
+/// **CIRISPersist#372 (CC 3.4.7.1 set-membership) — the `canonical`-role
+/// admission gate.** A `federation_keys` row may carry the
+/// [`super::types::identity_type::CANONICAL`] role (founding / canonical
+/// bootstrap server) in its `identity_type` **set** IFF the record is
+/// **anchor-scrub-signed**: `scrub_key_id != key_id` AND `scrub_key_id`'s
+/// Ed25519 pubkey ∈ the pinned HUMANITY_ACCORD anchor. That role is
+/// accord-CONFERRED, never self-claimed — a node cannot bootstrap itself into
+/// the founding set.
+///
+/// This wrapper pins the trusted anchor to the HUMANITY_ACCORD holder keyset
+/// (A1/B1/C1) via
+/// [`ciris_verify_core::accord_genesis::accord_holder_bootstrap_anchor`] — the
+/// SAME terminus [`super::rooting::root_binding`] and
+/// [`super::register::verify_key_registration`] verify against. Use
+/// [`check_canonical_role_admission_anchored`] to inject a different anchor
+/// (tests).
+///
+/// Behaviour:
+/// - The row's `identity_type` set does NOT contain `canonical` → `Ok(())`
+///   (no-op; the vast majority of rows).
+/// - It contains `canonical` AND the record is anchor-scrub-signed → `Ok(())`.
+/// - It contains `canonical` but the record is **self-signed**
+///   (`scrub_key_id == key_id`), scrubbed by an **unknown** key, or scrubbed
+///   by a key whose ed25519 is **not** in the anchor → refused with
+///   [`Error::CanonicalRoleNotAccordConferred`] (fail-closed; the caller must
+///   NOT store the row).
+///
+/// **Monotonicity.** Because this runs at every `federation_keys` write
+/// chokepoint (`put_public_key` on both backends + memory, plus the
+/// `adopt_scrub_upgrade` self→anchored path), `canonical` can never be added
+/// by a later self-registration or by replication of a self-signed row: those
+/// records are all self-signed (or non-anchor-scrubbed) and are refused here
+/// before any INSERT/UPDATE. The only way `canonical` enters the directory is
+/// an accord holder scrub-signing the node with the role (the Trust Root
+/// add-canonical op). Verify-before-mutation (AV-9); backend-agnostic.
+pub async fn check_canonical_role_admission(
+    directory: &dyn super::FederationDirectory,
+    row: &super::KeyRecord,
+) -> Result<(), Error> {
+    let anchor = ciris_verify_core::accord_genesis::accord_holder_bootstrap_anchor();
+    check_canonical_role_admission_anchored(directory, row, &anchor).await
+}
+
+/// [`check_canonical_role_admission`] with an explicit trusted-anchor keyset —
+/// the core primitive. `trusted_anchor` is a slice of raw 32-byte Ed25519
+/// keys; the scrubber's (`scrub_key_id`'s) ed25519 must appear in it or the
+/// `canonical` role is refused. Production callers use the
+/// [`check_canonical_role_admission`] wrapper (accord-holder anchor); this form
+/// exists so tests (and any alternative pinning) can supply their own anchor,
+/// mirroring [`super::rooting::root_binding_anchored`].
+pub async fn check_canonical_role_admission_anchored(
+    directory: &dyn super::FederationDirectory,
+    row: &super::KeyRecord,
+    trusted_anchor: &[[u8; 32]],
+) -> Result<(), Error> {
+    use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+
+    // Fast path: no `canonical` role in the set → nothing to gate.
+    if !identity_type::set_contains(&row.identity_type, identity_type::CANONICAL) {
+        return Ok(());
+    }
+
+    // Self-signed can NEVER confer `canonical` — this is the "a node cannot
+    // claim the founding role itself" invariant.
+    if row.scrub_key_id == row.key_id {
+        return Err(Error::CanonicalRoleNotAccordConferred {
+            key_id: row.key_id.clone(),
+            scrub_key_id: row.scrub_key_id.clone(),
+            reason: "self-signed record (scrub_key_id == key_id) cannot confer the `canonical` \
+                     role — it must be scrub-signed by a HUMANITY_ACCORD holder"
+                .to_owned(),
+        });
+    }
+
+    // Resolve the scrubber's row; an unknown scrubber cannot confer the role
+    // (fail-secure — the accord holder's key MUST already exist in the
+    // directory, the v12.2.0 gotcha).
+    let Some(scrubber) = directory.lookup_public_key(&row.scrub_key_id).await? else {
+        return Err(Error::CanonicalRoleNotAccordConferred {
+            key_id: row.key_id.clone(),
+            scrub_key_id: row.scrub_key_id.clone(),
+            reason: "scrub_key_id resolves to no federation_keys row — an unregistered scrubber \
+                     cannot confer the `canonical` role"
+                .to_owned(),
+        });
+    };
+
+    // The scrubber's ed25519 MUST be one of the pinned accord-holder anchor
+    // keys. This is the load-bearing gate: only the un-forgeable accord
+    // holders (A1/B1/C1) can confer `canonical`.
+    let raw = B64.decode(scrubber.pubkey_ed25519_base64.as_bytes()).ok();
+    let in_anchor = match raw {
+        Some(bytes) if bytes.len() == 32 => {
+            let mut ed = [0u8; 32];
+            ed.copy_from_slice(&bytes);
+            trusted_anchor.contains(&ed)
+        }
+        _ => false,
+    };
+    if !in_anchor {
+        return Err(Error::CanonicalRoleNotAccordConferred {
+            key_id: row.key_id.clone(),
+            scrub_key_id: row.scrub_key_id.clone(),
+            reason: "scrubber's ed25519 pubkey is not in the pinned HUMANITY_ACCORD anchor \
+                     (only accord holders may confer the `canonical` role)"
+                .to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+/// **CIRISPersist#372 — is `key_id` a canonical / founding bootstrap server?**
+/// True iff `key_id` resolves to a `federation_keys` row whose `identity_type`
+/// **set** contains [`super::types::identity_type::CANONICAL`]. Because
+/// [`check_canonical_role_admission`] gates every write path, a stored row can
+/// carry `canonical` only if it earned it via anchor-scrub — so this simple
+/// set-membership read is sufficient (the admission gate is the enforcement
+/// point). `false` for an unknown `key_id` or a non-canonical row.
+pub async fn is_canonical(
+    directory: &dyn super::FederationDirectory,
+    key_id: &str,
+) -> Result<bool, Error> {
+    Ok(directory
+        .lookup_public_key(key_id)
+        .await?
+        .is_some_and(|r| identity_type::set_contains(&r.identity_type, identity_type::CANONICAL)))
+}
+
 /// #249 Cut B — the steward-binding **PATH** for audit: the actual delegation
 /// chain `user → … → key_id` that steward-binds `key_id`, anchor-first (the
 /// human `user`-role key at index 0, `key_id` last). Where
@@ -5047,5 +5176,246 @@ mod tests {
         // agency kind — it just isn't an admissible node scope unprefixed.
         assert!(!scopes_are_infra_only(&scope_set(&["network_presence"])));
         assert!(!ds::is_legacy_agency_scope("network_presence"));
+    }
+}
+
+/// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — the accord-conferred `canonical`
+/// admission decision table, run identically against SQLite and (when
+/// `CIRIS_PERSIST_TEST_PG_URL` is set) Postgres. Exercises the PRODUCTION gate
+/// (`check_canonical_role_admission`, real HUMANITY_ACCORD anchor) end-to-end
+/// through `put_public_key` + `adopt_scrub_upgrade`, with the real A1 genesis
+/// holder seeded as the anchor scrubber (the v12.2.0 gotcha: the scrubber must
+/// exist as a `federation_keys` row). Proves `canonical` cannot be self-claimed
+/// via ANY path.
+#[cfg(all(test, any(feature = "sqlite", feature = "postgres")))]
+mod canonical_gate_tests {
+    use super::super::genesis::accord_holder_genesis_records;
+    use super::super::types::{algorithm, identity_type};
+    use super::super::{is_canonical, FederationDirectory, KeyRecord, SignedKeyRecord};
+    use crate::verify::canonical::ceg_produce_canonicalize;
+    use base64::engine::general_purpose::STANDARD as B64;
+    use base64::Engine as _;
+    use ed25519_dalek::SigningKey;
+    use sha2::{Digest, Sha256};
+
+    /// Build a `federation_keys` `KeyRecord` for `key_id` carrying
+    /// `identity_type`, scrubbed by `scrub_key_id` (set `== key_id` for a
+    /// self-signed row). The scrub-signature is NOT verified at the
+    /// `put_public_key` chokepoint (that is `verify_key_registration`'s job on
+    /// `register_federation_key`), so a syntactically-valid record suffices to
+    /// exercise the canonical admission gate. Deterministic per-key pubkey.
+    fn record(key_id: &str, identity_type: &str, scrub_key_id: &str) -> KeyRecord {
+        let mut seed = [0x11u8; 32];
+        for (i, b) in key_id.bytes().take(32).enumerate() {
+            seed[i] = b;
+        }
+        let ed = SigningKey::from_bytes(&seed);
+        let envelope = serde_json::json!({ "key_id": key_id });
+        let canonical = ceg_produce_canonicalize(&envelope).expect("canonicalize");
+        let now = chrono::Utc::now();
+        KeyRecord {
+            key_id: key_id.to_owned(),
+            pubkey_ed25519_base64: B64.encode(ed.verifying_key().to_bytes()),
+            pubkey_ml_dsa_65_base64: None,
+            algorithm: algorithm::HYBRID.to_owned(),
+            identity_type: identity_type.to_owned(),
+            identity_ref: key_id.to_owned(),
+            valid_from: now,
+            valid_until: None,
+            registration_envelope: envelope,
+            original_content_hash: hex::encode(Sha256::digest(&canonical)),
+            scrub_signature_classical: "AA".to_owned(),
+            scrub_signature_pqc: None,
+            scrub_key_id: scrub_key_id.to_owned(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+            consent_role: None,
+        }
+    }
+
+    async fn put(dir: &dyn FederationDirectory, rec: KeyRecord) -> Result<(), super::Error> {
+        dir.put_public_key(SignedKeyRecord { record: rec }).await
+    }
+
+    /// The full decision table over an anchor-seeded directory. `dir` MUST
+    /// already carry the genesis A1/B1/C1 holders. `tag` scopes key_ids so
+    /// parallel/repeat runs don't collide.
+    async fn run_put_matrix(dir: &dyn FederationDirectory, tag: &str) {
+        let a1 = &accord_holder_genesis_records()[0].record;
+        assert_eq!(a1.key_id, "A1");
+
+        // Seed a NON-anchor key that exists in the directory (a plain
+        // self-signed steward) — used as a non-anchor scrubber below.
+        let notanchor = format!("notanchor-{tag}");
+        put(dir, record(&notanchor, identity_type::STEWARD, &notanchor))
+            .await
+            .expect("plain non-anchor key admits");
+
+        // (1) ADMITTED: anchor-scrubbed `node,canonical` (scrub_key_id = A1,
+        //     A1's ed25519 ∈ the pinned anchor).
+        let good = format!("canon-good-{tag}");
+        put(dir, record(&good, "canonical,node", &a1.key_id))
+            .await
+            .expect("(1) anchor-scrubbed canonical must be ADMITTED");
+        assert!(
+            is_canonical(dir, &good).await.expect("is_canonical"),
+            "(1) admitted canonical row must resolve is_canonical == true"
+        );
+
+        // (2) REFUSED: self-signed `canonical` (scrub_key_id == key_id).
+        let selfsigned = format!("canon-self-{tag}");
+        let err = put(dir, record(&selfsigned, "canonical", &selfsigned))
+            .await
+            .expect_err("(2) self-signed canonical must be REFUSED");
+        assert_eq!(err.kind(), "canonical_role_not_accord_conferred");
+        assert!(
+            dir.lookup_public_key(&selfsigned).await.unwrap().is_none(),
+            "(2) refused self-signed canonical must leave NO row"
+        );
+        assert!(!is_canonical(dir, &selfsigned).await.unwrap());
+
+        // (3) REFUSED: non-anchor-scrubbed `canonical` (scrubber exists but is
+        //     not in the anchor).
+        let nonanchor_canon = format!("canon-nonanchor-{tag}");
+        let err = put(dir, record(&nonanchor_canon, "canonical,node", &notanchor))
+            .await
+            .expect_err("(3) non-anchor-scrubbed canonical must be REFUSED");
+        assert_eq!(err.kind(), "canonical_role_not_accord_conferred");
+        assert!(
+            dir.lookup_public_key(&nonanchor_canon)
+                .await
+                .unwrap()
+                .is_none(),
+            "(3) refused non-anchor canonical must leave NO row"
+        );
+
+        // (3') REFUSED: canonical scrubbed by an UNKNOWN key (fail-secure).
+        let unknown_canon = format!("canon-unknown-{tag}");
+        let err = put(
+            dir,
+            record(&unknown_canon, "canonical", &format!("ghost-{tag}")),
+        )
+        .await
+        .expect_err("(3') unknown-scrubber canonical must be REFUSED");
+        assert_eq!(err.kind(), "canonical_role_not_accord_conferred");
+
+        // (4) A plain `node` row is admitted and is NOT canonical.
+        let plain = format!("plain-node-{tag}");
+        put(dir, record(&plain, identity_type::NODE, &plain))
+            .await
+            .expect("(4) plain node admits");
+        assert!(
+            !is_canonical(dir, &plain).await.unwrap(),
+            "(4) plain node must not be canonical"
+        );
+
+        // (5) MONOTONIC: a self-signed `node` row is admitted; a later
+        //     SELF-registration of the same key adding `canonical` is REFUSED
+        //     (the role cannot be added by a later self-registration /
+        //     replication of a self-signed row).
+        let mono = format!("mono-{tag}");
+        put(dir, record(&mono, identity_type::NODE, &mono))
+            .await
+            .expect("(5) initial self-signed node admits");
+        let err = put(dir, record(&mono, "canonical,node", &mono))
+            .await
+            .expect_err("(5) later self-signed canonical must be REFUSED");
+        assert_eq!(err.kind(), "canonical_role_not_accord_conferred");
+        assert!(
+            !is_canonical(dir, &mono).await.unwrap(),
+            "(5) monotonic: canonical must NOT have been added"
+        );
+
+        // (6) is_canonical on an unknown key is false (not an error).
+        assert!(!is_canonical(dir, &format!("nope-{tag}")).await.unwrap());
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn canonical_matrix_sqlite() {
+        use crate::store::backend::Backend as _;
+        use crate::store::sqlite::SqliteBackend;
+
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .seed_genesis_accord_holders(accord_holder_genesis_records())
+            .await
+            .expect("genesis seed");
+
+        run_put_matrix(&backend, "sq").await;
+
+        // The enumerator returns exactly the one admitted canonical row.
+        let canon = backend.list_canonical_servers().await.expect("list");
+        assert_eq!(canon.len(), 1, "exactly one canonical row admitted");
+        assert_eq!(canon[0].key_id, "canon-good-sq");
+        assert!(identity_type::set_contains(
+            &canon[0].identity_type,
+            identity_type::CANONICAL
+        ));
+
+        // adopt_scrub_upgrade path is ALSO gated: seed a self-signed node,
+        // then attempt a non-anchor-scrubbed upgrade that adds canonical.
+        let up = "mono-adopt-sq";
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: record(up, identity_type::NODE, up),
+            })
+            .await
+            .expect("seed self-signed node for adopt");
+        // Non-anchor scrubber adding canonical via adopt → REFUSED.
+        let mut adopted = record(up, "canonical,node", "notanchor-sq");
+        adopted.pubkey_ed25519_base64 = record(up, identity_type::NODE, up).pubkey_ed25519_base64;
+        let err = backend
+            .adopt_scrub_upgrade(SignedKeyRecord { record: adopted })
+            .await
+            .expect_err("adopt adding canonical via non-anchor scrubber must be REFUSED");
+        assert_eq!(err.kind(), "canonical_role_not_accord_conferred");
+        assert!(!is_canonical(&backend, up).await.unwrap());
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn canonical_matrix_postgres() {
+        use crate::store::backend::Backend as _;
+        use crate::store::postgres::PostgresBackend;
+
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping canonical_matrix_postgres: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        // Fresh seed path: clear any prior A1/B1/C1 + our tagged rows.
+        let client = backend.pool().get().await.unwrap();
+        let _ = client
+            .execute(
+                "DELETE FROM cirislens.federation_keys WHERE key_id = ANY($1) \
+                 OR key_id LIKE 'canon-%pg' OR key_id LIKE '%-pg' OR identity_type LIKE '%canonical%'",
+                &[&vec!["A1".to_string(), "B1".to_string(), "C1".to_string()]],
+            )
+            .await;
+        backend
+            .seed_genesis_accord_holders(accord_holder_genesis_records())
+            .await
+            .expect("pg genesis seed");
+
+        run_put_matrix(&backend, "pg").await;
+
+        let canon = backend.list_canonical_servers().await.expect("list");
+        assert!(
+            canon.iter().any(|r| r.key_id == "canon-good-pg"),
+            "the admitted canonical row appears in list_canonical_servers"
+        );
+        assert!(
+            canon
+                .iter()
+                .all(|r| identity_type::set_contains(&r.identity_type, identity_type::CANONICAL)),
+            "every listed row carries canonical"
+        );
     }
 }

--- a/src/federation/age.rs
+++ b/src/federation/age.rs
@@ -9,6 +9,14 @@
 //! - `age_assurance:*` — the **witness** rung (provider/government). The
 //!   `attestation_type` is reserved to a `witness`-role emitter at admission
 //!   (see [`super::admission::check_reserved_prefix_admission`]). Authoritative.
+//!   v12.7.0 (CIRISPersist#368, CC 3.4.11/3.4.13): the row names its SUBJECT
+//!   via `attested_key_id` — the same cross-subject edge shape `delegates_to`
+//!   uses — so a witness graduates a **different** subject's band by emitting
+//!   with [`EmitAttestationInput::attested_key_id`](super::EmitAttestationInput::attested_key_id)
+//!   `= Some(subject)` (e.g. over [`crate::Engine::emit_attestation`]).
+//!   A subject MUST NOT emit on `age_assurance:` — attester==attested is
+//!   rejected at admission AND ignored here at read time (defense-in-depth),
+//!   so nobody self-mints their own graduation.
 //! - `age_self_declared:*` — the **self** rung (subject-signed onboarding
 //!   "state your band"). A self-declared **adult is IGNORED** here — the
 //!   one-way ratchet: a subject may self-declare MINOR to LOWER its own
@@ -229,6 +237,15 @@ pub async fn age_band(directory: &dyn FederationDirectory, k: &str) -> Result<Ag
         }
         let at = r.attestation_type.as_str();
         if at.starts_with("age_assurance:") {
+            // v12.7.0 (CIRISPersist#368, CC 3.4.11) — read-side
+            // defense-in-depth: a SELF-emitted witness row (attester ==
+            // attested) confers nothing. The admission gate
+            // (`check_reserved_prefix_admission`) rejects the shape at
+            // `put_attestation`, but a pre-gate legacy/replicated row must
+            // not graduate its own emitter either.
+            if r.attesting_key_id == r.attested_key_id {
+                continue;
+            }
             // Witness rung — authoritative. The most recent one that parses
             // to a recognized band wins outright.
             if let Some(band) = parse_age_band_token(at) {
@@ -283,6 +300,11 @@ pub async fn age_band_fine(
         }
         let at = r.attestation_type.as_str();
         if at.starts_with("age_assurance:") {
+            // v12.7.0 (CIRISPersist#368, CC 3.4.11) — a self-emitted witness
+            // row confers nothing (see `age_band`; same defense-in-depth).
+            if r.attesting_key_id == r.attested_key_id {
+                continue;
+            }
             // Witness rung — authoritative; most-recent parse wins outright.
             if let Some(band) = parse_age_band_fine_token(at) {
                 return Ok(band);

--- a/src/federation/blobs.rs
+++ b/src/federation/blobs.rs
@@ -2636,6 +2636,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::types::SignedKeyRecord {

--- a/src/federation/consent.rs
+++ b/src/federation/consent.rs
@@ -1,0 +1,66 @@
+//! v12.7.0 (CIRISPersist#365, CC 3.4.7.2 `consent-counter`) — the
+//! **Counter-RII `consent_role`** resolver.
+//!
+//! `federation_keys.consent_role` is the role token (see the
+//! [`consent_role`](super::types::consent_role) vocabulary — `temporary`
+//! / `partnered` / `anonymous` / `authorized_review` / `peer`, with
+//! `unregistered` as the stored no-role default) that gates Counter-RII
+//! probe detection (RATCHET `FSD/COUNTER_RII_DETECTION.md`; Lean
+//! `ConsentGate.lean`). Per CC 3.4.7.2 it is a **`federation_keys`
+//! identity field** — a sibling to `identity_type`, NOT an envelope
+//! primitive — and the clause states implementations MAY now build the
+//! substrate (no longer a reserved slot). The COLUMN itself already
+//! shipped in V020 (v1.3.0, the CIRISAgent#760 §RC "consent role lock"
+//! that CC 3.4.7.2 ratifies — `TEXT NOT NULL DEFAULT 'unregistered'`);
+//! v12.7.0 puts it on the wire ([`KeyRecord::consent_role`](super::KeyRecord),
+//! `None` ⇔ the stored `'unregistered'`) and exposes this resolver.
+//!
+//! **What persist owns (and does NOT own).** The three ratified
+//! semantics split by responsibility:
+//!
+//! - **OQ-1 (non-recursive revocation — SUBSTRATE):** a subsequent
+//!   revocation OVERWRITES the prior value; the field is flat, bounded,
+//!   and carries NO embedded chain. Persist implements this as the
+//!   natural UPDATE/overwrite of the single mutable V020 column via
+//!   [`super::FederationDirectory::set_consent_role`] (revoke = set
+//!   `None` = reset to `'unregistered'`). The field is excluded from
+//!   `compute_persist_row_hash` so the overwrite never disturbs the
+//!   signed-registration hash.
+//! - **OQ-2 (`peer` blanket suppression — CONSUMER):** a `peer`
+//!   `consent_role` escapes Counter-RII detection at any `trust_mode`.
+//!   Persist STORES + EXPOSES the role; edge's `ProbePatternObserver`
+//!   reads it (via [`consent_role_of`]) and suppresses the
+//!   advisory-only `ratchet:flag:counter_rii:*` signal. Persist houses
+//!   no detector, so it applies no suppression itself.
+//! - **OQ-3 (`authorized_review` strict post-window — CONSUMER):** an
+//!   `authorized_review` role is signal-eligible immediately at
+//!   `t > window_end`. Same split — persist carries the role; the
+//!   consumer enforces the window.
+//!
+//! So this module is the STORE + EXPOSE + OQ-1 half; OQ-2 / OQ-3 are
+//! consumer-applied signals on the field persist now carries.
+
+use super::{Error, FederationDirectory};
+
+/// v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — resolve the Counter-RII
+/// `consent_role` of `key_id`.
+///
+/// Returns `Ok(Some(role))` when the key exists and carries an assigned
+/// role; `Ok(None)` when the key exists with no assigned role (the
+/// stored `'unregistered'` default — including after an OQ-1
+/// revoke-overwrite) **or** when `key_id` is absent. The resolver is
+/// deliberately total: an absent key and a role-less key are both "no
+/// assigned Counter-RII role", which a consumer treats identically
+/// (detection applies normally, no suppression). The returned token is
+/// one of the assigned [`consent_role`](super::types::consent_role)
+/// tokens; the consumer interprets it — persist does not gate on the
+/// value here.
+pub async fn consent_role_of(
+    dir: &dyn FederationDirectory,
+    key_id: &str,
+) -> Result<Option<String>, Error> {
+    Ok(dir
+        .lookup_public_key(key_id)
+        .await?
+        .and_then(|record| record.consent_role))
+}

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -43,6 +43,7 @@ pub mod blobs;
 pub mod capacity;
 pub mod cohort;
 pub mod community_dek;
+pub mod consent;
 #[cfg(feature = "cirisaudit")]
 pub mod emit;
 pub mod genesis;
@@ -140,6 +141,7 @@ pub use blobs::{
     HOLDS_BYTES_ATTESTATION_TYPE_PREFIX, HOLDS_BYTES_PREFIX_HEX_LEN,
 };
 pub use cohort::{Cohort, GroupRef, GroupVersion, RevokeSpec, RosterMember};
+pub use consent::consent_role_of;
 pub use goal::{
     canonicalize_goal_text, DeliberationRef, Goal, GoalScope, GoalsFilter, M1Dimension,
     MetaGoalAlignment,
@@ -194,7 +196,7 @@ pub use topology::{
     DelegationGraph, EdgeType, FederationDirectoryFilter, TrustEdge, TrustNode, TrustTopology,
     WithdrawalEntry, MAX_DELEGATION_DEPTH,
 };
-pub use types::{device_class, identity_type};
+pub use types::{consent_role, device_class, identity_type};
 pub use types::{
     Attestation, Community, CommunityMember, CommunityMembershipRevocation, EmitAttestationInput,
     EncryptionPubkeys, Family, FamilyMember, FamilyMembershipRevocation, HybridPendingRow,
@@ -376,6 +378,35 @@ pub trait FederationDirectory: Send + Sync {
         &self,
         identity_type: &str,
     ) -> Result<Vec<KeyRecord>, Error>;
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 `consent-counter`) — assign
+    /// or **overwrite** the Counter-RII [`consent_role`](types::consent_role)
+    /// of `key_id`.
+    ///
+    /// This is the OQ-1 **non-recursive, overwrite-on-revoke** mutation
+    /// on the V020 `federation_keys.consent_role` column (the
+    /// CIRISAgent#760 §RC lock CC 3.4.7.2 ratifies): `Some(role)` sets
+    /// one of the six ratified tokens ([`types::consent_role::RECOGNIZED`]
+    /// — an unrecognized token is [`Error::InvalidArgument`] on EVERY
+    /// backend, keeping PG's schema CHECK and CHECK-less SQLite
+    /// symmetric); `None` revokes it back to the stored `'unregistered'`
+    /// default. There is NO chain — a subsequent call simply overwrites
+    /// the single flat column (chain history, if a deployment wants it,
+    /// lives in a separate audit surface, never embedded in this field).
+    /// `consent_role` is excluded from `persist_row_hash`, so the
+    /// overwrite does not disturb the signed registration row (and
+    /// `adopt_scrub_upgrade` never touches it). Returns
+    /// [`Error::InvalidArgument`] if `key_id` has no `federation_keys`
+    /// row.
+    ///
+    /// Persist's responsibility ends at STORE + EXPOSE + this overwrite.
+    /// The OQ-2 (`peer` blanket suppression) and OQ-3
+    /// (`authorized_review` strict post-window) *detection signals* are
+    /// applied by the consumer (edge `ProbePatternObserver` / RATCHET)
+    /// reading the role via [`consent::consent_role_of`] — persist houses
+    /// no Counter-RII detector.
+    async fn set_consent_role(&self, key_id: &str, consent_role: Option<&str>)
+        -> Result<(), Error>;
 
     // ── Attestations ───────────────────────────────────────────────
 

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -128,8 +128,9 @@ pub(crate) mod serde_bytes_b64 {
 }
 
 pub use admission::{
-    check_cohort_scope, check_consensus_protocol_form, check_device_class,
-    check_encryption_pubkeys, check_observed_region, AttestationLadderTransitionPolicy,
+    check_canonical_role_admission, check_canonical_role_admission_anchored, check_cohort_scope,
+    check_consensus_protocol_form, check_device_class, check_encryption_pubkeys,
+    check_observed_region, is_canonical, AttestationLadderTransitionPolicy,
     DimensionAdmissionPolicy, DimensionRejectionReason, ReachabilityVerdict, ReservedPrefixRule,
     ATTESTATION_LADDER_MECHANISMS,
 };
@@ -3673,6 +3674,38 @@ pub enum Error {
         owners: Vec<String>,
     },
 
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1 set-membership) — a
+    /// `federation_keys` row carrying the [`types::identity_type::CANONICAL`]
+    /// role was REJECTED at admission because it is **not accord-conferred**.
+    /// The `canonical` (founding bootstrap server) role is accord-CONFERRED,
+    /// never self-claimed: a row may carry it **iff** the record is
+    /// anchor-scrub-signed (`scrub_key_id != key_id` AND `scrub_key_id`'s
+    /// Ed25519 pubkey ∈ the pinned HUMANITY_ACCORD anchor —
+    /// [`ciris_verify_core::accord_genesis::accord_holder_bootstrap_anchor`]).
+    /// A **self-signed** record carrying `canonical`, or one scrubbed by a
+    /// **non-anchor** key, is refused here (fail-closed) — the row is NOT
+    /// stored (verify-before-mutation, AV-9). This closes the "a node
+    /// bootstraps itself into the founding set" gap on EVERY admission path
+    /// (direct registration, self-registration, replication of a self-signed
+    /// row, and the `adopt_scrub_upgrade` self→anchored path). Stable
+    /// `kind()` token `canonical_role_not_accord_conferred`. See
+    /// [`admission::check_canonical_role_admission`].
+    #[error(
+        "federation_keys row {key_id:?} carries the `canonical` role but is not accord-conferred \
+         (scrub_key_id={scrub_key_id:?}, reason: {reason}); the `canonical` founding-server role \
+         is accord-CONFERRED, never self-claimed — a row may carry it only when anchor-scrub-signed \
+         (scrub_key_id != key_id AND the scrubber's ed25519 ∈ the pinned HUMANITY_ACCORD anchor)"
+    )]
+    CanonicalRoleNotAccordConferred {
+        /// The `key_id` of the row that attempted to carry `canonical`.
+        key_id: String,
+        /// The row's `scrub_key_id` (the claimed scrubber).
+        scrub_key_id: String,
+        /// Why the record failed the accord-conferred test (self-signed /
+        /// unknown scrubber / non-anchor scrubber / undecodable scrubber key).
+        reason: String,
+    },
+
     /// v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — a **federation-tier**
     /// attestation was REJECTED at the bulk store/replicate ingest gate
     /// because its envelope hybrid signature could not be verified
@@ -3925,6 +3958,7 @@ impl Error {
             Error::NodeAgencyForbidden { .. } => "federation_node_agency_forbidden",
             Error::NodeAlreadyOwned { .. } => "federation_node_already_owned",
             Error::AmbiguousNodeOwner { .. } => "federation_ambiguous_node_owner",
+            Error::CanonicalRoleNotAccordConferred { .. } => "canonical_role_not_accord_conferred",
             Error::UnstewardedCommunityMember { .. } => "federation_unstewarded_community_member",
             Error::UserTargetStewardBindingForbidden { .. } => {
                 "federation_user_target_steward_binding_forbidden"

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -186,7 +186,9 @@ pub use stream_sth::{
     log_id_for_stream, parse_stream_id, recompute_and_assert_root, StreamChunkLeaf,
     STREAM_LOG_ID_PREFIX,
 };
-pub use tier_ingest::verify_federation_tier_ingest;
+pub use tier_ingest::{
+    verify_envelope_hybrid_signature, verify_federation_tier_ingest, verify_row_hybrid_signature,
+};
 pub use topology::{
     build_delegation_graph, build_trust_topology, AuditChainEntry, AuditChainProof, DelegationEdge,
     DelegationGraph, EdgeType, FederationDirectoryFilter, TrustEdge, TrustNode, TrustTopology,

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -3177,6 +3177,30 @@ pub enum Error {
         attestation_type: String,
     },
 
+    /// v12.7.0 (CIRISPersist#368, CC 3.4.11). An `age_assurance:*`
+    /// attestation was self-emitted (`attesting_key_id ==
+    /// attested_key_id`). The witness rung is an attestation ABOUT a
+    /// subject: CC 3.4.11 — "A subject MUST NOT emit on `age_assurance:`;
+    /// … a CCS MUST reject … at admission". Without this check a key that
+    /// happens to carry the `witness` identity_type could graduate ITSELF
+    /// to `adult` — the self-minted adulthood the witness reservation
+    /// exists to prevent. Rejected at admission; the row is not stored.
+    /// The exact sibling of [`Error::CapacitySelfEmissionRejected`]
+    /// (CC 3.4.12's identical subject-must-not-emit rule for
+    /// `capacity_assurance:*`); like it, an attester==attested check
+    /// independent of `identity_type`.
+    #[error(
+        "age_assurance:* self-emission rejected: attesting_key_id == attested_key_id \
+         ({key_id:?}) — a subject must not emit its own age assurance (CC 3.4.11; \
+         attestation_type={attestation_type:?})"
+    )]
+    AgeAssuranceSelfEmissionRejected {
+        /// The key that attempted to self-emit an `age_assurance:*` row.
+        key_id: String,
+        /// The `attestation_type` that triggered the rejection.
+        attestation_type: String,
+    },
+
     /// v2.5.0 (CIRISPersist#102 Ask 4). The submitted `scores`
     /// attestation's `attestation_envelope` failed JSON Schema
     /// validation against the per-axis schema registered for the
@@ -3864,6 +3888,9 @@ impl Error {
             Error::DimensionRejected { .. } => "federation_dimension_rejected",
             Error::CapacitySelfEmissionRejected { .. } => {
                 "federation_capacity_self_emission_rejected"
+            }
+            Error::AgeAssuranceSelfEmissionRejected { .. } => {
+                "federation_age_assurance_self_emission_rejected"
             }
             Error::ReservedPrefixEmitterMismatch { .. } => {
                 "federation_reserved_prefix_emitter_mismatch"

--- a/src/federation/register.rs
+++ b/src/federation/register.rs
@@ -360,6 +360,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence,
+            consent_role: None,
         };
         if drop_pqc {
             // A hybrid-pending row also drops the PQC pubkey.

--- a/src/federation/register.rs
+++ b/src/federation/register.rs
@@ -107,6 +107,151 @@ pub enum AdoptScrubOutcome {
     AlreadyAdopted,
 }
 
+/// v12.7.0 (CIRISPersist#371) — outcome of an
+/// [`apply_replicated_key_record`](crate::engine::Engine::apply_replicated_key_record),
+/// the **upgrade-aware replicated Key-plane apply**. Serde tokens are
+/// snake_case strings (`"inserted"` / `"upgraded"` / `"unchanged"` /
+/// `"refused"`), mirroring [`AdoptScrubOutcome`]'s wire shape.
+///
+/// A `Refused` is a *policy* outcome, not an error: the anti-entropy Key
+/// plane receives unsolicited records, so every gate failure that means
+/// "this record is not admitted against the current row" resolves to
+/// `Refused` (fail-closed, deterministic, safe to re-offer on the next
+/// anti-entropy round) rather than aborting the apply loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReplicatedKeyOutcome {
+    /// New `key_id` — stored via `put_public_key` (exactly the direct
+    /// registration path, including its admission gates).
+    Inserted,
+    /// Existing **self-signed** row replaced by the incoming
+    /// **anchor-scrubbed** record for the same identity (the #351
+    /// `adopt_scrub_upgrade`, now riding replication).
+    Upgraded,
+    /// The row already carries this exact record — idempotent no-op.
+    Unchanged,
+    /// The record was NOT applied: pubkey swap, anchored→self downgrade,
+    /// anchor-A→anchor-B re-scrub, conflicting second version (first-seen
+    /// wins), unverifiable scrub-signature, or an absent/ambiguous node
+    /// owner (`owner_of` fail-closed). The existing row is untouched.
+    Refused,
+}
+
+/// The classification half of the #371 replicated-key apply — which action
+/// [`apply_replicated_key_record`](crate::engine::Engine::apply_replicated_key_record)
+/// takes for an incoming record given the current directory state.
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplicatedKeyPlan {
+    /// No row for `key_id` — insert via `put_public_key` (as today).
+    Insert,
+    /// Self-signed → anchor-scrubbed, all gates passed — run the backend's
+    /// monotonic `adopt_scrub_upgrade`.
+    Upgrade,
+    /// Byte-identical re-apply — no-op.
+    Unchanged,
+    /// Not admitted; leave the row untouched (fail-closed).
+    Refused,
+}
+
+/// v12.7.0 (CIRISPersist#371) — decide what an **upgrade-aware replicated
+/// Key-plane apply** does with `record`, WITHOUT mutating anything. The
+/// shared (backend-agnostic) policy core behind both backends'
+/// `apply_replicated_key_record`, so postgres and sqlite cannot drift.
+///
+/// Decision table (the #371 spec):
+///
+/// - **no existing row** ⇒ [`ReplicatedKeyPlan::Insert`] — the store step is
+///   `put_public_key` itself, so every direct-registration admission gate
+///   (32-byte Ed25519, `hybrid` algorithm, `accord_holder`
+///   hardware-attestation) still binds; nothing is bypassed for fresh rows.
+/// - **byte-identical re-apply** (same `persist_row_hash`, which is computed
+///   over the canonical row with the hash field dropped) ⇒
+///   [`ReplicatedKeyPlan::Unchanged`].
+/// - **any pubkey change** — Ed25519 OR ML-DSA-65 — ⇒
+///   [`ReplicatedKeyPlan::Refused`]. A replicated apply may never swap an
+///   identity's keys (stricter than #351's Ed25519-only Rust pre-check: on
+///   the unattended replication plane the PQC half is identity too).
+/// - **existing self-signed + incoming anchor-scrubbed** ⇒ upgrade, iff ALL
+///   of (fail-closed on each):
+///   1. the incoming scrub verifies through the SAME
+///      [`verify_key_registration`] `Strict` gate as
+///      `register_federation_key` / `adopt_scrub_upgrade` — the scrubber
+///      (`scrub_key_id`) is resolved from the directory, i.e. it chains to
+///      the seeded HUMANITY_ACCORD anchor rows on a real node; a
+///      verification failure ⇒ `Refused`, and
+///   2. [`owner_of`](crate::federation::admission::owner_of)`(key_id)`
+///      resolves to exactly ONE live owner — the row is inside a
+///      well-defined single-owner node set (the v12.6.0 invariant that makes
+///      auto-upgrade-on-replication safe: the Key-plane cohort spans exactly
+///      the owner's nodes, CIRISServer#162). An unowned node (`None`) or an
+///      [`Error::AmbiguousNodeOwner`] pre-gate anomaly ⇒ `Refused`.
+///      (The record itself carries no owner field — verify's
+///      `produce_scrubbed_key_record` envelope shape is pinned — so the
+///      owner scope is resolved from the local attestation graph, the same
+///      source the owner's replication cohort is built from.)
+/// - **monotonic**: anchored→self (downgrade), anchor-A→anchor-B (re-scrub
+///   hijack), and a conflicting second self-signed version are all
+///   first-seen/duplicity ⇒ [`ReplicatedKeyPlan::Refused`].
+///
+/// Malformed input that no policy can classify (e.g. an un-canonicalizable
+/// row) and backend failures still surface as `Err` — `Refused` is reserved
+/// for "well-formed but not admitted".
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+pub(crate) async fn plan_replicated_key_apply(
+    directory: &dyn FederationDirectory,
+    record: &KeyRecord,
+) -> Result<ReplicatedKeyPlan, Error> {
+    let Some(existing) = directory.lookup_public_key(&record.key_id).await? else {
+        return Ok(ReplicatedKeyPlan::Insert);
+    };
+
+    // Idempotent re-apply: byte-identical row. `compute_persist_row_hash`
+    // drops the `persist_row_hash` field itself, so a record that arrives
+    // carrying the origin row's hash still compares stably.
+    let incoming_hash = super::types::compute_persist_row_hash(record)?;
+    if existing.persist_row_hash == incoming_hash {
+        return Ok(ReplicatedKeyPlan::Unchanged);
+    }
+
+    // Never a pubkey swap — BOTH hybrid halves must be identical. A
+    // different pubkey is a different identity, whatever the scrub says.
+    if existing.pubkey_ed25519_base64 != record.pubkey_ed25519_base64
+        || existing.pubkey_ml_dsa_65_base64 != record.pubkey_ml_dsa_65_base64
+    {
+        return Ok(ReplicatedKeyPlan::Refused);
+    }
+
+    let existing_self_signed = existing.scrub_key_id == existing.key_id;
+    let incoming_anchor_scrubbed = record.scrub_key_id != record.key_id;
+    if !(existing_self_signed && incoming_anchor_scrubbed) {
+        // anchored→self downgrade, anchor-A→anchor-B re-scrub, or a
+        // conflicting second self-signed version: first-seen/duplicity.
+        return Ok(ReplicatedKeyPlan::Refused);
+    }
+
+    // Gate 1 — the incoming scrub must verify (Strict hybrid, scrubber
+    // pubkeys resolved from the directory ⇒ chains to the seeded accord
+    // anchor). An unverifiable or malformed record is not admitted.
+    if let Err(e) = verify_key_registration(directory, record).await {
+        return match e {
+            Error::SignatureInvalid(_) | Error::InvalidArgument(_) => {
+                Ok(ReplicatedKeyPlan::Refused)
+            }
+            other => Err(other),
+        };
+    }
+
+    // Gate 2 — the row must sit inside a single owner's node set
+    // (v12.6.0 `owner_of`). Unowned or ambiguous ⇒ fail-closed.
+    match super::admission::owner_of(directory, &record.key_id).await {
+        Ok(Some(_)) => Ok(ReplicatedKeyPlan::Upgrade),
+        Ok(None) => Ok(ReplicatedKeyPlan::Refused),
+        Err(Error::AmbiguousNodeOwner { .. }) => Ok(ReplicatedKeyPlan::Refused),
+        Err(e) => Err(e),
+    }
+}
+
 /// v10.1.0 (CIRISPersist#275 hardening) — the **write-path admission
 /// invariant** for a `federation_keys` row's classical public key: it
 /// MUST base64-decode to exactly 32 bytes (a valid Ed25519 key).
@@ -678,5 +823,227 @@ mod tests {
         // the federation_keys PK (key_id is TEXT; uuid-suffix it).
         let tag = format!("pg-{}", uuid::Uuid::new_v4().simple());
         run_register_matrix(&engine, &tag).await;
+    }
+
+    // ─── v12.7.0 (CIRISPersist#371) — apply_replicated_key_record ───
+    //
+    // The upgrade-aware replicated Key-plane apply decision table, run
+    // identically against sqlite and (when CIRIS_PERSIST_TEST_PG_URL is
+    // set) postgres through the Engine wrapper, mirroring
+    // `run_register_matrix`. The ambiguous-owner (pre-gate anomaly) row
+    // needs raw SQL and lives with the backend siblings
+    // (`src/store/{sqlite,postgres}.rs`).
+
+    /// Apply one replicated record through the Engine wrapper.
+    async fn apply_one(engine: &Engine, record: KeyRecord) -> ReplicatedKeyOutcome {
+        engine
+            .apply_replicated_key_record(SignedKeyRecord { record })
+            .await
+            .expect("apply_replicated_key_record")
+    }
+
+    /// The `scrub_key_id` of `key_id`'s current directory row (the
+    /// self-signed vs anchor-scrubbed discriminator the matrix asserts on).
+    async fn row_scrub(engine: &Engine, key_id: &str) -> String {
+        engine
+            .federation_directory()
+            .lookup_public_key(key_id)
+            .await
+            .expect("lookup")
+            .expect("row exists")
+            .scrub_key_id
+    }
+
+    /// The #371 decision table: fresh insert (self-signed AND
+    /// anchor-scrubbed); idempotent re-apply; conflicting second version;
+    /// unverifiable scrub; pubkey swap (Ed25519 AND ML-DSA-65 halves);
+    /// absent owner; self→anchored upgrade happy path; anchored→self
+    /// downgrade; anchor-A→anchor-B re-scrub.
+    async fn run_apply_replicated_matrix(engine: &Engine, tag: &str) {
+        use crate::federation::register::ReplicatedKeyOutcome as O;
+        use crate::federation::tier_ingest::test_support as ts;
+        let directory = engine.federation_directory();
+        let dir = directory.as_ref();
+
+        let scrubber = format!("apply-anchor-a-{tag}");
+        let scrubber_b = format!("apply-anchor-b-{tag}");
+        let owner = format!("apply-owner-{tag}");
+        let node = format!("apply-node-{tag}");
+        // The scrubbers must exist as directory rows (the Strict gate
+        // resolves a granting-authority signer's pubkeys from the
+        // directory — the seeded accord-anchor shape) and the owner must
+        // be a live `user`-role granter for `owner_of`.
+        ts::register_hybrid_key(dir, &scrubber).await;
+        ts::register_hybrid_key(dir, &scrubber_b).await;
+        ts::register_identity_key(dir, &owner, identity_type::USER).await;
+
+        // (1) fresh insert — new key_id, self-signed (the boot state).
+        let self_rec = ts::replicated_key_record(&node, identity_type::NODE, &node, &node, "v1");
+        assert_eq!(
+            apply_one(engine, self_rec.clone()).await,
+            O::Inserted,
+            "(1) fresh insert"
+        );
+
+        // (2) byte-identical re-apply ⇒ Unchanged (idempotent).
+        assert_eq!(
+            apply_one(engine, self_rec.clone()).await,
+            O::Unchanged,
+            "(2) idempotent"
+        );
+
+        // (3) a conflicting second self-signed version ⇒ Refused
+        // (first-seen/duplicity; put_public_key's direct path stays
+        // untouched by this apply).
+        let self_v2 = ts::replicated_key_record(&node, identity_type::NODE, &node, &node, "v2");
+        assert_eq!(
+            apply_one(engine, self_v2).await,
+            O::Refused,
+            "(3) conflicting version"
+        );
+
+        // (4) verifiable anchor-scrubbed record but NO owner-binding ⇒
+        // Refused — the row is not inside any single-owner node set
+        // (owner_of = None, fail-closed), so replication may not upgrade it.
+        let scrubbed =
+            ts::replicated_key_record(&node, identity_type::NODE, &scrubber, &scrubber, "v1");
+        assert_eq!(
+            apply_one(engine, scrubbed.clone()).await,
+            O::Refused,
+            "(4) absent owner"
+        );
+        assert_eq!(
+            row_scrub(engine, &node).await,
+            node,
+            "(4) refused apply must leave the self-signed row untouched"
+        );
+
+        // Seed the owner-binding: delegates_to(owner → node) on the
+        // ownership dimension (the v12.6.0 single-owner relation).
+        directory
+            .put_attestation(crate::federation::SignedAttestation {
+                attestation: ts::owner_binding_attestation(
+                    &uuid::Uuid::new_v4().to_string(),
+                    &owner,
+                    &node,
+                ),
+            })
+            .await
+            .expect("owner-binding admitted");
+
+        // (5) unverifiable scrub — claims `scrubber`, signed by
+        // `scrubber_b` ⇒ Refused (Strict gate), row untouched.
+        let bad_sig =
+            ts::replicated_key_record(&node, identity_type::NODE, &scrubber, &scrubber_b, "v1");
+        assert_eq!(
+            apply_one(engine, bad_sig).await,
+            O::Refused,
+            "(5) unverifiable scrub"
+        );
+        assert_eq!(row_scrub(engine, &node).await, node, "(5) row untouched");
+
+        // (6) pubkey swap ⇒ Refused — EITHER hybrid half. Never an
+        // identity swap on the replication plane, whatever the scrub says.
+        let (other_ed, other_mldsa) = ts::hybrid_pubkeys(&format!("someone-else-{tag}"));
+        let mut ed_swap = scrubbed.clone();
+        ed_swap.pubkey_ed25519_base64 = other_ed;
+        assert_eq!(
+            apply_one(engine, ed_swap).await,
+            O::Refused,
+            "(6) Ed25519 swap"
+        );
+        let mut mldsa_swap = scrubbed.clone();
+        mldsa_swap.pubkey_ml_dsa_65_base64 = other_mldsa;
+        assert_eq!(
+            apply_one(engine, mldsa_swap).await,
+            O::Refused,
+            "(6) ML-DSA-65 swap"
+        );
+        assert_eq!(row_scrub(engine, &node).await, node, "(6) row untouched");
+
+        // (7) the happy path: same key_id + same hybrid pubkeys, scrub
+        // Strict-verifies against the directory-resolved scrubber, owner_of
+        // resolves exactly one live owner ⇒ Upgraded (the #351 adopt path
+        // riding replication).
+        assert_eq!(
+            apply_one(engine, scrubbed.clone()).await,
+            O::Upgraded,
+            "(7) upgrade"
+        );
+        assert_eq!(
+            row_scrub(engine, &node).await,
+            scrubber,
+            "(7) row is now anchor-scrubbed"
+        );
+
+        // (8) re-apply of the exact anchored record ⇒ Unchanged.
+        assert_eq!(
+            apply_one(engine, scrubbed.clone()).await,
+            O::Unchanged,
+            "(8) idempotent anchored"
+        );
+
+        // (9) anchored→self downgrade ⇒ Refused (monotonic).
+        assert_eq!(
+            apply_one(engine, self_rec).await,
+            O::Refused,
+            "(9) downgrade"
+        );
+        assert_eq!(
+            row_scrub(engine, &node).await,
+            scrubber,
+            "(9) still anchored"
+        );
+
+        // (10) anchor-A→anchor-B re-scrub ⇒ Refused (duplicity/first-seen),
+        // even though the record itself verifies.
+        let rescrub =
+            ts::replicated_key_record(&node, identity_type::NODE, &scrubber_b, &scrubber_b, "v1");
+        assert_eq!(
+            apply_one(engine, rescrub).await,
+            O::Refused,
+            "(10) re-scrub hijack"
+        );
+        assert_eq!(
+            row_scrub(engine, &node).await,
+            scrubber,
+            "(10) still anchor A"
+        );
+
+        // (11) fresh insert of an anchor-scrubbed record for an UNKNOWN
+        // key_id ⇒ Inserted — new-key inserts are exactly put_public_key
+        // "as today" (no owner gate on the insert path).
+        let node2 = format!("apply-node2-{tag}");
+        let fresh_scrubbed =
+            ts::replicated_key_record(&node2, identity_type::NODE, &scrubber, &scrubber, "v1");
+        assert_eq!(
+            apply_one(engine, fresh_scrubbed).await,
+            O::Inserted,
+            "(11) fresh scrubbed insert"
+        );
+        assert_eq!(row_scrub(engine, &node2).await, scrubber);
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn apply_replicated_matrix_sqlite() {
+        let engine = Engine::with_signer(test_signer(), "sqlite::memory:")
+            .await
+            .expect("construct sqlite engine");
+        run_apply_replicated_matrix(&engine, "sqlite").await;
+    }
+
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    async fn apply_replicated_matrix_postgres() {
+        let Ok(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL") else {
+            eprintln!("skipping apply_replicated_matrix_postgres: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let engine = Engine::with_signer(test_signer(), &dsn)
+            .await
+            .expect("construct postgres engine");
+        let tag = format!("pg-{}", uuid::Uuid::new_v4().simple());
+        run_apply_replicated_matrix(&engine, &tag).await;
     }
 }

--- a/src/federation/replication/eviction.rs
+++ b/src/federation/replication/eviction.rs
@@ -100,6 +100,14 @@ pub struct EvictionCandidate {
     /// (fail-toward-eviction is safe: an unattributed blob we can
     /// re-fetch is the right thing to shed first).
     pub attesting_key_id: Option<String>,
+    /// v12.7.0 (§Q B5 / CIRISPersist#370) — the row's
+    /// `federation_blobs.media_type`, the substrate's per-blob corpus-class
+    /// token. The sweep matches it against the installed
+    /// `StorageBudgetV1.pinned_class` set to classify the candidate as
+    /// PINNED (evict last, cache-before-pinned) vs cache. `None` ⇒ no
+    /// class ⇒ never pinned (fail-toward-eviction, same posture as
+    /// `attesting_key_id`).
+    pub media_type: Option<String>,
 }
 
 /// v3.4.0 (CIRISPersist#123) — outcome of one sweep cycle.

--- a/src/federation/rooting.rs
+++ b/src/federation/rooting.rs
@@ -973,6 +973,7 @@ mod conformance_helpers {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -423,6 +423,132 @@ pub(crate) mod test_support {
             Some(B64.encode(&pqc_sig)),
         )
     }
+
+    /// #371 — register `key_id` with its REAL deterministic hybrid pubkeys
+    /// and an explicit `identity_type` (the [`register_hybrid_key`] shape,
+    /// but e.g. `user`-role for `owner_of` granters or `node`-role for
+    /// owned-node rows). Self-signed, deterministic timestamps so a rebuilt
+    /// record is byte-identical.
+    pub async fn register_identity_key<D: crate::federation::FederationDirectory + ?Sized>(
+        dir: &D,
+        key_id: &str,
+        identity_type: &str,
+    ) {
+        let record = replicated_key_record(
+            key_id,
+            identity_type,
+            key_id, // self-signed
+            key_id,
+            "register",
+        );
+        dir.put_public_key(crate::federation::SignedKeyRecord { record })
+            .await
+            .expect("register identity key");
+    }
+
+    /// #371 — build a fully-formed [`KeyRecord`](crate::federation::KeyRecord)
+    /// for `key_id` carrying `key_id`'s REAL deterministic hybrid pubkeys,
+    /// whose registration envelope is hybrid-signed by `signer_key_id`'s
+    /// deterministic keys (through [`sign_envelope`], the exact shape
+    /// `verify_key_registration` Strict-verifies). Deterministic timestamps,
+    /// so building the same record twice is byte-identical (drives the
+    /// idempotent-`Unchanged` arm of the #371 decision table).
+    ///
+    /// - `scrub_key_id == key_id` + `signer_key_id == key_id` ⇒ a verifiable
+    ///   **self-signed** record (the in-place boot state).
+    /// - `scrub_key_id != key_id` + `signer_key_id == scrub_key_id` ⇒ a
+    ///   verifiable **granting-authority (anchor-scrubbed)** record —
+    ///   register the scrubber first ([`register_hybrid_key`] /
+    ///   [`register_identity_key`]) so the Strict gate resolves its pubkeys.
+    /// - `signer_key_id != scrub_key_id` ⇒ a record whose scrub does NOT
+    ///   verify (the bad-signer decision-table row).
+    ///
+    /// `nonce` is folded into the signed envelope, so two records for the
+    /// same `key_id` with different nonces are distinct-but-valid versions
+    /// (drives the conflicting-second-version / duplicity rows).
+    pub fn replicated_key_record(
+        key_id: &str,
+        identity_type: &str,
+        scrub_key_id: &str,
+        signer_key_id: &str,
+        nonce: &str,
+    ) -> crate::federation::KeyRecord {
+        let (ed_pk, mldsa_pk) = hybrid_pubkeys(key_id);
+        let envelope = serde_json::json!({
+            "key_id": key_id,
+            "purpose": "federation-peering",
+            "nonce": nonce,
+        });
+        let (och, classical, pqc) = sign_envelope(signer_key_id, &envelope);
+        let ts: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+        crate::federation::KeyRecord {
+            key_id: key_id.to_owned(),
+            pubkey_ed25519_base64: ed_pk,
+            pubkey_ml_dsa_65_base64: mldsa_pk,
+            algorithm: crate::federation::types::algorithm::HYBRID.to_owned(),
+            identity_type: identity_type.to_owned(),
+            identity_ref: key_id.to_owned(),
+            valid_from: ts,
+            valid_until: None,
+            registration_envelope: envelope,
+            original_content_hash: och,
+            scrub_signature_classical: classical,
+            scrub_signature_pqc: pqc,
+            scrub_key_id: scrub_key_id.to_owned(),
+            scrub_timestamp: ts,
+            pqc_completed_at: Some(ts),
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+        }
+    }
+
+    /// #371 — build a LIVE **owner-binding** `delegates_to(owner → node)`
+    /// (the CC 1.13.3.3 / CC 3.2 ownership dimension the v12.6.0
+    /// single-owner gate + `owner_of` key on), federation-tier
+    /// hybrid-signed by `owner`'s deterministic keys so
+    /// `verify_federation_tier_ingest` admits it. Register `owner` as a
+    /// `user`-role key ([`register_identity_key`]) first.
+    pub fn owner_binding_attestation(
+        id: &str,
+        owner: &str,
+        node: &str,
+    ) -> crate::federation::Attestation {
+        use crate::federation::types::{
+            attestation_tier, attestation_type, delegation_scope as ds, owner_binding,
+        };
+        let envelope = serde_json::json!({
+            "id": id,
+            "kind": "delegates_to",
+            "dimension": owner_binding::DIMENSION,
+            "delegation_purpose": owner_binding::PURPOSE,
+            "scope": [ds::INFRA_SERVE, ds::INFRA_NETWORK_PRESENCE],
+        });
+        let (och, classical, pqc) = sign_envelope(owner, &envelope);
+        let ts: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+        crate::federation::Attestation {
+            attestation_id: id.to_owned(),
+            attesting_key_id: owner.to_owned(),
+            attested_key_id: node.to_owned(),
+            attestation_type: attestation_type::DELEGATES_TO.to_owned(),
+            weight: Some(1.0),
+            asserted_at: ts,
+            expires_at: None,
+            attestation_envelope: envelope,
+            original_content_hash: och,
+            scrub_signature_classical: classical,
+            scrub_signature_pqc: pqc,
+            scrub_key_id: owner.to_owned(),
+            scrub_timestamp: ts,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            subject_key_ids: Vec::new(),
+            withdraws_admission_rule: None,
+            cohort_scope: "federation".to_owned(),
+            tier: attestation_tier::FEDERATION.to_owned(),
+            promoted_at: None,
+        }
+    }
 }
 
 #[cfg(all(test, any(feature = "postgres", feature = "sqlite")))]

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -500,6 +500,7 @@ pub(crate) mod test_support {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -358,6 +358,7 @@ pub(crate) mod test_support {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         dir.put_public_key(crate::federation::SignedKeyRecord { record: rec })
             .await
@@ -485,6 +486,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         dir.put_public_key(SignedKeyRecord { record: rec })
             .await

--- a/src/federation/tier_ingest.rs
+++ b/src/federation/tier_ingest.rs
@@ -124,23 +124,52 @@ where
     if row.tier != attestation_tier::FEDERATION {
         return Ok(());
     }
+    verify_row_hybrid_signature(directory, row).await
+}
 
+/// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — verify an
+/// [`Attestation`] row's envelope bound-hybrid signature **regardless of
+/// tier**. This is the tier-agnostic core [`verify_federation_tier_ingest`]
+/// runs for federation rows; the §10.1.3 subject-side revocation transit
+/// gate ([`super::admission::check_local_tier_eligibility`] /
+/// [`super::admission::check_consent_record_admission`]) runs it on a
+/// **local-tier** row so a subject revocation may *transit* the local write
+/// path only if its bound-hybrid signature verifies (the operator decision:
+/// accept on VALID crypto, never on an unsigned/forged revocation).
+///
+/// Same verify contract as the federation ingest gate: canonicalize the
+/// envelope, cross-check `SHA-256(canonical) == original_content_hash`,
+/// resolve the attester's REGISTERED pubkeys, [`verify_hybrid`] under
+/// [`HybridPolicy::Strict`] (both Ed25519 + ML-DSA-65 REQUIRED; PQC
+/// mandatory). ANY failure ⇒ [`Error::FederationTierUnverified`],
+/// fail-secure, row NOT stored.
+pub async fn verify_row_hybrid_signature<F>(directory: &F, row: &Attestation) -> Result<(), Error>
+where
+    F: FederationDirectory + ?Sized,
+{
     let reject = |reason: String| Error::FederationTierUnverified {
         attestation_id: row.attestation_id.clone(),
         attesting_key_id: row.attesting_key_id.clone(),
         reason,
     };
 
-    // (1) Canonicalize the attestation envelope through the CEG produce
-    // gate — the same canonical form the producer signed — and
-    // cross-check its SHA-256 against the row's declared
-    // original_content_hash. A canonicalizer disagreement (producer
-    // signed a different shape) is caught here, fail-secure, rather than
-    // masked as a downstream signature mismatch. Mirrors
-    // register.rs::verify_key_registration.
-    let canonical = ceg_produce_canonicalize(&row.attestation_envelope)
-        .map_err(|e| reject(format!("attestation_envelope canonicalize: {e}")))?;
-    let computed_hash = hex::encode(Sha256::digest(&canonical));
+    let computed_hash = verify_envelope_hybrid_signature(
+        directory,
+        &row.attesting_key_id,
+        &row.attestation_envelope,
+        &row.scrub_signature_classical,
+        row.scrub_signature_pqc.as_deref(),
+    )
+    .await
+    .map_err(|e| match e {
+        // Re-stamp the row's attestation_id onto the typed error (the
+        // envelope-level helper has no row id).
+        Error::FederationTierUnverified { reason, .. } => reject(reason),
+        other => other,
+    })?;
+
+    // Cross-check the declared original_content_hash matches the envelope's
+    // canonical SHA-256 (canonicalizer agreement, fail-secure).
     if computed_hash != row.original_content_hash {
         return Err(reject(format!(
             "original_content_hash mismatch: envelope canonicalizes to {computed_hash}, \
@@ -148,36 +177,62 @@ where
             row.original_content_hash
         )));
     }
+    Ok(())
+}
 
-    // (2) Resolve the attester's REGISTERED pubkeys. Verify against the
-    // registered key, never pubkeys carried on the row alone — an
-    // unknown/unregistered attester has no pubkeys to verify against and
-    // is rejected (fail-secure). The FK gate in put_attestation also
-    // requires attesting_key_id to exist, but resolving here keeps the
-    // gate self-contained and orders the reject as a typed
-    // federation-tier-unverified failure.
+/// v12.6.0 (CIRISPersist#171) — the envelope-level bound-hybrid verify
+/// primitive shared by [`verify_row_hybrid_signature`] (row form) and the
+/// §10.1.3 transit revocation local-write path (which has no assembled row
+/// yet — it verifies before building one). Canonicalizes `envelope` through
+/// the CEG produce gate, resolves `attesting_key_id`'s REGISTERED pubkeys via
+/// the directory (unknown attester ⇒ reject, fail-secure), and runs
+/// [`verify_hybrid`] under [`HybridPolicy::Strict`] (both halves REQUIRED,
+/// PQC-mandatory per CC 5.3.2.4.3.1). On success returns the hex-encoded
+/// `SHA-256(canonical)` (the row's `original_content_hash`); on ANY failure
+/// returns [`Error::FederationTierUnverified`] with an empty `attestation_id`
+/// (the caller re-stamps its own where one exists).
+pub async fn verify_envelope_hybrid_signature<F>(
+    directory: &F,
+    attesting_key_id: &str,
+    envelope: &serde_json::Value,
+    scrub_signature_classical: &str,
+    scrub_signature_pqc: Option<&str>,
+) -> Result<String, Error>
+where
+    F: FederationDirectory + ?Sized,
+{
+    let reject = |reason: String| Error::FederationTierUnverified {
+        attestation_id: String::new(),
+        attesting_key_id: attesting_key_id.to_string(),
+        reason,
+    };
+
+    // (1) Canonicalize through the CEG produce gate — the same canonical
+    // form the producer signed — and compute its SHA-256.
+    let canonical = ceg_produce_canonicalize(envelope)
+        .map_err(|e| reject(format!("attestation_envelope canonicalize: {e}")))?;
+    let computed_hash = hex::encode(Sha256::digest(&canonical));
+
+    // (2) Resolve the attester's REGISTERED pubkeys — never pubkeys carried
+    // on the row alone. Unknown/unregistered attester ⇒ reject (fail-secure).
     let attester = directory
-        .lookup_public_key(&row.attesting_key_id)
+        .lookup_public_key(attesting_key_id)
         .await
         .map_err(|e| reject(format!("attester lookup_public_key: {e} ({})", e.kind())))?
         .ok_or_else(|| {
             reject(format!(
-                "attesting_key_id {} is not registered — no pubkeys to verify the \
-                 federation-tier signature against",
-                row.attesting_key_id
+                "attesting_key_id {attesting_key_id} is not registered — no pubkeys to \
+                 verify the bound-hybrid signature against"
             ))
         })?;
 
-    // (3) Strict hybrid verify: both Ed25519 (over canonical) and
-    // ML-DSA-65 (over the bound canonical || classical_sig, applied
-    // inside the hybrid verifier) REQUIRED. A classical-only /
-    // hybrid-pending federation-tier row (PQC sig absent) is rejected —
-    // the load-bearing CC 5.3.2.4.3.1 guard. row_age is irrelevant under
-    // Strict.
+    // (3) Strict hybrid verify: Ed25519 (over canonical) AND ML-DSA-65 (over
+    // the bound canonical || classical_sig) both REQUIRED. A classical-only /
+    // hybrid-pending signature is rejected — the CC 5.3.2.4.3.1 guard.
     verify_hybrid(
         &canonical,
-        &row.scrub_signature_classical,
-        row.scrub_signature_pqc.as_deref(),
+        scrub_signature_classical,
+        scrub_signature_pqc,
         &attester.pubkey_ed25519_base64,
         attester.pubkey_ml_dsa_65_base64.as_deref(),
         HybridPolicy::Strict,
@@ -185,7 +240,7 @@ where
     )
     .map_err(|e| reject(format!("hybrid-verify: {e} ({})", e.kind())))?;
 
-    Ok(())
+    Ok(computed_hash)
 }
 
 /// v9.0.0 (CIRISPersist#237) — shared test-support for the

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -152,6 +152,20 @@ pub mod identity_type {
     /// this publishes the canonical token so producer + verifier agree
     /// byte-for-byte.
     pub const NODE: &str = "node";
+    /// v12.7.0 (CIRISPersist#366, CC 3.4.8) — the LensCore-detector role.
+    /// Only `federation_keys` rows whose `identity_type` **set** contains
+    /// this token may emit the detector-only reserved prefixes
+    /// `detection:correlated_action:*` and `detection:distributive:access:*`
+    /// (see [`super::admission::default_reserved_prefix_rules`]). Per
+    /// CC 3.4.7.1 the gate is evaluated by **set membership** — a folded
+    /// LensCore occurrence whose key holds `{agent, lenscore_detector}`
+    /// satisfies the detector gate via `lenscore_detector ∈ set` while its
+    /// cohabiting `agent` role neither grants nor blocks the detector right
+    /// (CC 3.4.8 LensCore-fold worked example). Cross-attestations by
+    /// non-detector peers MUST use the distinct `truth_grounding:detection:*`
+    /// prefix (ungated here), so anything on `detection:*` is a primary
+    /// detector emission and gate-able with no envelope field.
+    pub const LENSCORE_DETECTOR: &str = "lenscore_detector";
 
     /// v6.5.0 (CEG §7.0.1) — join an `identity_type` **set** into the
     /// single TEXT column representation: sorted, de-duplicated,

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -2105,6 +2105,46 @@ pub fn compute_persist_row_hash<T: Serialize>(row: &T) -> Result<String, super::
 mod tests {
     use super::*;
 
+    /// v12.7.0 (CIRISPersist#368) — the FFI wire contract for the
+    /// witness-targets-subject age surface: `EmitAttestationInput` JSON
+    /// (the exact `PyEngine::emit_attestation` / `emit_attestation_self`
+    /// input) carries the optional `attested_key_id` naming the SUBJECT,
+    /// and omitting it round-trips to `None` (the self-attestation
+    /// default).
+    #[test]
+    fn emit_attestation_input_json_carries_attested_key_id_subject() {
+        let with_subject: EmitAttestationInput = serde_json::from_str(
+            r#"{
+                "attestation_type": "age_assurance:government:adult:v1",
+                "attested_key_id": "subject-key-1",
+                "attestation_envelope": { "id": "wire-1" }
+            }"#,
+        )
+        .expect("decode");
+        assert_eq!(
+            with_subject.attested_key_id.as_deref(),
+            Some("subject-key-1")
+        );
+        assert_eq!(
+            with_subject.attestation_type,
+            "age_assurance:government:adult:v1"
+        );
+        // Round-trips (the field serializes back out when set).
+        let json = serde_json::to_value(&with_subject).unwrap();
+        assert_eq!(json["attested_key_id"], "subject-key-1");
+
+        // Omitted ⇒ None ⇒ the emit path self-binds to the emitter (and the
+        // `age_assurance:` admission gate then rejects the self-emission).
+        let without: EmitAttestationInput = serde_json::from_str(
+            r#"{
+                "attestation_type": "age_assurance:provider:adult:v1",
+                "attestation_envelope": { "id": "wire-2" }
+            }"#,
+        )
+        .expect("decode");
+        assert!(without.attested_key_id.is_none());
+    }
+
     /// #249 Cut C — the producer-side moderate-scope tokens MUST equal the
     /// admission duty-walk's scope constants, or an emitted edge would not
     /// be admissible by `is_named_moderator` / `check_moderation_admission`.

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -166,6 +166,33 @@ pub mod identity_type {
     /// prefix (ungated here), so anything on `detection:*` is a primary
     /// detector emission and gate-able with no envelope field.
     pub const LENSCORE_DETECTOR: &str = "lenscore_detector";
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1 set-membership) — a
+    /// **canonical / founding bootstrap server**. This role marks a node
+    /// as a member of the founding canonical set; it is **accord-CONFERRED,
+    /// never self-claimed**.
+    ///
+    /// The load-bearing invariant (the whole point of the role): a
+    /// `federation_keys` row may carry `canonical` in its `identity_type`
+    /// **set** ([`set_contains`]) **IFF** the record is
+    /// **anchor-scrub-signed** — `scrub_key_id != key_id` AND
+    /// `scrub_key_id`'s Ed25519 pubkey ∈ the pinned HUMANITY_ACCORD anchor
+    /// ([`ciris_verify_core::accord_genesis::accord_holder_bootstrap_anchor`],
+    /// the SAME terminus [`super::super::rooting::root_binding`] and
+    /// [`super::super::register::verify_key_registration`] /
+    /// `adopt_scrub_upgrade` verify). A **self-signed** record
+    /// (`scrub_key_id == key_id`) carrying `canonical`, or one scrubbed by a
+    /// **non-anchor** key, is REFUSED at admission
+    /// ([`super::super::Error::CanonicalRoleNotAccordConferred`], stable
+    /// `kind()` token `canonical_role_not_accord_conferred`) — fail-closed.
+    /// **Monotonic**: the role can only ever arrive on an anchor-scrubbed
+    /// record; it can never be added by a later self-registration or by
+    /// replication of a self-signed row (the gate composes with the
+    /// `put_public_key` DO-NOTHING / `adopt_scrub_upgrade` paths). The ONLY
+    /// way to become a canonical server is the Trust Root **add-canonical**
+    /// op: an accord holder scrub-signs the node with the `canonical` role.
+    /// The admission gate is
+    /// [`super::super::admission::check_canonical_role_admission`].
+    pub const CANONICAL: &str = "canonical";
 
     /// v6.5.0 (CEG §7.0.1) — join an `identity_type` **set** into the
     /// single TEXT column representation: sorted, de-duplicated,

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -194,6 +194,120 @@ pub mod identity_type {
     }
 }
 
+/// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 `consent-counter`) — the
+/// **Counter-RII `consent_role`** vocabulary: the role tokens carried on
+/// [`KeyRecord::consent_role`] that gate Counter-RII probe detection
+/// (RATCHET `FSD/COUNTER_RII_DETECTION.md`; Lean `ConsentGate.lean`, 8
+/// theorems verified). CC 3.4.7.2 ratified three primitive-level
+/// semantics that shape this field + edge's `ProbePatternObserver` gate.
+///
+/// Persist's role is **STORE + EXPOSE + OQ-1 overwrite**: it carries the
+/// role on the wire, resolves it ([`super::consent::consent_role_of`]),
+/// and gives it flat overwrite-on-revoke mutation semantics
+/// ([`super::FederationDirectory::set_consent_role`]). The **detection**
+/// itself (the OQ-2 / OQ-3 *signal* decisions) is applied by the
+/// consumer (edge / RATCHET) reading this field — persist does NOT house
+/// a Counter-RII detector.
+///
+/// **The column already shipped** — V020 (v1.3.0, the CIRISAgent#760 §RC
+/// "consent role lock") added `federation_keys.consent_role TEXT NOT NULL
+/// DEFAULT 'unregistered'` with exactly this six-token vocabulary (PG
+/// CHECK-enforced; SQLite by application contract — the Rust-level
+/// admission in `put_public_key`/`set_consent_role` keeps the backends
+/// symmetric). CC 3.4.7.2's "non-breaking against the shipped flat
+/// substrate" language is literal: OQ-1's flat overwrite-on-revoke IS the
+/// natural UPDATE semantics of that column. v12.7.0 puts the field **on
+/// the wire** ([`KeyRecord`]`::consent_role`, `None` ⇔ the stored
+/// `'unregistered'` default) and exposes the resolver + mutation surface.
+pub mod consent_role {
+    /// The stored default — no Counter-RII consent role assigned. This is
+    /// the V020 column default; on the wire it is represented as
+    /// `KeyRecord.consent_role = None` (interconverted at the storage
+    /// boundary, see [`wire_from_stored`] / [`stored_from_wire`]). An
+    /// `unregistered` key is subject to Counter-RII detection normally
+    /// (the `ConsentGate.lean` base default).
+    pub const UNREGISTERED: &str = "unregistered";
+    /// Base consent role mirroring [`super::TrustType::Temporary`] — the
+    /// CIRISAgent ConsentService taxonomy rung. Detection applies.
+    pub const TEMPORARY: &str = "temporary";
+    /// Base consent role mirroring [`super::TrustType::Partnered`]
+    /// (bilateral approval). Detection applies.
+    pub const PARTNERED: &str = "partnered";
+    /// Base consent role mirroring [`super::TrustType::Anonymous`].
+    /// Detection applies.
+    pub const ANONYMOUS: &str = "anonymous";
+    /// OQ-3 strict post-window role (`ConsentGate.lean` `AuthorizedReview`).
+    /// An `authorized_review` key is **signal-eligible immediately** at
+    /// `t > window_end` — no grace period. **Consumer-applied**: persist
+    /// carries the role; the consumer enforces the strict window.
+    pub const AUTHORIZED_REVIEW: &str = "authorized_review";
+    /// OQ-2 blanket-suppression role (`ConsentGate.lean` `Peer`). A node
+    /// holding `peer` **escapes Counter-RII detection at any `trust_mode`**
+    /// — a sovereign peer may probe other peers without raising the
+    /// (advisory-only) `ratchet:flag:counter_rii:*` signal (CC 3.1.6: the
+    /// flag can NEVER be sole evidence for `slashing:*`; the WA quorum is
+    /// the load-bearing adjudication gate). **Consumer-applied**: persist
+    /// carries the role; edge's `ProbePatternObserver` reads it and
+    /// suppresses.
+    pub const PEER: &str = "peer";
+
+    /// The six ratified tokens (identical to the V020 PG CHECK set), in
+    /// the V020 declaration order. Any other token is rejected at
+    /// admission on BOTH backends (Rust-level; the PG CHECK is defense in
+    /// depth).
+    pub const RECOGNIZED: [&str; 6] = [
+        UNREGISTERED,
+        TEMPORARY,
+        PARTNERED,
+        ANONYMOUS,
+        AUTHORIZED_REVIEW,
+        PEER,
+    ];
+
+    /// Is `role` one of the six ratified V020/CC 3.4.7.2 tokens?
+    pub fn is_recognized(role: &str) -> bool {
+        RECOGNIZED.contains(&role)
+    }
+
+    /// Storage → wire: the stored `'unregistered'` default (and empty
+    /// string, defensively) map to wire `None`; any other token is
+    /// carried verbatim.
+    pub fn wire_from_stored(stored: &str) -> Option<&str> {
+        if stored.is_empty() || stored == UNREGISTERED {
+            None
+        } else {
+            Some(stored)
+        }
+    }
+
+    /// Wire → storage: wire `None` maps to the stored `'unregistered'`
+    /// default (the V020 column is NOT NULL).
+    pub fn stored_from_wire(wire: Option<&str>) -> &str {
+        match wire {
+            Some(role) => role,
+            None => UNREGISTERED,
+        }
+    }
+
+    /// Admission gate for a wire-shape consent_role: `None` and the six
+    /// recognized tokens pass; anything else is
+    /// [`Error::InvalidArgument`](crate::federation::Error::InvalidArgument).
+    /// Applied in `put_public_key` + `set_consent_role` on EVERY backend
+    /// so PG (schema CHECK) and SQLite (no CHECK — SQLite's V020 ALTER
+    /// could not add one) behave identically.
+    pub fn check_admissible(wire: Option<&str>) -> Result<(), crate::federation::Error> {
+        match wire {
+            None => Ok(()),
+            Some(role) if is_recognized(role) => Ok(()),
+            Some(role) => Err(crate::federation::Error::InvalidArgument(format!(
+                "consent_role '{role}' is not a recognized CC 3.4.7.2 token \
+                 (expected one of: {})",
+                RECOGNIZED.join(", ")
+            ))),
+        }
+    }
+}
+
 /// Algorithm strings matching persist's `algorithm` column.
 ///
 /// **v0.2.0+ federation_keys writes MUST use [`HYBRID`].** Schema
@@ -531,6 +645,36 @@ pub struct KeyRecord {
     /// computations stay stable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attestation_evidence: Option<serde_json::Value>,
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 `consent-counter`) — the
+    /// **Counter-RII `consent_role`**. A single role token (see the
+    /// [`consent_role`] vocabulary module — `temporary` / `partnered` /
+    /// `anonymous` / `authorized_review` / `peer`) that gates the
+    /// Counter-RII probe detection a consumer (edge's
+    /// `ProbePatternObserver`, RATCHET `FSD/COUNTER_RII_DETECTION.md`)
+    /// applies. Per CC 3.4.7.2 this is a `federation_keys` **identity
+    /// field** — a sibling to [`identity_type`] — **not** an envelope
+    /// primitive. Backed by the V020 column (`TEXT NOT NULL DEFAULT
+    /// 'unregistered'`, the CIRISAgent#760 §RC lock CC 3.4.7.2 ratifies);
+    /// `None` here ⇔ the stored `'unregistered'` default (no assigned
+    /// role — detection applies normally).
+    ///
+    /// **Mutable + overwrite-on-revoke (OQ-1).** Unlike the signed
+    /// registration fields above, `consent_role` is an operational role
+    /// marker that a governance/consent surface assigns and later
+    /// overwrites (a subsequent revocation OVERWRITES the prior value —
+    /// flat, bounded, non-recursive; NO chain embedded in the field).
+    /// It is therefore **excluded from [`compute_persist_row_hash`]** (the
+    /// signed-registration content hash) so a later
+    /// [`FederationDirectory::set_consent_role`](super::FederationDirectory::set_consent_role)
+    /// overwrite does NOT disturb the registration hash / CIRISRegistry
+    /// vendored-shape parity, and `adopt_scrub_upgrade` deliberately does
+    /// NOT touch it (an anchor-scrub upgrade must not clobber an assigned
+    /// role). Backward-compatible default: pre-v12.7.0 rows + rows with no
+    /// assigned role serialize without the field
+    /// (`skip_serializing_if = "Option::is_none"`), so `persist_row_hash`
+    /// stays byte-stable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub consent_role: Option<String>,
 }
 
 impl KeyRecord {
@@ -1936,10 +2080,19 @@ pub fn compute_persist_row_hash<T: Serialize>(row: &T) -> Result<String, super::
     // canonicalize → hash. Dropping `persist_row_hash` keeps the hash
     // stable across populate/depopulate cycles (read response carries
     // the field; write submission may or may not).
+    //
+    // v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1): also drop
+    // `consent_role`. It is a MUTABLE, overwrite-on-revoke operational
+    // role marker — NOT part of the signed registration content — so it
+    // MUST NOT enter the registration hash. Excluding it keeps
+    // `persist_row_hash` byte-identical to CIRISRegistry's vendored
+    // shape (which does not carry the field) and lets `set_consent_role`
+    // overwrite the role without invalidating the hash.
     let mut value = serde_json::to_value(row)
         .map_err(|e| super::Error::Backend(format!("serialize for hash: {e}")))?;
     if let Some(obj) = value.as_object_mut() {
         obj.remove("persist_row_hash");
+        obj.remove("consent_role");
     }
     let bytes = PythonJsonDumpsCanonicalizer
         .canonicalize_value(&value)
@@ -2006,6 +2159,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/federation/types.rs
+++ b/src/federation/types.rs
@@ -714,6 +714,22 @@ pub struct LocalAttestationInput {
     /// other value at local tier. Promotion (v4.5) widens the scope.
     #[serde(default = "default_self_cohort_scope")]
     pub cohort_scope: String,
+    /// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — the classical
+    /// Ed25519 signature over `JCS(attestation_envelope)`. Populated ONLY
+    /// for a **subject-side revocation transiting the local tier**: an
+    /// ordinary producer-authority local row defers its signature (this
+    /// stays `None` and the row is written with the empty-sentinel scrub
+    /// envelope). When the write-path gate classifies the row as a
+    /// [`crate::federation::admission::LocalTierDisposition::TransitRevocation`],
+    /// this (and [`Self::scrub_signature_pqc`]) MUST be present and verify
+    /// against the attester's registered pubkeys, or the write is rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scrub_signature_classical: Option<String>,
+    /// v12.6.0 — the ML-DSA-65 signature over the bound payload
+    /// `JCS(attestation_envelope) ‖ ed25519_sig` (PQC-mandatory for a
+    /// transit revocation; see [`Self::scrub_signature_classical`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scrub_signature_pqc: Option<String>,
 }
 
 /// Default cohort_scope for a local-tier write — `self` (private to the
@@ -757,6 +773,53 @@ impl LocalAttestationInput {
             scrub_key_id: self.attesting_key_id,
             scrub_timestamp: asserted_at,
             pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            subject_key_ids: self.subject_key_ids,
+            withdraws_admission_rule: None,
+            cohort_scope: self.cohort_scope,
+            tier: attestation_tier::LOCAL.to_string(),
+            promoted_at: None,
+        }
+    }
+
+    /// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — build the
+    /// `local`-tier row for a **subject-side revocation transiting** the
+    /// local write path. Unlike [`Self::into_local_row`] (deferred
+    /// empty-sentinel scrub envelope), this carries the caller's REAL
+    /// bound-hybrid signature + the persist-computed `original_content_hash`
+    /// (hex `SHA-256(JCS(envelope))`, returned by the verify step) so the
+    /// row is a fully-signed federation-classified revocation staged at
+    /// `tier = local`, `promoted_at = None`. It is NOT a durable local row:
+    /// the consent-SLA watcher drives it to promotion or overdue-flag.
+    /// `persist_row_hash` is filled by the caller after construction.
+    pub fn into_transit_revocation_row(
+        self,
+        attestation_id: String,
+        asserted_at: DateTime<Utc>,
+        original_content_hash: String,
+        scrub_signature_classical: String,
+        scrub_signature_pqc: Option<String>,
+    ) -> Attestation {
+        let attested_key_id = self
+            .attested_key_id
+            .unwrap_or_else(|| self.attesting_key_id.clone());
+        Attestation {
+            attestation_id,
+            attesting_key_id: self.attesting_key_id.clone(),
+            attested_key_id,
+            attestation_type: self.attestation_type,
+            weight: self.weight,
+            asserted_at,
+            expires_at: self.expires_at,
+            attestation_envelope: self.attestation_envelope,
+            original_content_hash,
+            scrub_signature_classical,
+            scrub_signature_pqc,
+            // Self-signed: the subject is the attester.
+            scrub_key_id: self.attesting_key_id,
+            scrub_timestamp: asserted_at,
+            // PQC half is present + verified for a transit revocation.
+            pqc_completed_at: Some(asserted_at),
             persist_row_hash: String::new(),
             subject_key_ids: self.subject_key_ids,
             withdraws_admission_rule: None,

--- a/src/ffi/directory_capsule.rs
+++ b/src/ffi/directory_capsule.rs
@@ -1675,6 +1675,17 @@ impl FederationDirectory for OpsDirectory {
             method: "lookup_keys_for_identity",
         })
     }
+    async fn set_consent_role(
+        &self,
+        _key_id: &str,
+        _consent_role: Option<&str>,
+    ) -> Result<(), Error> {
+        // v12.7.0 (CIRISPersist#365) — no DirectoryOp in the capsule
+        // protocol carries consent_role mutation; not routable here.
+        Err(Error::Unsupported {
+            method: "set_consent_role",
+        })
+    }
     async fn attestation_upsert_local(
         &self,
         input: crate::federation::types::LocalAttestationInput,
@@ -2171,6 +2182,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/ffi/outbound_queue_capsule.rs
+++ b/src/ffi/outbound_queue_capsule.rs
@@ -768,6 +768,7 @@ mod tests {
                 persist_row_hash: String::new(),
                 roles: Vec::new(),
                 attestation_evidence: None,
+                consent_role: None,
             },
         }
     }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2839,9 +2839,12 @@ impl PyEngine {
             ) {
                 Ok(()) => Ok(true),
                 Err(E::Invalid(_)) | Err(E::SignatureFailed) => Ok(false),
-                Err(e @ (E::MalformedJson(_) | E::MalformedBase64(_))) => {
-                    Err(storage_contention_err_to_py(e))
-                }
+                // RevisionRollback is unreachable from a pure verify (it is
+                // the #370 install-path error) — grouped with the raising
+                // arm for exhaustiveness.
+                Err(
+                    e @ (E::MalformedJson(_) | E::MalformedBase64(_) | E::RevisionRollback { .. }),
+                ) => Err(storage_contention_err_to_py(e)),
             }
         })
     }
@@ -2864,9 +2867,12 @@ impl PyEngine {
             ) {
                 Ok(()) => Ok(true),
                 Err(E::Invalid(_)) | Err(E::SignatureFailed) => Ok(false),
-                Err(e @ (E::MalformedJson(_) | E::MalformedBase64(_))) => {
-                    Err(storage_contention_err_to_py(e))
-                }
+                // RevisionRollback is unreachable from a pure verify (it is
+                // the #370 install-path error) — grouped with the raising
+                // arm for exhaustiveness.
+                Err(
+                    e @ (E::MalformedJson(_) | E::MalformedBase64(_) | E::RevisionRollback { .. }),
+                ) => Err(storage_contention_err_to_py(e)),
             }
         })
     }
@@ -2908,6 +2914,83 @@ impl PyEngine {
                 object_bytes,
             )
             .map_err(storage_contention_err_to_py)
+        })
+    }
+
+    /// #370 (§Q B2/B3, CC 6.1.5.2) — INSTALL a signed `StorageBudgetV1` so
+    /// it governs this node's capacity eviction. Verifies the bound-hybrid
+    /// signature against the owner pubkeys (PQC-mandatory — verify at the
+    /// gate, BEFORE persistence), enforces §Q B3 anti-rollback (a
+    /// lower/equal `revision` from the same `node_id` than the installed
+    /// one is rejected), then persists the budget (V092, both backends).
+    /// The installed `pinned_class` / `pin_reserve_bytes` drive the B5
+    /// CACHE-BEFORE-PINNED ordering of the eviction sweep; revocation
+    /// (`evict_fountain_content_hard_delete`) stays pin-blind (§Q B6).
+    /// Returns the accepted `revision`. Raises `ValueError` on a
+    /// structural/signature failure or an anti-rollback rejection
+    /// (`storage_contention_revision_rollback`).
+    #[pyo3(name = "install_storage_budget_v1")]
+    fn install_storage_budget_v1_py(
+        &self,
+        py: Python<'_>,
+        wire_json: &str,
+        ed25519_pubkey_base64: &str,
+        ml_dsa_65_pubkey_base64: &str,
+    ) -> PyResult<u64> {
+        self.ensure_usable()?;
+        let wire_json = wire_json.to_owned();
+        let ed_pub = ed25519_pubkey_base64.to_owned();
+        let mldsa_pub = ml_dsa_65_pubkey_base64.to_owned();
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let backend = match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
+            };
+            let signer = self.signer.clone();
+            let local_signer = self.local_signer.clone();
+            py.detach(move || {
+                let engine = crate::Engine::from_shared_with_local(backend, signer, local_signer);
+                runtime.block_on(async move {
+                    engine
+                        .install_storage_budget_v1(&wire_json, &ed_pub, &mldsa_pub)
+                        .await
+                })
+            })
+            .map_err(fountain_store_err_to_py)
+        })
+    }
+
+    /// #370 — the installed `StorageBudgetV1` wire JSON for `node_id`,
+    /// VERBATIM as accepted (re-verifiable with `verify_storage_budget_v1`).
+    /// `None` when no budget is installed for that node.
+    #[pyo3(name = "get_installed_storage_budget_json")]
+    fn get_installed_storage_budget_json_py(
+        &self,
+        py: Python<'_>,
+        node_id: &str,
+    ) -> PyResult<Option<String>> {
+        self.ensure_usable()?;
+        let node_id = node_id.to_owned();
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let backend = match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(b) => crate::engine::BackendDispatch::Postgres(b.clone()),
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(b) => crate::engine::BackendDispatch::Sqlite(b.clone()),
+            };
+            let signer = self.signer.clone();
+            let local_signer = self.local_signer.clone();
+            py.detach(move || {
+                let engine = crate::Engine::from_shared_with_local(backend, signer, local_signer);
+                runtime.block_on(
+                    async move { engine.get_installed_storage_budget_json(&node_id).await },
+                )
+            })
+            .map_err(fountain_store_err_to_py)
         })
     }
 
@@ -24133,6 +24216,7 @@ fn fountain_store_err_to_py(e: crate::store::Error) -> PyErr {
         Error::FountainAdmit(_)
         | Error::FountainIntegrity(_)
         | Error::AggregationMetaRejected(_)
+        | Error::StorageContention(_)
         | Error::Schema(_) => PyValueError::new_err(e.kind()),
         Error::NotImplemented(_) | Error::Backend(_) | Error::Migration { .. } => {
             PyRuntimeError::new_err(format!("{e}"))

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3941,6 +3941,68 @@ impl PyEngine {
         })
     }
 
+
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — is `key_id` a **canonical /
+    /// founding bootstrap server**? Returns `True` iff its `federation_keys`
+    /// row's `identity_type` set contains `canonical`. Because the substrate
+    /// admission gate only ever admits `canonical` on an anchor-scrub-conferred
+    /// record (an accord holder scrub-signed the node with the role), a `True`
+    /// here means the role was accord-conferred — it cannot be self-claimed.
+    /// `False` for an unknown key or a non-canonical row.
+    fn is_canonical(&self, py: Python<'_>, key_id: &str) -> PyResult<bool> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            py.detach(move || match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        crate::federation::is_canonical(backend.as_ref(), &key_id).await
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        crate::federation::is_canonical(backend.as_ref(), &key_id).await
+                    })
+                }
+            })
+            .map_err(federation_err_to_py)
+        })
+    }
+
+
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — enumerate the **canonical /
+    /// founding bootstrap servers** as a JSON array of `KeyRecord`s
+    /// (`federation_keys` rows whose `identity_type` set contains `canonical`,
+    /// stable-sorted by `key_id`). Every returned row is anchor-scrub-conferred
+    /// (the admission gate refuses a self-claimed `canonical`).
+    fn list_canonical_servers(&self, py: Python<'_>) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let rows = py
+                .detach(move || match &self.backend {
+                    #[cfg(feature = "postgres")]
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move { backend.list_canonical_servers().await })
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move { backend.list_canonical_servers().await })
+                    }
+                })
+                .map_err(federation_err_to_py)?;
+            serde_json::to_string(&rows)
+                .map_err(|e| PyRuntimeError::new_err(format!("KeyRecord list JSON encode: {e}")))
+        })
+    }
+
     /// v1.5.3 — One-call helper that registers THIS engine's local
     /// pubkey as a `federation_keys` row of the specified
     /// `identity_type`. Composes the existing primitives
@@ -24804,6 +24866,14 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // ValueError (4xx / 409-shaped, like `Conflict`).
         crate::federation::Error::NodeAlreadyOwned { .. }
         | crate::federation::Error::AmbiguousNodeOwner { .. } => PyValueError::new_err(kind),
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — a rejected `canonical`
+        // (founding-server) role that is not accord-conferred (self-claimed /
+        // non-anchor-scrubbed) is a caller-side authorization failure;
+        // ValueError (4xx). The `canonical` role is accord-CONFERRED, never
+        // self-claimed.
+        crate::federation::Error::CanonicalRoleNotAccordConferred { .. } => {
+            PyValueError::new_err(kind)
+        }
         // v9.0.0 (CC 3.2 / CC 3.4.7.1) — admitting an unstewarded node/agent to
         // a non-infrastructure community is a caller-side authorization
         // failure (non-infra membership is an authority act that must root

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -26319,6 +26319,8 @@ mod tests {
                     }),
                     subject_key_ids: vec![],
                     cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                    scrub_signature_classical: None,
+                    scrub_signature_pqc: None,
                 })
                 .await
                 .unwrap();

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4355,6 +4355,17 @@ impl PyEngine {
     /// #247 floor: this can't FK-violate the way the hand-rolled emit sites
     /// did. Requires a PQC-configured local signer (the hybrid sign);
     /// raises if absent.
+    ///
+    /// v12.7.0 (CIRISPersist#368, CC 3.4.11/3.4.13) — `attested_key_id`
+    /// names the row's **SUBJECT** (the cross-subject edge shape
+    /// `delegates_to` uses). Omitted ⇒ self-attestation. This is the
+    /// **witness-targets-subject** age surface: a `witness`-role engine
+    /// emits `{"attestation_type": "age_assurance:{level}:{band}:v1",
+    /// "attested_key_id": "<subject>", ...}` and the SUBJECT's
+    /// `age_band_json` graduates (witness outranks self). A subject cannot
+    /// graduate itself: attester==attested on `age_assurance:*` raises
+    /// `ValueError("federation_age_assurance_self_emission_rejected")`, and
+    /// a non-witness emitter raises the reserved-prefix mismatch.
     fn emit_attestation(&self, py: Python<'_>, input_json: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
@@ -4411,6 +4422,14 @@ impl PyEngine {
     /// **DERIVED** federation key_id (`local_derived_key_id`, the #247
     /// floor), computed internally. Surfaces a clear error if the engine
     /// has no composed hybrid signer (no local signer / no PQC half).
+    ///
+    /// v12.7.0 (CIRISPersist#368) — despite the `_self` name (which refers
+    /// to signing with the engine's OWN composed signer), the input's
+    /// optional `attested_key_id` still names the row's SUBJECT, exactly as
+    /// on [`PyEngine::emit_attestation`] — so a witness-role hardware-hybrid
+    /// engine can graduate a DIFFERENT subject's age band through this path
+    /// too. Omitted ⇒ self-attestation (and `age_assurance:*` then rejects:
+    /// a subject must not emit its own age assurance, CC 3.4.11).
     fn emit_attestation_self(&self, py: Python<'_>, input_json: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
@@ -7456,6 +7475,14 @@ impl PyEngine {
     /// fail-closed (a key whose chain to a `user` identity cannot be shown is
     /// not steward-bound). The most-reconstructed walk; exposing it stops
     /// consumers re-deriving the §5.6.8.10 graph.
+    ///
+    /// v12.7.0 (CIRISPersist#367, CC 3.2) — this is also THE
+    /// **steward-less-minor liveness predicate**: a PROVEN minor (witness
+    /// `age_assurance:*:minor` about it, emittable cross-subject per #368)
+    /// does NOT self-anchor, so it returns `true` only while a live
+    /// `delegates_to(adult-user → minor)` guardianship edge exists — and
+    /// flips to `false` (fail-secure) the moment the steward withdraws it.
+    /// An adult / age-unverified user self-anchors (`true` with no edge).
     fn is_steward_bound_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
         self.ensure_usable()?;
         catch_panic(|| {
@@ -24537,8 +24564,11 @@ fn federation_err_to_py(e: crate::federation::Error) -> PyErr {
         // shape as the other admission-gate rejections.
         // v10.3.0 (#288, CC 3.4.5) — capacity:* self-emission is the same
         // admission-gate-rejection shape (caller-fault, ValueError).
+        // v12.7.0 (#368, CC 3.4.11) — age_assurance:* self-emission is its
+        // exact sibling (subject-must-not-emit; caller-fault, ValueError).
         crate::federation::Error::ReservedPrefixEmitterMismatch { .. }
-        | crate::federation::Error::CapacitySelfEmissionRejected { .. } => {
+        | crate::federation::Error::CapacitySelfEmissionRejected { .. }
+        | crate::federation::Error::AgeAssuranceSelfEmissionRejected { .. } => {
             PyValueError::new_err(kind)
         }
         // v3.9.1 (CIRISPersist#150 Ask 3) — cohort_scope admission

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2021,6 +2021,37 @@ impl PyEngine {
         })
     }
 
+    /// #227 (residual) — drive one **consent-decay** sweep synchronously
+    /// (the time-driven twin of [`Self::sweep_evictions_once`]). Ages every
+    /// fountain content unit against its consent-decay schedule (TEMPORARY
+    /// 14-day, pattern 90-day) and evicts symbols down to the clock's
+    /// target tier via the SAME eviction mechanism disk-pressure uses.
+    /// Returns the number of symbol rows evicted this pass. Disk-independent
+    /// (no watermark) and idempotent (re-running evicts nothing further).
+    /// Sovereign callers (Pi-cron / k8s CronJob) drive this on their own
+    /// cadence.
+    fn sweep_consent_decay_once(&self, py: Python<'_>) -> PyResult<i64> {
+        self.ensure_usable()?;
+        let runtime = self.runtime.clone();
+        let slot = engine_slot();
+        let cell = slot
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("engine cell missing"))?;
+        let engine = crate::Engine::from_shared_with_local(
+            cell.engine_backend_dispatch(),
+            cell.signer.clone(),
+            cell.local_signer.clone(),
+        );
+        drop(slot);
+        py.detach(move || {
+            let now = chrono::Utc::now();
+            runtime
+                .block_on(async move { engine.sweep_consent_decay_once(now).await })
+                .map(|report| report.symbols_evicted as i64)
+                .map_err(fountain_store_err_to_py)
+        })
+    }
+
     /// v6.8.0 (CIRISPersist#148) — current total local
     /// `federation_blobs` bytes (the cache usage). For ops monitoring.
     fn cache_usage_bytes(&self, py: Python<'_>) -> PyResult<u64> {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3941,7 +3941,6 @@ impl PyEngine {
         })
     }
 
-
     /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — is `key_id` a **canonical /
     /// founding bootstrap server**? Returns `True` iff its `federation_keys`
     /// row's `identity_type` set contains `canonical`. Because the substrate
@@ -3973,7 +3972,6 @@ impl PyEngine {
             .map_err(federation_err_to_py)
         })
     }
-
 
     /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — enumerate the **canonical /
     /// founding bootstrap servers** as a JSON array of `KeyRecord`s

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7467,6 +7467,64 @@ impl PyEngine {
         })
     }
 
+    /// v12.7.0 (CIRISPersist#369, CC 4.5.4 / §11.11) — the directly drivable
+    /// no-moderator-no-federate admission VERDICT for one community: exactly
+    /// the decision the federation-apply gate
+    /// ([`admission::check_no_moderator_federate_apply`](crate::federation::admission::check_no_moderator_federate_apply),
+    /// wired into every backend's `put_attestation`) takes for a federation
+    /// apply step keyed on `community_id`, returned as JSON instead of a
+    /// refusal so the gate can be staged without constructing a full
+    /// federation flow. Returns
+    /// `{"admitted": true, "community_known": false}` (not locally known —
+    /// out of scope, fail-open), `{"admitted": true, "community_known": true}`
+    /// (a live `moderate`-holder resolves, or the authorized-infrastructure
+    /// carve-out applies), or `{"admitted": false, "community_known": true,
+    /// "reason": "federation_community_no_moderator"}` (§11.11 rule-3
+    /// fail-secure). Read-only. Wraps the free function
+    /// [`admission::no_moderator_federate_verdict`](crate::federation::admission::no_moderator_federate_verdict).
+    fn check_no_moderator_federate_json(
+        &self,
+        py: Python<'_>,
+        community_id: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let community_id = community_id.to_owned();
+            py.detach(move || {
+                let verdict: serde_json::Value = match &self.backend {
+                    #[cfg(feature = "postgres")]
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::admission::no_moderator_federate_verdict(
+                                &*backend,
+                                &community_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::admission::no_moderator_federate_verdict(
+                                &*backend,
+                                &community_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(&verdict).map_err(|e| {
+                    PyValueError::new_err(format!("no_moderator_federate_verdict serialize: {e}"))
+                })
+            })
+        })
+    }
+
     /// #249 Cut A — is `key_id` **steward-bound** (resolves to a `user`-role
     /// human identity, directly / via occurrence / via a live `delegates_to`
     /// from a user-role granter)? Returns JSON `true` / `false`. Wraps the

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7531,6 +7531,107 @@ impl PyEngine {
         })
     }
 
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 `consent-counter`) — resolve the
+    /// **Counter-RII `consent_role`** of `key_id`. Returns a JSON string: the
+    /// assigned role token (`"temporary"` / `"partnered"` / `"anonymous"` /
+    /// `"authorized_review"` / `"peer"` — the V020 vocabulary CC 3.4.7.2
+    /// ratifies), or `null` when the key has no assigned role (the stored
+    /// `'unregistered'` default, or the key is absent — all "no assigned
+    /// role": detection applies normally). Wraps
+    /// [`consent_role_of`](crate::federation::consent::consent_role_of). Persist
+    /// STORES + EXPOSES the role; the OQ-2 (`peer` blanket suppression) and
+    /// OQ-3 (`authorized_review` strict post-window) detection *signals* are
+    /// applied by the consumer (edge `ProbePatternObserver` / RATCHET) reading
+    /// this — persist houses no Counter-RII detector.
+    fn consent_role_json(&self, py: Python<'_>, key_id: &str) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            py.detach(move || {
+                let role: Option<String> = match &self.backend {
+                    #[cfg(feature = "postgres")]
+                    BackendDispatch::Postgres(pg) => {
+                        let backend = pg.clone();
+                        runtime.block_on(async move {
+                            crate::federation::consent::consent_role_of(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                    #[cfg(feature = "sqlite")]
+                    BackendDispatch::Sqlite(sq) => {
+                        let backend = sq.clone();
+                        runtime.block_on(async move {
+                            crate::federation::consent::consent_role_of(
+                                &*backend as &dyn crate::federation::FederationDirectory,
+                                &key_id,
+                            )
+                            .await
+                            .map_err(federation_err_to_py)
+                        })?
+                    }
+                };
+                serde_json::to_string(&role)
+                    .map_err(|e| PyValueError::new_err(format!("consent_role serialize: {e}")))
+            })
+        })
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1) — assign or **overwrite** the
+    /// Counter-RII `consent_role` of `key_id`. `consent_role=None` revokes it
+    /// (resets the V020 column to its `'unregistered'` default). This is the
+    /// OQ-1 non-recursive overwrite: a subsequent call overwrites the single
+    /// flat column (no chain embedded in the field). Raises `ValueError` if
+    /// `key_id` has no `federation_keys` row, or if the token is not one of
+    /// the ratified vocabulary (`temporary` / `partnered` / `anonymous` /
+    /// `authorized_review` / `peer` — same rejection on BOTH backends).
+    #[pyo3(signature = (key_id, consent_role=None))]
+    fn set_consent_role(
+        &self,
+        py: Python<'_>,
+        key_id: &str,
+        consent_role: Option<&str>,
+    ) -> PyResult<()> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let key_id = key_id.to_owned();
+            let role: Option<String> = consent_role.map(str::to_owned);
+            py.detach(move || match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        crate::federation::FederationDirectory::set_consent_role(
+                            &*backend,
+                            &key_id,
+                            role.as_deref(),
+                        )
+                        .await
+                        .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        crate::federation::FederationDirectory::set_consent_role(
+                            &*backend,
+                            &key_id,
+                            role.as_deref(),
+                        )
+                        .await
+                        .map_err(federation_err_to_py)
+                    })
+                }
+            })
+        })
+    }
+
     /// v11.9.0 (CIRISPersist#309, CC 3.4.12) — the resolved **capacity state**
     /// of `key_id` for decision-`domain`, from its incoming witness
     /// `capacity_assurance:*:{domain}:*` attestations (most-recent live wins,
@@ -26302,6 +26403,7 @@ mod tests {
                     persist_row_hash: String::new(),
                     roles: Vec::new(),
                     attestation_evidence: None,
+                    consent_role: None,
                 },
             })
             .await

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3767,6 +3767,66 @@ impl PyEngine {
         })
     }
 
+    /// v12.7.0 (CIRISPersist#371) — **upgrade-aware replicated Key-plane
+    /// apply**. FFI mirror of
+    /// [`Engine::apply_replicated_key_record`](crate::engine::Engine::apply_replicated_key_record)
+    /// — the apply the replication bridge routes `apply_key` to instead of
+    /// raw `put_public_key` (which keeps its insert-only semantics for
+    /// direct registration).
+    ///
+    /// `signed_key_record_json` is the replicated `SignedKeyRecord`. Returns
+    /// the outcome token: `"inserted"` (new key_id, every `put_public_key`
+    /// admission gate intact), `"upgraded"` (existing self-signed row
+    /// adopted the anchor-scrubbed record — same hybrid pubkeys, scrub
+    /// Strict-verified against the directory-resolved scrubber, and the
+    /// v12.6.0 `owner_of(key_id)` gate resolved exactly one live owner),
+    /// `"unchanged"` (byte-identical re-apply), or `"refused"` (pubkey swap
+    /// / downgrade / re-scrub / conflicting version / unverifiable scrub /
+    /// unowned or ambiguous owner — fail-closed, row untouched). Refusals
+    /// are outcomes, not exceptions, so an apply loop stays total.
+    fn apply_replicated_key_record(
+        &self,
+        py: Python<'_>,
+        signed_key_record_json: &str,
+    ) -> PyResult<String> {
+        self.ensure_usable()?;
+        catch_panic(|| {
+            let runtime = self.runtime.clone();
+            let record: crate::federation::SignedKeyRecord =
+                serde_json::from_str(signed_key_record_json).map_err(|e| {
+                    PyValueError::new_err(format!("SignedKeyRecord JSON decode: {e}"))
+                })?;
+            let outcome = py.detach(|| match &self.backend {
+                #[cfg(feature = "postgres")]
+                BackendDispatch::Postgres(pg) => {
+                    let backend = pg.clone();
+                    runtime.block_on(async move {
+                        backend
+                            .apply_replicated_key_record(record)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+                #[cfg(feature = "sqlite")]
+                BackendDispatch::Sqlite(sq) => {
+                    let backend = sq.clone();
+                    runtime.block_on(async move {
+                        backend
+                            .apply_replicated_key_record(record)
+                            .await
+                            .map_err(federation_err_to_py)
+                    })
+                }
+            })?;
+            serde_json::to_value(outcome)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_owned))
+                .ok_or_else(|| {
+                    PyValueError::new_err("apply_replicated_key_record outcome serialize")
+                })
+        })
+    }
+
     /// v1.5.3 — One-call helper that registers THIS engine's local
     /// pubkey as a `federation_keys` row of the specified
     /// `identity_type`. Composes the existing primitives

--- a/src/fountain/decay.rs
+++ b/src/fountain/decay.rs
@@ -1,0 +1,369 @@
+//! Consent-decay clock — the time-driven half of the two orthogonal
+//! fountain eviction triggers (CIRISPersist#227 residual).
+//!
+//! The disk-pressure trigger ([`FountainTier::from_pressure`]) drives a
+//! `content_id`'s tier down when the HOST is short on bytes. This module
+//! is its orthogonal twin: a per-`content_id` **consent clock** that
+//! drives the tier down as the content AGES past its consent stream's
+//! decay window, **independent of disk pressure** (it fires regardless of
+//! free bytes). Both triggers reuse the SAME persist-owned eviction
+//! MECHANISM ([`crate::store::Backend::evict_fountain_content_to_tier`]):
+//! this module only decides the TARGET tier from elapsed time; it never
+//! touches a symbol row itself.
+//!
+//! # What is spec-pinned vs. an operator-approved default
+//!
+//! **Spec-pinned** (CIRIS Constitution, `part_4_composition_governance`):
+//! - The **TEMPORARY** consent stream has a **14-day** default lifetime
+//!   (CC 4.4.3.5.6 — `valid_until = asserted_at + 14d`).
+//! - The **ANONYMOUS** / standard "pattern" stream decays over a
+//!   **90-day** window (CC 4.4.3.5.1 — the canonical `ciris-agent-90day`
+//!   decay protocol: `identity_severed` @0d, `patterns_anonymized` @30d,
+//!   `complete` @90d).
+//!
+//! **Operator-approved DEFAULT (tunable — NOT spec-pinned)**:
+//! - The mapping of *elapsed fraction of the window* onto persist's five
+//!   [`FountainTier`]s (the [`DECAY_FRACTION_*`](DECAY_FRACTION_T2)
+//!   breakpoints). The Constitution's decay-protocol stage map names
+//!   consent *stages*, not fountain *keep-counts*; there is no ratified
+//!   stage→tier table, so persist interpolates the five tiers evenly
+//!   across the window. Change the breakpoints (or the window lengths via
+//!   [`TEMPORARY_DECAY_DAYS`] / [`PATTERN_DECAY_DAYS`]) to re-tune.
+//! - The **reference instant** the clock measures from is the content's
+//!   `admitted_at` (the store's own per-content timestamp). The spec's
+//!   TEMPORARY window is measured from `asserted_at` and the ANONYMOUS
+//!   decay from the revocation `asserted_at`; persist does not retain
+//!   either on the fountain manifest, so `admitted_at` is the honest
+//!   substrate-local proxy.
+//! - The **class discriminator**: persist reads the content's decay class
+//!   from the signed `envelope` (see [`consent_decay_class_from_envelope`]).
+//!   Content that declares NO decay class is never touched by the decay
+//!   sweep (fail-safe: absent declaration ⇒ retained).
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::eviction::FountainTier;
+
+/// **Spec-pinned** (CC 4.4.3.5.6): the TEMPORARY consent stream's default
+/// lifetime, in days. Tunable knob for the decay window of
+/// [`ConsentDecayClass::Temporary`].
+pub const TEMPORARY_DECAY_DAYS: i64 = 14;
+
+/// **Spec-pinned** (CC 4.4.3.5.1): the ANONYMOUS / standard "pattern"
+/// decay window, in days (the canonical `ciris-agent-90day` protocol).
+/// Tunable knob for [`ConsentDecayClass::Pattern`].
+pub const PATTERN_DECAY_DAYS: i64 = 90;
+
+/// **Default (tunable)** — elapsed-fraction breakpoint at/above which the
+/// decay clock targets [`FountainTier::T2`] (drop repair). Below it the
+/// content stays [`FountainTier::Full`].
+pub const DECAY_FRACTION_T2: f64 = 0.25;
+/// **Default (tunable)** — fraction breakpoint for [`FountainTier::T3`].
+pub const DECAY_FRACTION_T3: f64 = 0.50;
+/// **Default (tunable)** — fraction breakpoint for [`FountainTier::T4`].
+pub const DECAY_FRACTION_T4: f64 = 0.75;
+/// **Default (tunable)** — fraction breakpoint for [`FountainTier::T5`]
+/// (EnvelopeOnly). At/after the full window the content is envelope-only.
+pub const DECAY_FRACTION_T5: f64 = 1.0;
+
+/// The consent stream a fountain content unit decays under. Chosen by
+/// [`consent_decay_class_from_envelope`] from the content's signed
+/// envelope; each class carries a decay window ([`Self::window_days`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentDecayClass {
+    /// The CIRISAgent TEMPORARY stream — a short 14-day (default) window
+    /// (CC 4.4.3.5.6). Content is envelope-only once the window elapses.
+    Temporary,
+    /// The ANONYMOUS / standard "pattern" stream — the 90-day (default)
+    /// decay window (CC 4.4.3.5.1).
+    Pattern,
+}
+
+impl ConsentDecayClass {
+    /// Stable string token (telemetry / logs / envelope round-trip).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            ConsentDecayClass::Temporary => "temporary",
+            ConsentDecayClass::Pattern => "pattern",
+        }
+    }
+
+    /// This class's decay window in days (the [`TEMPORARY_DECAY_DAYS`] /
+    /// [`PATTERN_DECAY_DAYS`] const). At/after this many days elapsed the
+    /// content targets [`FountainTier::T5`] (EnvelopeOnly).
+    #[must_use]
+    pub fn window_days(self) -> i64 {
+        match self {
+            ConsentDecayClass::Temporary => TEMPORARY_DECAY_DAYS,
+            ConsentDecayClass::Pattern => PATTERN_DECAY_DAYS,
+        }
+    }
+
+    /// Map `elapsed` (time since the content's reference instant, e.g.
+    /// `now - admitted_at`) onto a target [`FountainTier`], mirroring how
+    /// [`FountainTier::from_pressure`] maps a `PressureTier`. The five
+    /// tiers are laid out evenly across this class's window via the
+    /// [`DECAY_FRACTION_*`](DECAY_FRACTION_T2) breakpoints:
+    ///
+    /// | elapsed / window | Fountain |
+    /// |---|---|
+    /// | `< 0.25` | `Full`  |
+    /// | `< 0.50` | `T2`    |
+    /// | `< 0.75` | `T3`    |
+    /// | `< 1.00` | `T4`    |
+    /// | `>= 1.00`| `T5`    |
+    ///
+    /// Monotone non-decreasing in `elapsed`, so the clock only ever drives
+    /// the tier DOWN (never resurrects symbols). A negative `elapsed`
+    /// (clock skew: reference in the future) clamps to `Full`.
+    #[must_use]
+    pub fn target_tier(self, elapsed: Duration) -> FountainTier {
+        let window = self.window_days();
+        // Degenerate/tunable-to-zero window ⇒ any non-negative elapsed is
+        // fully decayed; a negative elapsed keeps Full.
+        if window <= 0 {
+            return if elapsed <= Duration::zero() {
+                FountainTier::Full
+            } else {
+                FountainTier::T5
+            };
+        }
+        // Fraction of the window elapsed. Use whole-second precision so
+        // the mapping is deterministic and backend-agnostic.
+        let elapsed_secs = elapsed.num_seconds();
+        if elapsed_secs <= 0 {
+            return FountainTier::Full;
+        }
+        let window_secs = window * 24 * 60 * 60;
+        #[allow(clippy::cast_precision_loss)]
+        let fraction = elapsed_secs as f64 / window_secs as f64;
+        if fraction < DECAY_FRACTION_T2 {
+            FountainTier::Full
+        } else if fraction < DECAY_FRACTION_T3 {
+            FountainTier::T2
+        } else if fraction < DECAY_FRACTION_T4 {
+            FountainTier::T3
+        } else if fraction < DECAY_FRACTION_T5 {
+            FountainTier::T4
+        } else {
+            FountainTier::T5
+        }
+    }
+}
+
+/// Read the [`ConsentDecayClass`] a fountain content unit decays under
+/// from its signed `envelope`. Resolution order:
+///
+/// 1. Explicit `consent_decay_class` string key: `"temporary"` ⇒
+///    [`ConsentDecayClass::Temporary`]; `"pattern"` / `"standard"` ⇒
+///    [`ConsentDecayClass::Pattern`].
+/// 2. Else a `decay_protocol` string key (CC 4.4.3.5.1 — the producer's
+///    published decay-protocol name, e.g. `"ciris-agent-90day"`) ⇒
+///    [`ConsentDecayClass::Pattern`] (the standard multi-stage window).
+/// 3. Else `None` — the content declares no decay class and the decay
+///    sweep leaves it alone (fail-safe: absence ⇒ retained). Disk-pressure
+///    eviction still applies; only the time-clock opts out.
+///
+/// Persist does not otherwise interpret the envelope — it round-trips the
+/// producer's signed declaration into a decay schedule. Absent / non-object
+/// / non-string values yield `None`.
+#[must_use]
+pub fn consent_decay_class_from_envelope(
+    envelope: &serde_json::Value,
+) -> Option<ConsentDecayClass> {
+    if let Some(cls) = envelope.get("consent_decay_class").and_then(|v| v.as_str()) {
+        return match cls {
+            "temporary" => Some(ConsentDecayClass::Temporary),
+            "pattern" | "standard" => Some(ConsentDecayClass::Pattern),
+            _ => None,
+        };
+    }
+    if envelope
+        .get("decay_protocol")
+        .and_then(|v| v.as_str())
+        .is_some()
+    {
+        return Some(ConsentDecayClass::Pattern);
+    }
+    None
+}
+
+/// Resolve the decay target tier for one content unit: read its class from
+/// the `envelope`, then map `now - admitted_at` through
+/// [`ConsentDecayClass::target_tier`]. `None` when the content declares no
+/// decay class (⇒ the caller does not touch it).
+#[must_use]
+pub fn consent_decay_target_tier(
+    envelope: &serde_json::Value,
+    admitted_at: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Option<FountainTier> {
+    let class = consent_decay_class_from_envelope(envelope)?;
+    Some(class.target_tier(now - admitted_at))
+}
+
+/// One row the consent-decay sweep considers: the manifest coordinates,
+/// the signed `envelope` (carries the decay class), and the store's
+/// `admitted_at` (the decay reference instant). Symbol-count-agnostic —
+/// the sweep asks [`consent_decay_target_tier`] for a target tier and
+/// hands it to the shared eviction mechanism.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FountainDecayCandidate {
+    /// The content's id (`content_manifest.content_id`).
+    pub content_id: String,
+    /// The corpus kind (`content_manifest.corpus_kind`).
+    pub corpus_kind: String,
+    /// The signed envelope — the decay-class source.
+    pub envelope: serde_json::Value,
+    /// The admission wall-clock (the decay reference instant).
+    pub admitted_at: DateTime<Utc>,
+}
+
+/// What one [`sweep_consent_decay_once`](crate::Engine::sweep_consent_decay_once)
+/// pass did. `symbols_evicted` is the total symbol rows the decay clock
+/// removed this pass (0 on an idempotent re-run of an already-decayed
+/// corpus); the FFI surfaces this scalar to mirror `sweep_evictions_once`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ConsentDecaySweepReport {
+    /// Content units examined (had a manifest this pass).
+    pub content_scanned: u64,
+    /// Content units that declare a decay class (were clock-evaluated).
+    pub content_with_decay_class: u64,
+    /// Content units this pass actually evicted at least one symbol from.
+    pub content_decayed: u64,
+    /// Total symbol rows the decay clock evicted this pass.
+    pub symbols_evicted: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn days(n: i64) -> Duration {
+        Duration::days(n)
+    }
+
+    #[test]
+    fn temporary_14day_schedule() {
+        let t = ConsentDecayClass::Temporary;
+        assert_eq!(t.window_days(), 14);
+        // < 25% of 14d (3.5d) ⇒ Full.
+        assert_eq!(t.target_tier(days(0)), FountainTier::Full);
+        assert_eq!(t.target_tier(days(3)), FountainTier::Full);
+        // 25% (3.5d) .. 50% (7d) ⇒ T2.
+        assert_eq!(t.target_tier(days(4)), FountainTier::T2);
+        // 50% (7d) .. 75% (10.5d) ⇒ T3.
+        assert_eq!(t.target_tier(days(8)), FountainTier::T3);
+        // 75% (10.5d) .. 100% (14d) ⇒ T4.
+        assert_eq!(t.target_tier(days(11)), FountainTier::T4);
+        // >= 14d ⇒ T5 (EnvelopeOnly).
+        assert_eq!(t.target_tier(days(14)), FountainTier::T5);
+        assert_eq!(t.target_tier(days(100)), FountainTier::T5);
+    }
+
+    #[test]
+    fn pattern_90day_schedule() {
+        let p = ConsentDecayClass::Pattern;
+        assert_eq!(p.window_days(), 90);
+        assert_eq!(p.target_tier(days(0)), FountainTier::Full);
+        assert_eq!(p.target_tier(days(22)), FountainTier::Full); // < 22.5d
+        assert_eq!(p.target_tier(days(23)), FountainTier::T2); // >= 22.5d
+        assert_eq!(p.target_tier(days(46)), FountainTier::T3); // >= 45d
+        assert_eq!(p.target_tier(days(68)), FountainTier::T4); // >= 67.5d
+        assert_eq!(p.target_tier(days(90)), FountainTier::T5);
+        assert_eq!(p.target_tier(days(365)), FountainTier::T5);
+    }
+
+    #[test]
+    fn monotone_non_decreasing() {
+        // The clock only ever drives DOWN (severity non-decreasing).
+        let p = ConsentDecayClass::Pattern;
+        let mut prev = p.target_tier(days(0));
+        for d in 0..=120 {
+            let t = p.target_tier(days(d));
+            assert!(t >= prev, "tier regressed at day {d}: {t:?} < {prev:?}");
+            prev = t;
+        }
+    }
+
+    #[test]
+    fn negative_elapsed_clamps_to_full() {
+        assert_eq!(
+            ConsentDecayClass::Temporary.target_tier(days(-5)),
+            FountainTier::Full
+        );
+    }
+
+    #[test]
+    fn class_from_envelope_explicit() {
+        assert_eq!(
+            consent_decay_class_from_envelope(
+                &serde_json::json!({ "consent_decay_class": "temporary" })
+            ),
+            Some(ConsentDecayClass::Temporary)
+        );
+        assert_eq!(
+            consent_decay_class_from_envelope(
+                &serde_json::json!({ "consent_decay_class": "pattern" })
+            ),
+            Some(ConsentDecayClass::Pattern)
+        );
+        assert_eq!(
+            consent_decay_class_from_envelope(
+                &serde_json::json!({ "consent_decay_class": "standard" })
+            ),
+            Some(ConsentDecayClass::Pattern)
+        );
+    }
+
+    #[test]
+    fn class_from_envelope_decay_protocol_is_pattern() {
+        assert_eq!(
+            consent_decay_class_from_envelope(
+                &serde_json::json!({ "decay_protocol": "ciris-agent-90day" })
+            ),
+            Some(ConsentDecayClass::Pattern)
+        );
+    }
+
+    #[test]
+    fn class_from_envelope_absent_is_none() {
+        assert_eq!(
+            consent_decay_class_from_envelope(&serde_json::json!({ "x": 1 })),
+            None
+        );
+        // Explicit key with an unknown value ⇒ None (fail-safe: retained).
+        assert_eq!(
+            consent_decay_class_from_envelope(
+                &serde_json::json!({ "consent_decay_class": "weird" })
+            ),
+            None
+        );
+        assert_eq!(
+            consent_decay_class_from_envelope(&serde_json::json!("scalar")),
+            None
+        );
+    }
+
+    #[test]
+    fn target_tier_helper_reads_envelope_and_clock() {
+        let admitted = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let now = admitted + days(20); // past a 14d TEMPORARY window
+        assert_eq!(
+            consent_decay_target_tier(
+                &serde_json::json!({ "consent_decay_class": "temporary" }),
+                admitted,
+                now
+            ),
+            Some(FountainTier::T5)
+        );
+        // No class ⇒ None (untouched).
+        assert_eq!(
+            consent_decay_target_tier(&serde_json::json!({}), admitted, now),
+            None
+        );
+    }
+}

--- a/src/fountain/eviction.rs
+++ b/src/fountain/eviction.rs
@@ -10,12 +10,11 @@
 //!      a [`FountainTier`] via [`FountainTier::from_pressure`].
 //!   2. **Consent decay** — the Consensual-Evolution clock (TEMPORARY
 //!      14-day, 90-day pattern decay) drives the tier down on a consent
-//!      schedule independent of disk. **NOTE (follow-on):** this cut
-//!      exposes the eviction MECHANISM as a callable
-//!      ([`crate::store::Backend::evict_fountain_content_to_tier`]); the
-//!      FULL Consensual-Evolution stream scheduling integration (per-
-//!      content_id consent clock → tier) is an explicit documented
-//!      follow-on and is intentionally NOT built here.
+//!      schedule independent of disk. The per-`content_id` consent clock →
+//!      tier mapping lives in [`crate::fountain::decay`] and is driven by
+//!      [`crate::Engine::sweep_consent_decay_once`]; it REUSES the same
+//!      eviction MECHANISM this module's tier×keep-count policy backs
+//!      ([`crate::store::Backend::evict_fountain_content_to_tier`]).
 //!
 //! **Revocation overrides rarity (CEG 1.0-RC11 §19 / CIRISPersist#228
 //! N5).** A withdrawn / `consent:state:revoked` content_id is HardDelete

--- a/src/fountain/mod.rs
+++ b/src/fountain/mod.rs
@@ -20,11 +20,14 @@
 //! # Two orthogonal eviction triggers
 //! 1. **DiskPressure** (#149) — [`FountainTier::from_pressure`] maps the
 //!    free-bytes tier to a keep-count.
-//! 2. **Consent decay** — the eviction MECHANISM is exposed as a
-//!    callable ([`crate::store::Backend::evict_fountain_content_to_tier`]);
-//!    the FULL Consensual-Evolution stream scheduling integration is an
-//!    explicit **documented follow-on** (see CHANGELOG [8.0.0]) and is
-//!    intentionally NOT built in this cut.
+//! 2. **Consent decay** — the per-`content_id` consent clock in [`decay`]
+//!    drives the tier down as content ages past its consent stream's
+//!    window (TEMPORARY 14-day, pattern 90-day), **independent of disk**.
+//!    It reuses the SAME eviction MECHANISM
+//!    ([`crate::store::Backend::evict_fountain_content_to_tier`]); the
+//!    scheduling is driven by
+//!    [`crate::Engine::sweep_consent_decay_once`]. See [`decay`] for the
+//!    spec-pinned-vs-default schedule breakdown.
 //!
 //! # Modules
 //! - [`types`] — the LOCKED `FountainContentV1` structs + the typed
@@ -39,6 +42,7 @@
 
 pub mod admit;
 pub mod aggregation;
+pub mod decay;
 pub mod eviction;
 pub mod retention;
 pub mod storage_contention;
@@ -54,6 +58,11 @@ pub use aggregation::{
     verify_member_commitment, AggregationMetaError, AggregationMetaV1, AggregationMetaVerification,
     AggregationMetaVerifyInputsV1, AggregationRecordV1, EjectionAction, EjectionVerdict,
     AGGREGATE_CORPUS_PREFIX,
+};
+pub use decay::{
+    consent_decay_class_from_envelope, consent_decay_target_tier, ConsentDecayClass,
+    ConsentDecaySweepReport, FountainDecayCandidate, DECAY_FRACTION_T2, DECAY_FRACTION_T3,
+    DECAY_FRACTION_T4, DECAY_FRACTION_T5, PATTERN_DECAY_DAYS, TEMPORARY_DECAY_DAYS,
 };
 pub use eviction::FountainTier;
 pub use retention::{

--- a/src/fountain/storage_contention.rs
+++ b/src/fountain/storage_contention.rs
@@ -10,11 +10,20 @@
 //! [`crate::fountain::aggregation::AggregationMetaVerifyInputsV1`] wrapping the
 //! verify-core `AggregationMetaV1`.
 //!
-//! These shapes are **verified-at-ingest, not stored** (CC 6.1.3 store-path):
-//! there is no persist admit/put table for them — a consumer builds one to
-//! advertise / verifies one it received.
+//! `CorpusWantV1` remains **verified-at-ingest, not stored** (CC 6.1.3
+//! store-path): a consumer builds one to advertise / verifies one it received.
+//! `StorageBudgetV1` gained a pin-INSTALL surface in #370 (v12.7.0):
+//! [`Engine::install_storage_budget_v1`](crate::Engine::install_storage_budget_v1)
+//! verifies the bound-hybrid signature (PQC-mandatory — verify at the gate,
+//! BEFORE persistence) and upserts an [`InstalledStorageBudget`] row (V092,
+//! both backends) under the §Q B3 anti-rollback rule (a lower/equal
+//! `revision` from the same `node_id` is refused). The installed budget is
+//! what makes §Q B5 real: the disk-pressure eviction sweep
+//! ([`Engine::sweep_evictions_once`](crate::Engine::sweep_evictions_once))
+//! orders candidates **cache-before-pinned** against the installed
+//! `pinned_class` set and holds the `pin_reserve_bytes` floor.
 //!
-//! # §Q B6/N5 — pinning never defeats revocation (CIRISPersist#359)
+//! # §Q B6/N5 — pinning never defeats revocation (CIRISPersist#359 / #370)
 //!
 //! CC 6.1.5.2 §Q B6: *"Pinning never defeats consent: an active `withdraws` /
 //! `consent:state:revoked` still forces immediate descent below the noise floor
@@ -23,28 +32,26 @@
 //! 6.1.5: revocation is a content-level dominating signal that never competes
 //! inside the priority/rarity ordering.)
 //!
-//! persist satisfies this invariant **structurally**, and the THIN form the
-//! spec confirms is sufficient:
+//! With #370 there IS persisted pin state — so B6 no longer holds by the mere
+//! absence of a pin table. It holds **structurally at the deletion path**:
 //!
-//! - A `StorageBudgetV1.pinned_class` / `pin_reserve_bytes` is a **verified-at-
-//!   ingest advertisement**, not persisted pin STATE. There is no pin table, no
-//!   `pinned_class` column, and no migration — nothing a deletion path could
-//!   query.
 //! - The revocation path
 //!   [`crate::store::Backend::evict_fountain_content_hard_delete`] takes only
-//!   `(content_id, corpus_kind)`. It has **no §Q pin parameter and reads no pin
-//!   state**; it unconditionally drops every symbol (it does not even consult
-//!   `retention_priority`). A pin covering that `subject_kind` therefore cannot
-//!   reach the delete, so it cannot shield the content.
+//!   `(content_id, corpus_kind)`. It has **no §Q pin parameter and reads no
+//!   pin state** — no backend implementation touches
+//!   `storage_budget_installed` (it does not even consult
+//!   `retention_priority`). A pin covering that `subject_kind` therefore
+//!   cannot reach the delete, so it cannot shield the content.
+//! - Only the CAPACITY sweep consumes the installed pin state
+//!   ([`Engine::sweep_evictions_once`](crate::Engine::sweep_evictions_once)'s
+//!   B5 candidate ordering) — §Q is the positive inverse of N5 and is bounded
+//!   by it.
 //!
-//! Because the pin advertisement and the delete never share a code path, B6
-//! holds by construction. The proof is locked by
-//! `tests/fountain_content.rs` section (j): a *verified* `StorageBudgetV1` whose
-//! `pinned_class` covers `trace` with `pin_reserve_bytes > 0` does not prevent a
-//! subsequent `evict_fountain_content_hard_delete` from removing `trace`
-//! content. Making the gate "real" (a stored pin the delete overrides) would
-//! require adding the very pin STATE whose absence is what makes revocation
-//! unconditional today — so the thin form is the conformant one.
+//! The proof is locked by `tests/fountain_content.rs` sections (j) and (k):
+//! (j) a *verified* `StorageBudgetV1` whose `pinned_class` covers `trace`
+//! with `pin_reserve_bytes > 0`, and (k) the SAME budget **installed as
+//! durable pin state**, do not prevent a subsequent
+//! `evict_fountain_content_hard_delete` from removing `trace` content.
 
 use serde::{Deserialize, Serialize};
 
@@ -69,6 +76,21 @@ pub enum StorageContentionError {
     /// ML-DSA-65 half — PQC-mandatory).
     #[error("storage-contention: bound-hybrid signature did not verify (PQC-mandatory)")]
     SignatureFailed,
+    /// #370 (§Q B3 anti-rollback) — the candidate budget's `revision` does
+    /// not supersede the installed one for the same `node_id` (lower OR
+    /// equal ⇒ rejected; only a strictly-higher revision replaces).
+    #[error(
+        "storage-contention: anti-rollback — candidate revision {candidate} does not \
+         supersede installed revision {installed} for node {node_id:?} (§Q B3)"
+    )]
+    RevisionRollback {
+        /// The owner node both budgets bind.
+        node_id: String,
+        /// The revision currently installed.
+        installed: u64,
+        /// The refused candidate revision.
+        candidate: u64,
+    },
 }
 
 impl StorageContentionError {
@@ -80,6 +102,7 @@ impl StorageContentionError {
             Self::Invalid(_) => "storage_contention_invalid",
             Self::MalformedBase64(_) => "storage_contention_malformed_base64",
             Self::SignatureFailed => "storage_contention_signature_failed",
+            Self::RevisionRollback { .. } => "storage_contention_revision_rollback",
         }
     }
 }
@@ -170,6 +193,73 @@ impl StorageBudgetWire {
     #[must_use]
     pub fn supersedes(&self, other: &StorageBudgetWire) -> bool {
         self.to_verify().supersedes(&other.to_verify())
+    }
+}
+
+/// #370 (§Q B2/B3/B5) — an **installed** `StorageBudgetV1`: the durable pin
+/// STATE row the pin-INSTALL surface
+/// ([`Engine::install_storage_budget_v1`](crate::Engine::install_storage_budget_v1))
+/// writes after the bound-hybrid signature verified, and the B5 capacity
+/// sweep reads back. One row per owner `node_id`; `wire_json` carries the
+/// signed wire VERBATIM so the installed budget stays re-verifiable
+/// end-to-end (persist never re-derives signed bytes).
+///
+/// The revocation path never reads this state — §Q B6 (see the module docs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledStorageBudget {
+    /// The owner node this budget binds.
+    pub node_id: String,
+    /// Monotonic revision; strictly-higher supersedes (anti-rollback).
+    pub revision: u64,
+    /// Epoch keying (CC 5.1).
+    pub epoch_id: String,
+    /// Per-`cohort_scope` allotments (denormalized from the wire).
+    pub scopes: Vec<ScopeBudgetWire>,
+    /// Corpus `subject_kind`s the owner elects to pin (B2-ii).
+    pub pinned_class: Vec<String>,
+    /// The signed `StorageBudgetV1` wire JSON, verbatim.
+    pub wire_json: String,
+    /// When this revision was accepted locally.
+    pub installed_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl InstalledStorageBudget {
+    /// Build the install row from a signed wire JSON. Parses AND
+    /// structurally re-validates the payload (defense in depth — the caller
+    /// must already have run [`verify_storage_budget_wire`]; this never
+    /// admits a shape `validate()` rejects even on a buggy call path).
+    ///
+    /// # Errors
+    /// [`StorageContentionError::MalformedJson`] /
+    /// [`StorageContentionError::Invalid`].
+    pub fn from_wire_json(
+        wire_json: &str,
+        installed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Self, StorageContentionError> {
+        let wire: StorageBudgetWire = serde_json::from_str(wire_json)
+            .map_err(|e| StorageContentionError::MalformedJson(e.to_string()))?;
+        wire.to_verify()
+            .validate()
+            .map_err(|e| StorageContentionError::Invalid(e.to_string()))?;
+        Ok(InstalledStorageBudget {
+            node_id: wire.node_id,
+            revision: wire.revision,
+            epoch_id: wire.epoch_id,
+            scopes: wire.scopes,
+            pinned_class: wire.pinned_class,
+            wire_json: wire_json.to_owned(),
+            installed_at,
+        })
+    }
+
+    /// The total `pin_reserve_bytes` floor this budget declares (sum over
+    /// its per-scope allotments) — the bytes the B5 sweep holds for the
+    /// pinned classes under capacity pressure.
+    #[must_use]
+    pub fn pin_reserve_total(&self) -> u64 {
+        self.scopes
+            .iter()
+            .fold(0u64, |acc, s| acc.saturating_add(s.pin_reserve_bytes))
     }
 }
 
@@ -561,5 +651,52 @@ mod tests {
             verify_storage_budget_wire("{not json", "", ""),
             Err(StorageContentionError::MalformedJson(_))
         ));
+    }
+
+    /// #370 — `InstalledStorageBudget::from_wire_json` denormalizes the
+    /// wire, keeps the signed JSON verbatim, and re-runs the structural
+    /// validation (defense in depth).
+    #[test]
+    fn installed_budget_from_wire_json() {
+        let id = id();
+        let wire = build_budget(&id, BUDGET_PAYLOAD); // revision 3
+        let now = chrono::Utc::now();
+        let installed = InstalledStorageBudget::from_wire_json(&wire, now).unwrap();
+        assert_eq!(installed.node_id, "n1");
+        assert_eq!(installed.revision, 3);
+        assert_eq!(installed.epoch_id, "e1");
+        assert_eq!(installed.pinned_class, vec!["av_chunk", "trace"]);
+        assert_eq!(
+            installed.pin_reserve_total(),
+            200,
+            "summed pin_reserve_bytes over scopes"
+        );
+        assert_eq!(installed.wire_json, wire, "signed wire kept verbatim");
+        assert_eq!(installed.installed_at, now);
+
+        // Structural invalidity is refused even when signatures aren't
+        // checked here (a suppressed `self` scope).
+        let bad = r#"{"node_id":"n1","epoch_id":"e1","revision":1,
+            "scopes":[{"cohort_scope":"self","budget_bytes":1,"pin_reserve_bytes":0}],
+            "pinned_class":[],
+            "signature_ed25519_base64":"","signature_ml_dsa_65_base64":""}"#;
+        assert!(matches!(
+            InstalledStorageBudget::from_wire_json(bad, now),
+            Err(StorageContentionError::Invalid(_))
+        ));
+    }
+
+    /// #370 — the anti-rollback error carries a stable telemetry token.
+    #[test]
+    fn revision_rollback_kind_token() {
+        let e = StorageContentionError::RevisionRollback {
+            node_id: "n1".into(),
+            installed: 5,
+            candidate: 3,
+        };
+        assert_eq!(e.kind(), "storage_contention_revision_rollback");
+        let msg = e.to_string();
+        assert!(msg.contains("candidate revision 3"));
+        assert!(msg.contains("installed revision 5"));
     }
 }

--- a/src/fountain/storage_contention.rs
+++ b/src/fountain/storage_contention.rs
@@ -15,7 +15,7 @@
 //! `StorageBudgetV1` gained a pin-INSTALL surface in #370 (v12.7.0):
 //! [`Engine::install_storage_budget_v1`](crate::Engine::install_storage_budget_v1)
 //! verifies the bound-hybrid signature (PQC-mandatory — verify at the gate,
-//! BEFORE persistence) and upserts an [`InstalledStorageBudget`] row (V092,
+//! BEFORE persistence) and upserts an [`InstalledStorageBudget`] row (V093,
 //! both backends) under the §Q B3 anti-rollback rule (a lower/equal
 //! `revision` from the same `node_id` is refused). The installed budget is
 //! what makes §Q B5 real: the disk-pressure eviction sweep

--- a/src/scope/admission.rs
+++ b/src/scope/admission.rs
@@ -273,6 +273,7 @@ mod revocation_honesty_tests {
                 persist_row_hash: String::new(),
                 roles: Vec::new(),
                 attestation_evidence: None,
+                consent_role: None,
             },
         }
     }

--- a/src/server/secrets.rs
+++ b/src/server/secrets.rs
@@ -961,6 +961,7 @@ mod tests {
                 ROLE_SECRETS_ADMIN.to_owned(),
             ],
             attestation_evidence: None,
+            consent_role: None,
         };
         FederationDirectory::put_public_key(&*backend, SignedKeyRecord { record: key })
             .await

--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -428,6 +428,50 @@ pub trait Backend: Send + Sync {
         publisher_key_id: &str,
     ) -> impl Future<Output = Result<Vec<crate::fountain::FountainHeldMeta>, Error>> + Send;
 
+    // ─── v12.7.0 — §Q pin-INSTALL surface (CC 6.1.5.2 / CIRISPersist#370) ──
+    //
+    // The durable half of the storage-contention shapes (#356 shipped
+    // build/verify as wire-negotiation only). One row per owner node_id in
+    // `storage_budget_installed` (V093). The B5 capacity sweep
+    // (`Engine::sweep_evictions_once`) reads this state back; the
+    // revocation path (`evict_fountain_content_hard_delete`, above) NEVER
+    // does — §Q B6: pinning never defeats revocation.
+
+    /// #370 (§Q B3) — conditionally upsert an installed `StorageBudgetV1`.
+    ///
+    /// The caller (`Engine::install_storage_budget_v1`) MUST have
+    /// bound-hybrid-verified the wire first (PQC-mandatory, CC 5.3.2.4.3.1
+    /// store-path); this method enforces the **anti-rollback** half
+    /// ATOMICALLY at the row: insert if the `node_id` is new, replace iff
+    /// `budget.revision` is STRICTLY higher than the installed revision.
+    /// Returns `Ok(true)` when the row was written, `Ok(false)` when refused
+    /// (lower/equal revision — the caller surfaces
+    /// `StorageContentionError::RevisionRollback`). Doing the check in the
+    /// upsert itself (`... WHERE installed.revision < excluded.revision`)
+    /// means two racing installs cannot roll the revision back.
+    fn put_installed_storage_budget(
+        &self,
+        budget: &crate::fountain::storage_contention::InstalledStorageBudget,
+    ) -> impl Future<Output = Result<bool, Error>> + Send;
+
+    /// #370 — read back the installed budget for `node_id` (the signed wire
+    /// verbatim + denormalized fields). `Ok(None)` when none installed.
+    fn get_installed_storage_budget(
+        &self,
+        node_id: &str,
+    ) -> impl Future<
+        Output = Result<Option<crate::fountain::storage_contention::InstalledStorageBudget>, Error>,
+    > + Send;
+
+    /// #370 (§Q B5) — every installed budget (typically exactly one: this
+    /// node's own). The capacity sweep folds these into the effective
+    /// `pinned_class` set + `pin_reserve_bytes` floor once per cycle.
+    fn list_installed_storage_budgets(
+        &self,
+    ) -> impl Future<
+        Output = Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, Error>,
+    > + Send;
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
     //
     // The forever-memory storage half of operator 2. persist is

--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -471,6 +471,19 @@ pub trait Backend: Send + Sync {
     ) -> impl Future<
         Output = Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, Error>,
     > + Send;
+    /// #227 (residual) — enumerate EVERY fountain content unit's decay
+    /// coordinates for the consent-decay clock: `(content_id, corpus_kind,
+    /// envelope, admitted_at)`. The signed `envelope` carries the decay
+    /// class ([`crate::fountain::consent_decay_class_from_envelope`]) and
+    /// `admitted_at` is the decay reference instant. No symbol bytes are
+    /// read; the sweep asks
+    /// [`consent_decay_target_tier`](crate::fountain::consent_decay_target_tier)
+    /// for a target tier and reuses the shared eviction mechanism
+    /// ([`Self::evict_fountain_content_to_tier`]). Unordered; empty when
+    /// nothing is stored. Disk-INDEPENDENT (never consults free bytes).
+    fn list_fountain_decay_candidates(
+        &self,
+    ) -> impl Future<Output = Result<Vec<crate::fountain::FountainDecayCandidate>, Error>> + Send;
 
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
     //

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1391,11 +1391,14 @@ impl crate::federation::FederationDirectory for MemoryBackend {
 
         // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
         // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
-        // keyed on a community (`community_id` in its envelope) is a federation
+        // keyed on a community is a federation
         // apply step keyed on C; it is refused if C has lost its last live
         // `moderate`-holder (so a moderator-less community cannot continue at
-        // moderated capability). No-op for local-tier rows, rows with no
-        // community_id, and communities not locally known. Resolves the
+        // moderated capability). #369 broadened the keying: C is referenced
+        // via envelope `community_id`/`community_key_id`/`cohort_key_id`, OR
+        // a row endpoint / subject_key_ids entry resolving as a stored
+        // community (the membership shape). No-op for local-tier rows and
+        // rows referencing no locally-known community. Resolves the
         // community + steward-binding via the directory (locks state itself),
         // so it runs before the state lock. Backend-symmetric.
         crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
@@ -9142,6 +9145,179 @@ mod tests {
         check_no_moderator_federate_admission_by_id(&b, "no-such")
             .await
             .expect("unknown community ⇒ out of scope ⇒ no-op");
+    }
+
+    /// #369 (CC 4.5.4 / §11.11) — BROADENED apply-gate keying: a federation
+    /// apply step is keyed on `C` under ANY of the substrate's community-
+    /// reference shapes, not only a literal `attestation_envelope.community_id`.
+    /// Decision table over the membership-attestation shapes: row endpoints
+    /// (`attested_key_id` / `attesting_key_id` resolving as a stored
+    /// community — the "subject doubles as the membership target" read-gate
+    /// rule), `subject_key_ids` entries, and the sibling envelope field names
+    /// (`community_key_id` / `cohort_key_id`). Plus the negative half:
+    /// local-tier + storage-only community ops stay untouched.
+    #[tokio::test]
+    async fn no_moderator_federate_gate_broadened_keying_decision_table() {
+        use crate::federation::admission::{
+            check_no_moderator_federate_apply, no_moderator_federate_verdict, MEMBER_ROLE_FOUNDER,
+        };
+        use crate::federation::types::{consensus_protocol, identity_type};
+
+        let b = MemoryBackend::new();
+
+        // Seed a MODERATOR-LESS community (primitive founder — passes the
+        // steward-binding storage gate, but is NOT steward-bound ⇒ no
+        // zero-hop moderator) and a MODERATORED one (user founder).
+        async fn seed(backend: &MemoryBackend, cid: &str, founder: &str, founder_it: &str) {
+            let ck = fix_key(cid, "primitive", cid);
+            backend
+                .put_public_key(SignedKeyRecord { record: ck })
+                .await
+                .unwrap();
+            let mut fk = fix_key(founder, "primitive", founder);
+            fk.identity_type = founder_it.into();
+            backend
+                .put_public_key(SignedKeyRecord { record: fk })
+                .await
+                .unwrap();
+            backend
+                .put_community(crate::federation::SignedCommunity {
+                    community: crate::federation::types::Community {
+                        community_key_id: cid.into(),
+                        community_name: "bk".into(),
+                        members: vec![crate::federation::types::CommunityMember {
+                            key_id: founder.into(),
+                            joined_at: "2026-05-01T00:00:00Z".parse().unwrap(),
+                            role: Some(MEMBER_ROLE_FOUNDER.into()),
+                        }],
+                        founded_at: "2026-05-01T00:00:00Z".parse().unwrap(),
+                        consensus_protocol: consensus_protocol::FOUNDER_ONLY.into(),
+                        policy_blob: None,
+                        persist_row_hash: String::new(),
+                    },
+                })
+                .await
+                .expect("storage-only put_community is NOT the moderator gate");
+        }
+        seed(&b, "bk-no", "bk-prim", identity_type::PRIMITIVE).await;
+        seed(&b, "bk-ok", "bk-user", identity_type::USER).await;
+
+        let refused = |err: crate::federation::Error, shape: &str| {
+            assert!(
+                matches!(
+                    err,
+                    crate::federation::Error::CommunityHasNoModerator { .. }
+                ),
+                "{shape}: moderator-less community must refuse, got {err:?}"
+            );
+        };
+
+        // (1) MEMBERSHIP shape — federation-tier row attested TO the
+        //     moderator-less community (no envelope community field) → REJECT.
+        let bare_env = serde_json::json!({ "id": "bk-1", "dimension": "identity_binding:v1" });
+        let mut row = fix_attestation("bk-1", "bk-prim", "bk-no", "bk-prim");
+        row.attestation_envelope = bare_env.clone();
+        refused(
+            check_no_moderator_federate_apply(&b, &row)
+                .await
+                .unwrap_err(),
+            "attested_key_id = C",
+        );
+        // Same shape onto the MODERATORED community → ADMIT.
+        let mut ok_row = fix_attestation("bk-2", "bk-user", "bk-ok", "bk-user");
+        ok_row.attestation_envelope = bare_env.clone();
+        check_no_moderator_federate_apply(&b, &ok_row)
+            .await
+            .expect("membership-shaped row onto a moderatored community is admitted");
+        // LOCAL tier onto the moderator-less community → untouched.
+        let mut local = row.clone();
+        local.tier = crate::federation::types::attestation_tier::LOCAL.into();
+        check_no_moderator_federate_apply(&b, &local)
+            .await
+            .expect("local-tier membership row is not a federation apply step");
+
+        // (2) EMITTED-BY-C shape — attesting_key_id = the community → REJECT.
+        let mut by_c = fix_attestation("bk-3", "bk-no", "bk-prim", "bk-no");
+        by_c.attestation_envelope = bare_env.clone();
+        refused(
+            check_no_moderator_federate_apply(&b, &by_c)
+                .await
+                .unwrap_err(),
+            "attesting_key_id = C",
+        );
+
+        // (3) subject_key_ids shape → REJECT; non-community subjects fail-open.
+        let mut subj = fix_attestation("bk-4", "bk-prim", "bk-prim", "bk-prim");
+        subj.attestation_envelope = bare_env.clone();
+        subj.subject_key_ids = vec!["not-a-community".into(), "bk-no".into()];
+        refused(
+            check_no_moderator_federate_apply(&b, &subj)
+                .await
+                .unwrap_err(),
+            "subject_key_ids ∋ C",
+        );
+        let mut subj_ok = subj.clone();
+        subj_ok.subject_key_ids = vec!["not-a-community".into(), "bk-ok".into()];
+        check_no_moderator_federate_apply(&b, &subj_ok)
+            .await
+            .expect("subject-keyed row onto a moderatored community is admitted");
+
+        // (4) Sibling envelope field names (`community_key_id` / `cohort_key_id`)
+        //     → REJECT on the moderator-less community.
+        for field in ["community_key_id", "cohort_key_id"] {
+            let mut env_row = fix_attestation("bk-5", "bk-prim", "bk-prim", "bk-prim");
+            env_row.attestation_envelope = serde_json::json!({
+                "id": "bk-5", "dimension": "identity_binding:v1", field: "bk-no"
+            });
+            refused(
+                check_no_moderator_federate_apply(&b, &env_row)
+                    .await
+                    .unwrap_err(),
+                field,
+            );
+        }
+
+        // (5) Storage-only community ops on the moderator-less community stay
+        //     untouched: the record can be re-stored (roster rewrite) and its
+        //     membership revocations recorded — loss-processing + the CC
+        //     4.5.13 recovery must not be blocked by the federate gate.
+        seed(&b, "bk-no", "bk-prim", identity_type::PRIMITIVE).await;
+        b.put_community_membership_revocation(
+            crate::federation::SignedCommunityMembershipRevocation {
+                community_membership_revocation:
+                    crate::federation::types::CommunityMembershipRevocation {
+                        community_key_id: "bk-no".into(),
+                        removed_identity_key_id: "bk-prim".into(),
+                        removed_at: "2026-05-02T00:00:00Z".parse().unwrap(),
+                        effective_at: "2026-05-02T00:00:00Z".parse().unwrap(),
+                        reason: Some("storage-only membership op stays ungated".into()),
+                        witness_set: Vec::new(),
+                        persist_row_hash: String::new(),
+                    },
+            },
+        )
+        .await
+        .expect("membership revocation on a moderator-less community is storage, not federation");
+
+        // (6) The drivable verdict mirrors the gate decision exactly.
+        let v = no_moderator_federate_verdict(&b, "bk-no").await.unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "admitted": false, "community_known": true,
+                "reason": "federation_community_no_moderator"
+            })
+        );
+        let v = no_moderator_federate_verdict(&b, "bk-ok").await.unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({ "admitted": true, "community_known": true })
+        );
+        let v = no_moderator_federate_verdict(&b, "no-such").await.unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({ "admitted": true, "community_known": false })
+        );
     }
 
     /// v12.6.0 (CIRISPersist#171 / #238 / #146, §10.1.3 transit-not-rest) —

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -520,6 +520,7 @@ impl MemoryBackend {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         state.federation_keys.insert(key_id.to_owned(), rec);
         // Keep the legacy map populated too — some tests still
@@ -1214,6 +1215,16 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         record: crate::federation::SignedKeyRecord,
     ) -> Result<(), crate::federation::Error> {
         let mut row = record.record;
+        // v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — same consent_role
+        // admission gate + 'unregistered'⇔None normalization as the SQL
+        // backends (a stored-form 'unregistered' submitted on the wire
+        // reads back as None everywhere).
+        crate::federation::types::consent_role::check_admissible(row.consent_role.as_deref())?;
+        row.consent_role = row
+            .consent_role
+            .as_deref()
+            .and_then(crate::federation::types::consent_role::wire_from_stored)
+            .map(str::to_owned);
         // Server-computed hash (excludes the field itself).
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let mut state = self.state.lock().expect("memory backend lock");
@@ -1268,6 +1279,33 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .collect();
         rows.sort_by(|a, b| a.key_id.cmp(&b.key_id));
         Ok(rows)
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1) — overwrite-on-revoke
+    /// consent_role. `None` revokes (back to the unset/'unregistered'
+    /// default). No chain; a subsequent call overwrites. `consent_role`
+    /// is excluded from `persist_row_hash`, so mutating it does not
+    /// change the stored row's hash. Same admission gate +
+    /// 'unregistered'⇔None normalization as the SQL backends.
+    async fn set_consent_role(
+        &self,
+        key_id: &str,
+        consent_role: Option<&str>,
+    ) -> Result<(), crate::federation::Error> {
+        crate::federation::types::consent_role::check_admissible(consent_role)?;
+        let normalized: Option<String> = consent_role
+            .and_then(crate::federation::types::consent_role::wire_from_stored)
+            .map(str::to_owned);
+        let mut state = self.state.lock().expect("memory backend lock");
+        match state.federation_keys.get_mut(key_id) {
+            Some(row) => {
+                row.consent_role = normalized;
+                Ok(())
+            }
+            None => Err(crate::federation::Error::InvalidArgument(format!(
+                "set_consent_role: no federation_keys row for {key_id}"
+            ))),
+        }
     }
 
     async fn put_attestation(
@@ -3379,6 +3417,7 @@ impl crate::federation::FederationDirectory for MemoryBackend {
                 persist_row_hash: String::new(),
                 roles: Vec::new(),
                 attestation_evidence: None,
+                consent_role: None,
             };
             // persist_row_hash filled in inline (mirrors put_public_key)
             let mut to_insert = key;
@@ -4731,6 +4770,92 @@ mod tests {
         assert_eq!(got.to_bytes(), vkey.to_bytes());
     }
 
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — consent_role round-trip,
+    /// OQ-1 overwrite-on-revoke via set_consent_role, and the
+    /// consent_role_of resolver, on the memory backend.
+    #[tokio::test]
+    async fn consent_role_round_trip_overwrite_and_resolver_memory() {
+        use crate::federation::consent::consent_role_of;
+        use crate::federation::types::consent_role;
+        let backend = MemoryBackend::new();
+
+        // Born with consent_role = peer → round-trips through put/lookup.
+        let mut key = fix_key("k-cr", "primitive-cr", "k-cr");
+        key.consent_role = Some(consent_role::PEER.into());
+        crate::federation::FederationDirectory::put_public_key(
+            &backend,
+            crate::federation::SignedKeyRecord { record: key },
+        )
+        .await
+        .unwrap();
+        let got = crate::federation::FederationDirectory::lookup_public_key(&backend, "k-cr")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.consent_role.as_deref(), Some(consent_role::PEER));
+        assert_eq!(
+            consent_role_of(&backend, "k-cr").await.unwrap().as_deref(),
+            Some(consent_role::PEER)
+        );
+
+        // OQ-1 overwrite → authorized_review (flat, non-recursive).
+        crate::federation::FederationDirectory::set_consent_role(
+            &backend,
+            "k-cr",
+            Some(consent_role::AUTHORIZED_REVIEW),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            consent_role_of(&backend, "k-cr").await.unwrap().as_deref(),
+            Some(consent_role::AUTHORIZED_REVIEW)
+        );
+
+        // Revoke (overwrite to None).
+        crate::federation::FederationDirectory::set_consent_role(&backend, "k-cr", None)
+            .await
+            .unwrap();
+        assert_eq!(consent_role_of(&backend, "k-cr").await.unwrap(), None);
+
+        // Unknown key: setter errors, resolver stays total (Ok(None)).
+        assert!(crate::federation::FederationDirectory::set_consent_role(
+            &backend,
+            "k-missing",
+            Some("peer")
+        )
+        .await
+        .is_err());
+        assert_eq!(consent_role_of(&backend, "k-missing").await.unwrap(), None);
+
+        // Unrecognized token: rejected at admission (backend-symmetric).
+        assert!(crate::federation::FederationDirectory::set_consent_role(
+            &backend,
+            "k-cr",
+            Some("emperor")
+        )
+        .await
+        .is_err());
+
+        // The literal stored default 'unregistered' normalizes to wire
+        // None on set (stored/wire forms cohere).
+        crate::federation::FederationDirectory::set_consent_role(
+            &backend,
+            "k-cr",
+            Some(consent_role::UNREGISTERED),
+        )
+        .await
+        .unwrap();
+        assert_eq!(consent_role_of(&backend, "k-cr").await.unwrap(), None);
+
+        // consent_role does NOT enter persist_row_hash (OQ-1 exclusion).
+        let mut a = fix_key("k-hash", "primitive-cr", "k-hash");
+        a.consent_role = None;
+        let h0 = crate::federation::types::compute_persist_row_hash(&a).unwrap();
+        a.consent_role = Some(consent_role::PARTNERED.into());
+        let h1 = crate::federation::types::compute_persist_row_hash(&a).unwrap();
+        assert_eq!(h0, h1, "consent_role must not affect persist_row_hash");
+    }
+
     /// Mission category §4 "Backend parity" (placeholder for the
     /// Phase-1.4 conformance suite): a decomposed CompleteTrace lands
     /// on the in-memory backend with the right row counts, dedup
@@ -4864,6 +4989,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -392,8 +392,10 @@ impl MemoryBackend {
     }
 
     /// v4.4.0 (CIRISPersist#171) — local-tier write (upsert/insert)
-    /// parity with the sqlite/postgres backends. Synchronous (in-process).
-    fn memory_write_local_attestation(
+    /// parity with the sqlite/postgres backends. `async` since v12.6.0: a
+    /// subject-side revocation transiting the local tier is hybrid-verified
+    /// (resolving pubkeys via the directory) before it is written.
+    async fn memory_write_local_attestation(
         &self,
         input: crate::federation::types::LocalAttestationInput,
         replace: bool,
@@ -404,7 +406,7 @@ impl MemoryBackend {
                 "local attestation envelope must carry a \"dimension\" string".into(),
             )
         })?;
-        crate::federation::admission::check_local_tier_eligibility(
+        let disposition = crate::federation::admission::check_local_tier_eligibility(
             &input.attestation_type,
             Some(dimension.as_str()),
             &input.attesting_key_id,
@@ -412,6 +414,18 @@ impl MemoryBackend {
             &input.cohort_scope,
         )?;
         crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        // v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — a subject-side
+        // revocation MAY *transit* the local write path only if its bound-hybrid
+        // signature verifies (accept on VALID crypto only; the operator gate).
+        // Runs BEFORE the state lock (verify resolves pubkeys via the directory,
+        // which locks itself). `None` for a durable producer-authority row.
+        let transit = crate::federation::admission::verify_local_transit_revocation(
+            self,
+            disposition,
+            &input,
+        )
+        .await?;
 
         let mut state = self.state.lock().expect("memory backend lock");
         let identity_type = match state.federation_keys.get(&input.attesting_key_id) {
@@ -442,7 +456,17 @@ impl MemoryBackend {
 
         let attestation_id = uuid::Uuid::new_v4().to_string();
         let attesting_key_id = input.attesting_key_id.clone();
-        let mut row = input.into_local_row(attestation_id.clone(), chrono::Utc::now());
+        let now = chrono::Utc::now();
+        let mut row = match transit {
+            Some((hash, sig_classical, sig_pqc)) => input.into_transit_revocation_row(
+                attestation_id.clone(),
+                now,
+                hash,
+                sig_classical,
+                sig_pqc,
+            ),
+            None => input.into_local_row(attestation_id.clone(), now),
+        };
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 
         if replace {
@@ -1352,6 +1376,15 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         // non-conformant per CC 5.3.2.4.3.1).
         crate::federation::verify_federation_tier_ingest(self, &row).await?;
 
+        // v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — a `revoked`
+        // consent_record at local tier MAY *transit* the local write path
+        // only if its bound-hybrid signature verifies (accept on VALID crypto
+        // only). Runs BEFORE the state lock (it resolves pubkeys via the
+        // directory, which locks itself) and BEFORE persist. No-op for
+        // non-consent_record rows and durable (granted / federation) ones.
+        // Backend-symmetric with SQLite + Postgres.
+        crate::federation::admission::verify_consent_record_transit_ingest(self, &row).await?;
+
         let mut state = self.state.lock().expect("memory backend lock");
         // FK enforcement parity with postgres: both attesting_key_id
         // and attested_key_id must exist in federation_keys.
@@ -1383,16 +1416,6 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             &attesting_identity_type,
         )?;
 
-        // v6.7.0 (CIRISPersist#146 Ask 5, CEG §5.6.8.7) — `consent_record`
-        // ceremony admission (required fields / closed stance set /
-        // substrate-only `expired` / §10.1.3 revoked-not-local). No-op for
-        // every non-`consent_record` row.
-        crate::federation::admission::check_consent_record_admission(
-            &row.attestation_type,
-            &row.attestation_envelope,
-            &row.tier,
-        )?;
-
         // v3.0.0 (CIRISPersist#116, CEG 0.2 §6.1) — structural-composer
         // dedup on `(references_attestation_id, attestation_type,
         // attesting_key_id)`. A duplicate composer is a typed
@@ -1416,14 +1439,14 @@ impl crate::federation::FederationDirectory for MemoryBackend {
         &self,
         input: crate::federation::types::LocalAttestationInput,
     ) -> Result<String, crate::federation::Error> {
-        self.memory_write_local_attestation(input, true)
+        self.memory_write_local_attestation(input, true).await
     }
 
     async fn attestation_insert_local(
         &self,
         input: crate::federation::types::LocalAttestationInput,
     ) -> Result<String, crate::federation::Error> {
-        self.memory_write_local_attestation(input, false)
+        self.memory_write_local_attestation(input, false).await
     }
 
     async fn list_attestations_for(
@@ -8206,9 +8229,15 @@ mod tests {
         );
     }
 
+    /// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — a `revoked`
+    /// consent_record at local tier is ACCEPTED as a **transit** write when
+    /// its bound-hybrid signature verifies (the operator decision), but a
+    /// crypto-INVALID one is rejected at admission (never rests unsigned).
+    /// Pre-v12.6.0 this was a hard rejection of both.
     #[tokio::test]
-    async fn consent_record_revoked_local_tier_rejected() {
+    async fn consent_record_revoked_local_tier_transits_iff_signed() {
         let backend = consent_backend().await;
+        // (1) Validly-signed revoked consent_record @ local → transit-accepted.
         let row = consent_record_row(
             "cr-4",
             "subject-key",
@@ -8216,13 +8245,74 @@ mod tests {
             crate::federation::types::attestation_tier::LOCAL,
             true,
         );
-        let err = backend
+        backend
             .put_attestation(SignedAttestation { attestation: row })
+            .await
+            .expect("crypto-valid revoked consent_record transits the local tier (§10.1.3)");
+
+        // (2) A crypto-INVALID one (signature corrupted) is rejected at
+        // admission — accept ONLY on a valid bound-hybrid signature.
+        let mut forged = consent_record_row(
+            "cr-4b",
+            "subject-key",
+            consent_record::stance::REVOKED,
+            crate::federation::types::attestation_tier::LOCAL,
+            true,
+        );
+        forged.scrub_signature_classical = "AAAA".into(); // not a valid sig
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: forged,
+            })
             .await
             .unwrap_err();
         assert!(
-            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("not local-tier-eligible") || m.contains("NOT local-tier-eligible")),
-            "revoked local-tier rejected (§10.1.3), got {err:?}"
+            matches!(
+                err,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "unsigned/forged revoked consent_record rejected at admission, got {err:?}"
+        );
+    }
+
+    /// v12.6.0 (CIRISPersist#171, §10.1.3) — the `put_attestation(tier=local)`
+    /// bypass is CLOSED for *bare* subject-side revocations too (not only the
+    /// consent_record ceremony): a `consent:state:revoked` row whose writer ∈
+    /// `subject_key_ids` at local tier is hybrid-verified at ingest — a valid
+    /// signature transits, a forged one is rejected.
+    #[tokio::test]
+    async fn bare_subject_side_revocation_via_put_attestation_gated() {
+        let backend = consent_backend().await;
+        let mut row = fix_attestation("bare-rev", "subject-key", "registry-steward", "subject-key");
+        row.attestation_envelope = serde_json::json!({
+            "id": "bare-rev", "dimension": "consent:state:revoked:v1",
+            "score": 1.0, "confidence": 0.9,
+        });
+        row.subject_key_ids = vec!["subject-key".into()];
+        row.tier = crate::federation::types::attestation_tier::LOCAL.into();
+        row.cohort_scope = crate::federation::types::cohort_scope::SELF.to_string();
+        resign_fix(&mut row); // envelope changed → re-sign
+        let mut forged = row.clone();
+        backend
+            .put_attestation(SignedAttestation { attestation: row })
+            .await
+            .expect("crypto-valid bare subject-side revocation transits at local tier");
+
+        // Forged signature → rejected (no put_attestation bypass of the gate).
+        forged.attestation_id = "bare-rev-forged".into();
+        forged.scrub_signature_classical = "AAAA".into();
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: forged,
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "forged bare revocation rejected at put_attestation local tier, got {err:?}"
         );
     }
 
@@ -8928,14 +9018,19 @@ mod tests {
             .expect("unknown community ⇒ out of scope ⇒ no-op");
     }
 
-    /// #238 / #146 (CC 5.3.2.2 / §10.1.3, AV-61 transit-not-rest) — the
-    /// consent-revocation promotion-overdue `hard_case` fires at the 24 h
-    /// window boundary for a subject-side revocation that stays local-tier
-    /// (unpromoted), is idempotent on re-scan, and stops once the row promotes.
+    /// v12.6.0 (CIRISPersist#171 / #238 / #146, §10.1.3 transit-not-rest) —
+    /// the FULL consent-SLA loop through the REAL admission path (replacing the
+    /// #238 test that staged the transit row artificially): a crypto-valid
+    /// subject-side `consent:state:revoked` is ADMITTED as a transit local-tier
+    /// write via `attestation_upsert_local`, the revocation scan sees it, the
+    /// promotion-overdue `hard_case` fires at the 24 h boundary (not before), is
+    /// idempotent on re-scan, and stops once promoted. Also asserts a
+    /// crypto-INVALID revocation is REJECTED at admission (never transits).
     #[tokio::test]
-    async fn consent_revocation_promotion_overdue_fires_at_window_boundary() {
+    async fn consent_revocation_transit_admits_and_sla_fires_end_to_end() {
         use crate::federation::hard_case::{kind, HardCaseFilter};
-        use crate::federation::types::attestation_tier;
+        use crate::federation::tier_ingest::test_support::sign_envelope;
+        use crate::federation::types::{attestation_tier, attestation_type, LocalAttestationInput};
         use crate::federation::FederationDirectory;
         use std::time::Duration;
         let backend = MemoryBackend::new();
@@ -8947,35 +9042,50 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let revoked_at: chrono::DateTime<chrono::Utc> = "2026-06-01T00:00:00Z".parse().unwrap();
-        // A subject-side `consent:state:revoked` TRANSITING local-tier
-        // (unpromoted). persist's admission gate refuses to *originate* such a
-        // local row (transit-not-rest); we stage it directly to exercise the
-        // watcher's promotion-overdue detection.
-        let mut rev = fix_attestation("rev-c", "subject-c", "target-c", "subject-c");
-        rev.attestation_envelope =
-            serde_json::json!({ "id": "rev-c", "dimension": "consent:state:revoked:v1" });
-        rev.asserted_at = revoked_at;
-        rev.subject_key_ids = vec!["subject-c".into()];
-        rev.tier = attestation_tier::LOCAL.into();
-        rev.promoted_at = None;
-        backend
-            .state
-            .lock()
-            .unwrap()
-            .federation_attestations
-            .push(rev);
+
+        // A subject-side `consent:state:revoked` envelope, hybrid-signed by the
+        // subject (Ed25519 + ML-DSA-65 bound) over the CEG canonical form.
+        let env = serde_json::json!({
+            "id": "rev-c", "dimension": "consent:state:revoked:v1",
+            "score": 1.0, "confidence": 0.9,
+        });
+        let (_hash, sig_classical, sig_pqc) = sign_envelope("subject-c", &env);
+
+        // Admit it through the REAL local-write admission path — accepted as a
+        // TRANSIT write because the bound-hybrid signature verifies (§10.1.3).
+        let att_id = backend
+            .attestation_upsert_local(LocalAttestationInput {
+                attesting_key_id: "subject-c".into(),
+                attested_key_id: Some("target-c".into()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: env.clone(),
+                subject_key_ids: vec!["subject-c".into()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some(sig_classical),
+                scrub_signature_pqc: sig_pqc,
+            })
+            .await
+            .expect("crypto-valid subject-side revocation transits the local tier (§10.1.3)");
+
+        // The transit row is stored at local tier, unpromoted, carrying its
+        // REAL signature (not the deferred empty sentinel) — never a durable
+        // unsigned local row.
+        let rows = backend.list_consent_revocations(None).await.unwrap();
+        assert_eq!(rows.len(), 1, "revocation scan sees the transit row");
+        let rev = &rows[0];
+        assert_eq!(rev.tier, attestation_tier::LOCAL);
+        assert!(rev.promoted_at.is_none());
+        assert!(
+            !rev.scrub_signature_classical.is_empty() && rev.scrub_signature_pqc.is_some(),
+            "transit row carries a real bound-hybrid signature"
+        );
+        let revoked_at = rev.asserted_at;
 
         let window = Duration::from_secs(86_400); // 24 h
 
-        // The local-tier transit row is visible to the revocation scan.
-        assert_eq!(
-            backend.list_consent_revocations(None).await.unwrap().len(),
-            1,
-            "list_consent_revocations includes the local-tier transit row"
-        );
-
-        // Just BEFORE the boundary (24 h − 1 s) → in flight, NOT overdue.
+        // Just BEFORE the boundary → in flight, NOT overdue.
         let before = revoked_at + chrono::Duration::seconds(86_400 - 1);
         let r = backend.run_consent_sla_watch(before, window).await.unwrap();
         assert_eq!(r.revocations_scanned, 1);
@@ -8986,7 +9096,7 @@ mod tests {
             .unwrap()
             .is_empty());
 
-        // Just AFTER the boundary (24 h + 1 s) → overdue fires.
+        // Just AFTER the boundary → overdue fires.
         let after = revoked_at + chrono::Duration::seconds(86_400 + 1);
         let r = backend.run_consent_sla_watch(after, window).await.unwrap();
         assert_eq!(r.promotion_overdue, 1, "past the window: overdue fires");
@@ -9019,7 +9129,7 @@ mod tests {
         {
             let mut st = backend.state.lock().unwrap();
             for a in st.federation_attestations.iter_mut() {
-                if a.attestation_id == "rev-c" {
+                if a.attestation_id == att_id {
                     a.tier = attestation_tier::FEDERATION.into();
                     a.promoted_at = Some(after);
                 }
@@ -9032,6 +9142,57 @@ mod tests {
         assert_eq!(
             r.promotion_overdue, 0,
             "a promoted revocation is no longer overdue"
+        );
+
+        // A crypto-INVALID revocation is REJECTED at admission (never transits).
+        let bad = backend
+            .attestation_insert_local(LocalAttestationInput {
+                attesting_key_id: "subject-c".into(),
+                attested_key_id: Some("target-c".into()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: serde_json::json!({
+                    "id": "rev-bad", "dimension": "consent:state:revoked:v1",
+                    "score": 1.0, "confidence": 0.9,
+                }),
+                subject_key_ids: vec!["subject-c".into()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some("AAAA".into()), // not a valid sig
+                scrub_signature_pqc: Some("AAAA".into()),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                bad,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "crypto-invalid revocation rejected at admission, got {bad:?}"
+        );
+
+        // An UNSIGNED revocation (no signature material) is likewise rejected.
+        let unsigned = backend
+            .attestation_insert_local(LocalAttestationInput {
+                attesting_key_id: "subject-c".into(),
+                attested_key_id: Some("target-c".into()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: serde_json::json!({
+                    "id": "rev-unsigned", "dimension": "consent:state:revoked:v1",
+                    "score": 1.0, "confidence": 0.9,
+                }),
+                subject_key_ids: vec!["subject-c".into()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: None,
+                scrub_signature_pqc: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(unsigned, crate::federation::Error::InvalidArgument(ref m) if m.contains("bound-hybrid signature")),
+            "unsigned revocation rejected at admission, got {unsigned:?}"
         );
     }
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -10330,6 +10330,156 @@ mod tests {
             .expect("a node target is governed by the node-agency gate, not the user-target gate");
     }
 
+    // ── v12.7.0 (CIRISPersist#368, CC 3.4.11 / CC 3.4.13) ────────────────
+    //    Witness-targets-subject age_assurance admission decision table.
+
+    /// CC 3.4.11 witness-targets-subject decision table, through the REAL
+    /// `put_attestation` admission path:
+    ///
+    /// - a witness emitting `age_assurance:*` ABOUT a DIFFERENT subject is
+    ///   ADMITTED and graduates THAT subject's band (witness outranks the
+    ///   subject's own self-declared rung);
+    /// - a witness emitting `age_assurance:*` about ITSELF (attester ==
+    ///   attested) is REJECTED — "a subject MUST NOT emit on
+    ///   `age_assurance:`" — so nobody self-mints their own graduation;
+    /// - a non-witness cross-subject emitter is still REJECTED by the
+    ///   unchanged identity gate (reserved-prefix emitter mismatch).
+    #[tokio::test]
+    async fn age_assurance_witness_targets_subject_decision_table() {
+        use crate::federation::age::{age_band, age_band_fine, AgeBand, AgeBandFine};
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "wts-witness", "witness").await;
+        put_typed_key(&backend, "wts-T", "user").await; // the subject
+        put_typed_key(&backend, "wts-P", "user").await; // plain (non-witness) user
+
+        // Baseline: T self-declares MINOR (the non-reserved self rung still
+        // admits attester==attested — it is subject-signed by design).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "wts-self-minor",
+                    "wts-T",
+                    "wts-T",
+                    "age_self_declared:minor:v1",
+                ),
+            })
+            .await
+            .expect("subject-signed self rung admits");
+        assert_eq!(age_band(&backend, "wts-T").await.unwrap(), AgeBand::Minor);
+
+        // CROSS-SUBJECT witness graduation: W attests T adult — ADMITTED, and
+        // T's band graduates (witness outranks T's own self-declared minor).
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "wts-w-adult",
+                    "wts-witness",
+                    "wts-T",
+                    "age_assurance:government:adult:v1",
+                ),
+            })
+            .await
+            .expect("witness-targets-subject age_assurance is admitted (CC 3.4.13)");
+        assert_eq!(
+            age_band(&backend, "wts-T").await.unwrap(),
+            AgeBand::Adult,
+            "a witness row ABOUT T graduates T's band",
+        );
+        assert_eq!(
+            age_band_fine(&backend, "wts-T").await.unwrap(),
+            AgeBandFine::Adult,
+            "the finer resolution graduates too",
+        );
+
+        // SELF-graduation via the witness prefix: W attests W — REJECTED
+        // (attester == attested; CC 3.4.11 "a subject MUST NOT emit on
+        // `age_assurance:`"). The witness identity_type does NOT bypass.
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "wts-w-self",
+                    "wts-witness",
+                    "wts-witness",
+                    "age_assurance:provider:adult:v1",
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_age_assurance_self_emission_rejected");
+        assert_eq!(
+            age_band(&backend, "wts-witness").await.unwrap(),
+            AgeBand::Unknown,
+            "the rejected self-emission confers nothing",
+        );
+
+        // Identity gate UNCHANGED: a plain user cross-attesting T's age is
+        // still refused (reserved prefix requires a witness emitter).
+        let e = backend
+            .put_attestation(SignedAttestation {
+                attestation: fix_age_attestation(
+                    "wts-p-cross",
+                    "wts-P",
+                    "wts-T",
+                    "age_assurance:provider:minor:v1",
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(e.kind(), "federation_reserved_prefix_emitter_mismatch");
+    }
+
+    /// #368 read-side defense-in-depth: a self-emitted `age_assurance:*` row
+    /// that PRE-DATES the admission gate (or arrived via replication before
+    /// v12.7.0) must not graduate its own emitter either. Injected directly
+    /// into backend state (bypassing `put_attestation`) to simulate the
+    /// legacy row; `age_band` / `age_band_fine` skip it.
+    #[tokio::test]
+    async fn age_band_ignores_pre_gate_self_emitted_witness_row() {
+        use crate::federation::age::{age_band, age_band_fine, AgeBand, AgeBandFine};
+        let backend = MemoryBackend::new();
+        put_typed_key(&backend, "pg-witness", "witness").await;
+        put_typed_key(&backend, "pg-T", "user").await;
+
+        // Bypass the gate: push a self-emitted witness-adult row directly.
+        let legacy = fix_age_attestation(
+            "pg-self-adult",
+            "pg-witness",
+            "pg-witness",
+            "age_assurance:government:adult:v1",
+        );
+        backend
+            .state
+            .lock()
+            .expect("memory backend lock")
+            .federation_attestations
+            .push(legacy);
+
+        assert_eq!(
+            age_band(&backend, "pg-witness").await.unwrap(),
+            AgeBand::Unknown,
+            "a pre-gate self-emitted witness row is skipped at read time",
+        );
+        assert_eq!(
+            age_band_fine(&backend, "pg-witness").await.unwrap(),
+            AgeBandFine::Unknown,
+        );
+
+        // Control: the SAME token about a DIFFERENT subject resolves.
+        let cross = fix_age_attestation(
+            "pg-cross-adult",
+            "pg-witness",
+            "pg-T",
+            "age_assurance:government:adult:v1",
+        );
+        backend
+            .state
+            .lock()
+            .expect("memory backend lock")
+            .federation_attestations
+            .push(cross);
+        assert_eq!(age_band(&backend, "pg-T").await.unwrap(), AgeBand::Adult);
+    }
+
     // ── CIRISPersist#309 (CC 3.4.12) — adult-incapacity steward-binding ──
 
     /// Build an adult-incapacity `delegates_to(steward -> ward)` carrying the

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -161,6 +161,11 @@ struct State {
     /// strictly-higher revision (§Q B3 anti-rollback).
     installed_storage_budgets:
         HashMap<String, crate::fountain::storage_contention::InstalledStorageBudget>,
+    /// #227 (residual) — the admission wall-clock per `(content_id,
+    /// corpus_kind)`, the decay reference instant for the consent-decay
+    /// clock. Parity with the pg/sqlite `content_manifest.admitted_at`
+    /// column (which memory's `FountainHeldMeta` view stubs to empty).
+    fountain_admitted_at: HashMap<(String, String), chrono::DateTime<chrono::Utc>>,
     /// v8.2.0 (CEG 1.0-RC11 §19.1 / CIRISPersist#228) — WholenessWitness
     /// corpus, keyed by `peer_id`, inner vec the last-K verified witnesses
     /// (newest last). Parity with the postgres/sqlite
@@ -242,6 +247,7 @@ impl Default for MemoryBackend {
                 fountain_manifests: HashMap::new(),
                 fountain_symbols: HashMap::new(),
                 installed_storage_budgets: HashMap::new(),
+                fountain_admitted_at: HashMap::new(),
                 wholeness_witnesses: HashMap::new(),
                 content_aggregations: HashMap::new(),
                 federation_scope_blobs: HashMap::new(),
@@ -932,8 +938,14 @@ impl Backend for MemoryBackend {
         // manifest, mirroring ON CONFLICT DO NOTHING).
         state
             .fountain_manifests
-            .entry(key)
+            .entry(key.clone())
             .or_insert_with(|| manifest.clone());
+        // Record the admission instant once (the consent-decay clock's
+        // reference); idempotent re-admit keeps the first.
+        state
+            .fountain_admitted_at
+            .entry(key)
+            .or_insert_with(chrono::Utc::now);
         // Symbols: upsert by symbol_id (idempotent).
         let bucket = state
             .fountain_symbols
@@ -1109,6 +1121,31 @@ impl Backend for MemoryBackend {
         Ok(out)
     }
 
+    // #227 (residual) — consent-decay clock enumerator (disk-independent).
+    async fn list_fountain_decay_candidates(
+        &self,
+    ) -> Result<Vec<crate::fountain::FountainDecayCandidate>, Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let out = state
+            .fountain_manifests
+            .iter()
+            .map(|((content_id, corpus_kind), m)| {
+                let admitted_at = state
+                    .fountain_admitted_at
+                    .get(&(content_id.clone(), corpus_kind.clone()))
+                    .copied()
+                    .unwrap_or_else(chrono::Utc::now);
+                crate::fountain::FountainDecayCandidate {
+                    content_id: content_id.clone(),
+                    corpus_kind: corpus_kind.clone(),
+                    envelope: m.envelope.clone(),
+                    admitted_at,
+                }
+            })
+            .collect();
+        Ok(out)
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(
@@ -1137,8 +1174,12 @@ impl Backend for MemoryBackend {
         let key = (manifest.content_id.clone(), manifest.corpus_kind.clone());
         state
             .fountain_manifests
-            .entry(key)
+            .entry(key.clone())
             .or_insert_with(|| manifest.clone());
+        state
+            .fountain_admitted_at
+            .entry(key)
+            .or_insert_with(chrono::Utc::now);
         let bucket = state
             .fountain_symbols
             .entry(manifest.content_id.clone())

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1311,6 +1311,12 @@ impl crate::federation::FederationDirectory for MemoryBackend {
             .as_deref()
             .and_then(crate::federation::types::consent_role::wire_from_stored)
             .map(str::to_owned);
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — accord-conferred `canonical`
+        // gate. Runs BEFORE the state lock (it calls lookup_public_key on self,
+        // which acquires the lock itself) and BEFORE persist — a self-signed /
+        // non-anchor-scrubbed `canonical` claim leaves no trace. Backend-
+        // symmetric with SQLite + Postgres.
+        crate::federation::admission::check_canonical_role_admission(self, &row).await?;
         // Server-computed hash (excludes the field itself).
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let mut state = self.state.lock().expect("memory backend lock");

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -155,6 +155,12 @@ struct State {
     /// pressure/decay evict (by `retention_priority DESC`). Parity with
     /// the postgres/sqlite `content_symbols` table (V084).
     fountain_symbols: HashMap<String, HashMap<u32, crate::fountain::FountainSymbolV1>>,
+    /// v12.7.0 (§Q / CIRISPersist#370) — installed `StorageBudgetV1` pin
+    /// state, keyed by owner `node_id`. Parity with the postgres/sqlite
+    /// `storage_budget_installed` table (V093). Replaced only by a
+    /// strictly-higher revision (§Q B3 anti-rollback).
+    installed_storage_budgets:
+        HashMap<String, crate::fountain::storage_contention::InstalledStorageBudget>,
     /// v8.2.0 (CEG 1.0-RC11 §19.1 / CIRISPersist#228) — WholenessWitness
     /// corpus, keyed by `peer_id`, inner vec the last-K verified witnesses
     /// (newest last). Parity with the postgres/sqlite
@@ -235,6 +241,7 @@ impl Default for MemoryBackend {
                 federation_hard_case_events: HashMap::new(),
                 fountain_manifests: HashMap::new(),
                 fountain_symbols: HashMap::new(),
+                installed_storage_budgets: HashMap::new(),
                 wholeness_witnesses: HashMap::new(),
                 content_aggregations: HashMap::new(),
                 federation_scope_blobs: HashMap::new(),
@@ -1061,6 +1068,44 @@ impl Backend for MemoryBackend {
             })
             .collect();
         out.sort_by(|a, b| b.content_id.cmp(&a.content_id));
+        Ok(out)
+    }
+
+    // ─── v12.7.0 — §Q pin-INSTALL surface (CIRISPersist#370) ─────────
+
+    async fn put_installed_storage_budget(
+        &self,
+        budget: &crate::fountain::storage_contention::InstalledStorageBudget,
+    ) -> Result<bool, Error> {
+        let mut state = self.state.lock().expect("memory backend lock");
+        // §Q B3 anti-rollback under the same lock the map lives behind —
+        // replace only on a STRICTLY higher revision (parity with the
+        // SQL dialects' conditional upsert).
+        match state.installed_storage_budgets.get(&budget.node_id) {
+            Some(existing) if existing.revision >= budget.revision => Ok(false),
+            _ => {
+                state
+                    .installed_storage_budgets
+                    .insert(budget.node_id.clone(), budget.clone());
+                Ok(true)
+            }
+        }
+    }
+
+    async fn get_installed_storage_budget(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        Ok(state.installed_storage_budgets.get(node_id).cloned())
+    }
+
+    async fn list_installed_storage_budgets(
+        &self,
+    ) -> Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let state = self.state.lock().expect("memory backend lock");
+        let mut out: Vec<_> = state.installed_storage_budgets.values().cloned().collect();
+        out.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         Ok(out)
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -88,6 +88,17 @@ pub enum Error {
     #[error("aggregation meta rejected: {0}")]
     AggregationMetaRejected(#[from] crate::fountain::AggregationMetaError),
 
+    /// v12.7.0 (§Q / CIRISPersist#370) — a `StorageBudgetV1` pin-install was
+    /// refused: the bound-hybrid signature did not verify (PQC-mandatory —
+    /// verify at the gate, before persistence), the shape was structurally
+    /// invalid, or the candidate `revision` did not supersede the installed
+    /// one (§Q B3 anti-rollback). Carries the
+    /// [`crate::fountain::storage_contention::StorageContentionError`] (its
+    /// `kind()` is preserved via [`Error::kind`]). Verify-before-mutation:
+    /// NOTHING was written.
+    #[error("storage budget install rejected: {0}")]
+    StorageContention(#[from] crate::fountain::storage_contention::StorageContentionError),
+
     /// Migration phase error. v0.1.5: the `sqlstate` is extracted from
     /// the underlying tokio-postgres error chain when available so
     /// lens-side callers can distinguish 40P01 (deadlock detected),
@@ -127,6 +138,7 @@ impl Error {
             Error::FountainAdmit(e) => e.kind(),
             Error::FountainIntegrity(_) => "fountain_integrity",
             Error::AggregationMetaRejected(e) => e.kind(),
+            Error::StorageContention(e) => e.kind(),
         }
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1686,6 +1686,85 @@ impl Backend for PostgresBackend {
         Ok(out)
     }
 
+    // ─── v12.7.0 — §Q pin-INSTALL surface (CIRISPersist#370) ─────────
+
+    async fn put_installed_storage_budget(
+        &self,
+        budget: &crate::fountain::storage_contention::InstalledStorageBudget,
+    ) -> Result<bool, Error> {
+        let revision = i64::try_from(budget.revision)
+            .map_err(|_| Error::Backend("storage budget revision exceeds i64".into()))?;
+        let scopes = serde_json::to_value(&budget.scopes)
+            .map_err(|e| Error::Backend(format!("serialize budget scopes: {e}")))?;
+        let pinned_class = serde_json::to_value(&budget.pinned_class)
+            .map_err(|e| Error::Backend(format!("serialize budget pinned_class: {e}")))?;
+        let wire: serde_json::Value = serde_json::from_str(&budget.wire_json)
+            .map_err(|e| Error::Backend(format!("parse budget wire json: {e}")))?;
+        let client = self.get_client().await?;
+        // §Q B3 anti-rollback, ATOMIC at the row: the DO UPDATE only fires
+        // when the incoming revision is STRICTLY higher; rows_affected == 0
+        // ⇒ refused (the Engine surfaces RevisionRollback).
+        let n = client
+            .execute(
+                "INSERT INTO cirislens.storage_budget_installed (\
+                     node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at\
+                 ) VALUES ($1,$2,$3,$4,$5,$6,$7) \
+                 ON CONFLICT (node_id) DO UPDATE SET \
+                     revision = EXCLUDED.revision, \
+                     epoch_id = EXCLUDED.epoch_id, \
+                     scopes = EXCLUDED.scopes, \
+                     pinned_class = EXCLUDED.pinned_class, \
+                     wire = EXCLUDED.wire, \
+                     installed_at = EXCLUDED.installed_at \
+                 WHERE storage_budget_installed.revision < EXCLUDED.revision",
+                &[
+                    &budget.node_id,
+                    &revision,
+                    &budget.epoch_id,
+                    &scopes,
+                    &pinned_class,
+                    &wire,
+                    &budget.installed_at,
+                ],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("put_installed_storage_budget: {e}")))?;
+        Ok(n > 0)
+    }
+
+    async fn get_installed_storage_budget(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let client = self.get_client().await?;
+        let row = client
+            .query_opt(
+                "SELECT node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at \
+                 FROM cirislens.storage_budget_installed WHERE node_id = $1",
+                &[&node_id],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("get_installed_storage_budget: {e}")))?;
+        row.map(pg_row_to_installed_storage_budget).transpose()
+    }
+
+    async fn list_installed_storage_budgets(
+        &self,
+    ) -> Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let client = self.get_client().await?;
+        let rows = client
+            .query(
+                "SELECT node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at \
+                 FROM cirislens.storage_budget_installed ORDER BY node_id ASC",
+                &[],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("list_installed_storage_budgets: {e}")))?;
+        rows.into_iter()
+            .map(pg_row_to_installed_storage_budget)
+            .collect()
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(
@@ -1850,6 +1929,33 @@ impl Backend for PostgresBackend {
             .map_err(|e| Error::Backend(format!("list content_aggregation: {e}")))?;
         rows.iter().map(Self::aggregation_record_from_row).collect()
     }
+}
+
+/// #370 — decode one `storage_budget_installed` row. The `wire` JSONB is
+/// re-serialized to the `wire_json` string (round-trips losslessly — JSONB
+/// key order is not signed material; the signatures verify over the CC
+/// 6.1.3 binary preimage rebuilt from the FIELDS, not over the JSON text).
+fn pg_row_to_installed_storage_budget(
+    row: tokio_postgres::Row,
+) -> Result<crate::fountain::storage_contention::InstalledStorageBudget, Error> {
+    let revision: i64 = row.safe_get_with("revision", Error::Backend)?;
+    let scopes: serde_json::Value = row.safe_get_with("scopes", Error::Backend)?;
+    let pinned_class: serde_json::Value = row.safe_get_with("pinned_class", Error::Backend)?;
+    let wire: serde_json::Value = row.safe_get_with("wire", Error::Backend)?;
+    Ok(
+        crate::fountain::storage_contention::InstalledStorageBudget {
+            node_id: row.safe_get_with("node_id", Error::Backend)?,
+            revision: u64::try_from(revision)
+                .map_err(|_| Error::Backend("installed budget revision negative".into()))?,
+            epoch_id: row.safe_get_with("epoch_id", Error::Backend)?,
+            scopes: serde_json::from_value(scopes)
+                .map_err(|e| Error::Backend(format!("decode budget scopes: {e}")))?,
+            pinned_class: serde_json::from_value(pinned_class)
+                .map_err(|e| Error::Backend(format!("decode budget pinned_class: {e}")))?,
+            wire_json: wire.to_string(),
+            installed_at: row.safe_get_with("installed_at", Error::Backend)?,
+        },
+    )
 }
 
 // ─── Pipeline read surface (v0.6.0-α5, CIRISPersist#19) ───────────
@@ -9054,7 +9160,7 @@ impl PostgresBackend {
             .map_err(|e| crate::federation::BlobError::Backend(format!("pool get: {e}")))?;
         let rows = client
             .query(
-                "SELECT sha256, size_bytes, access_count, last_accessed_at \
+                "SELECT sha256, size_bytes, access_count, last_accessed_at, media_type \
                  FROM cirislens.federation_blobs \
                  ORDER BY \
                    (access_count + 1)::float8 * \
@@ -9084,6 +9190,8 @@ impl PostgresBackend {
                 row.safe_get_with("access_count", crate::federation::BlobError::Backend)?;
             let last_accessed_at: chrono::DateTime<chrono::Utc> =
                 row.safe_get_with("last_accessed_at", crate::federation::BlobError::Backend)?;
+            let media_type: Option<String> =
+                row.safe_get_with("media_type", crate::federation::BlobError::Backend)?;
             out.push(crate::federation::EvictionCandidate {
                 sha256: sha,
                 size_bytes: size_bytes.max(0) as u64,
@@ -9093,9 +9201,43 @@ impl PostgresBackend {
                 // the signer's holds_bytes index (no attesting_key_id
                 // column on federation_blobs).
                 attesting_key_id: None,
+                // v12.7.0 (§Q B5, #370): the corpus-class token the
+                // Engine matches against the installed pinned_class set.
+                media_type,
             });
         }
         Ok(out)
+    }
+
+    /// v12.7.0 (§Q B5 / CIRISPersist#370) — total bytes currently held by
+    /// blobs whose `media_type` is one of `media_types` (the installed
+    /// `pinned_class` set). This is the §Q "consumption accounting is
+    /// edge-internal — recomputed from held content" number the sweep uses
+    /// to hold the `pin_reserve_bytes` floor; it is NEVER taken from the
+    /// wire. Empty set ⇒ 0.
+    pub async fn pinned_blob_bytes(
+        &self,
+        media_types: &[String],
+    ) -> Result<u64, crate::federation::BlobError> {
+        if media_types.is_empty() {
+            return Ok(0);
+        }
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::BlobError::Backend(format!("pool get: {e}")))?;
+        let row = client
+            .query_one(
+                "SELECT COALESCE(SUM(size_bytes), 0)::BIGINT AS total \
+                 FROM cirislens.federation_blobs WHERE media_type = ANY($1)",
+                &[&media_types],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::BlobError::Backend(format!("pinned_blob_bytes query: {e}"))
+            })?;
+        let total: i64 = row.safe_get_with("total", crate::federation::BlobError::Backend)?;
+        Ok(total.max(0) as u64)
     }
 
     /// v3.4.0 (CIRISPersist#123) — delete one `federation_blobs` row

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2352,6 +2352,13 @@ impl PostgresBackend {
                 row.algorithm
             )));
         }
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — adopt_scrub_upgrade is a
+        // self-signed → anchor-scrubbed UPDATE that CAN change identity_type,
+        // so it is a second path a `canonical` role could otherwise enter on.
+        // Re-run the accord-conferred gate: `canonical` is admitted here only
+        // if THIS incoming (anchor-scrubbed) record earned it via a real
+        // accord-holder scrubber. Backend-symmetric with SQLite.
+        crate::federation::admission::check_canonical_role_admission(self, &row).await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 
         let existing = crate::federation::FederationDirectory::lookup_public_key(self, &row.key_id)
@@ -2487,6 +2494,54 @@ impl PostgresBackend {
             },
         }
     }
+
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — enumerate the **canonical /
+    /// founding bootstrap servers**: `federation_keys` rows whose
+    /// `identity_type` **set** contains
+    /// [`crate::federation::types::identity_type::CANONICAL`], stable-sorted by
+    /// `key_id`. Every such row is (by the admission gate
+    /// [`crate::federation::admission::check_canonical_role_admission`])
+    /// necessarily anchor-scrub-conferred — the role cannot be self-claimed.
+    /// Inherent on the backend (dispatched by `Engine::list_canonical_servers`)
+    /// to avoid `FederationDirectory`/capsule bloat, mirroring
+    /// [`Self::adopt_scrub_upgrade`]. The SQL `LIKE` is a coarse prefilter; the
+    /// exact set-membership check is applied in Rust via `set_contains`.
+    pub async fn list_canonical_servers(
+        &self,
+    ) -> Result<Vec<crate::federation::KeyRecord>, crate::federation::Error> {
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT key_id, pubkey_ed25519_base64, pubkey_ml_dsa_65_base64, algorithm, \
+                    identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
+                    original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                    scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
+                    attestation_evidence \
+                 FROM cirislens.federation_keys WHERE identity_type LIKE '%canonical%' \
+                 ORDER BY key_id",
+                &[],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("list_canonical_servers: {e}"))
+            })?;
+        let recs: Vec<crate::federation::KeyRecord> = rows
+            .into_iter()
+            .map(pg_row_to_key_record)
+            .collect::<Result<_, _>>()?;
+        Ok(recs
+            .into_iter()
+            .filter(|r| {
+                crate::federation::types::identity_type::set_contains(
+                    &r.identity_type,
+                    crate::federation::types::identity_type::CANONICAL,
+                )
+            })
+            .collect())
+    }
 }
 
 #[async_trait::async_trait]
@@ -2517,6 +2572,16 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 chrono::Utc::now(),
             )?;
         }
+
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — the `canonical` (founding
+        // bootstrap server) role is accord-CONFERRED, never self-claimed: a row
+        // may carry `canonical` only when anchor-scrub-signed (scrub_key_id !=
+        // key_id AND the scrubber's ed25519 ∈ the pinned HUMANITY_ACCORD
+        // anchor). This is the substrate write chokepoint every registration
+        // path funnels through, so a self-signed / non-anchor-scrubbed
+        // `canonical` claim is refused here before any INSERT
+        // (verify-before-mutation). Backend-symmetric with SQLite + memory.
+        crate::federation::admission::check_canonical_role_admission(self, &row).await?;
 
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2293,6 +2293,49 @@ impl PostgresBackend {
         }
         Ok(AdoptScrubOutcome::Upgraded)
     }
+
+    /// v12.7.0 (CIRISPersist#371) — **upgrade-aware replicated Key-plane
+    /// apply** — Postgres twin of
+    /// [`SqliteBackend::apply_replicated_key_record`](crate::store::sqlite::SqliteBackend::apply_replicated_key_record).
+    /// All policy lives in the shared, backend-agnostic
+    /// [`plan_replicated_key_apply`](crate::federation::register::plan_replicated_key_apply)
+    /// (fresh insert via `put_public_key` with every direct-registration
+    /// gate intact; self-signed → anchor-scrubbed upgrade via
+    /// [`adopt_scrub_upgrade`](Self::adopt_scrub_upgrade) only after the
+    /// `verify_key_registration` Strict scrub gate + the v12.6.0 `owner_of`
+    /// single-owner gate pass; everything else `Unchanged` / `Refused`),
+    /// so the two backends cannot drift. A store-step `Conflict` (a row
+    /// that changed between plan and act) resolves to `Refused` —
+    /// fail-closed + re-offerable on the anti-entropy plane, never fatal.
+    pub async fn apply_replicated_key_record(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, crate::federation::Error> {
+        use crate::federation::register::{
+            plan_replicated_key_apply, AdoptScrubOutcome, ReplicatedKeyOutcome, ReplicatedKeyPlan,
+        };
+        match plan_replicated_key_apply(self, &record.record).await? {
+            ReplicatedKeyPlan::Unchanged => Ok(ReplicatedKeyOutcome::Unchanged),
+            ReplicatedKeyPlan::Refused => Ok(ReplicatedKeyOutcome::Refused),
+            ReplicatedKeyPlan::Insert => {
+                match crate::federation::FederationDirectory::put_public_key(self, record).await {
+                    Ok(()) => Ok(ReplicatedKeyOutcome::Inserted),
+                    // A row appeared between plan and act with different
+                    // content — first-seen wins on the replication plane.
+                    Err(crate::federation::Error::Conflict(_)) => Ok(ReplicatedKeyOutcome::Refused),
+                    Err(e) => Err(e),
+                }
+            }
+            ReplicatedKeyPlan::Upgrade => match self.adopt_scrub_upgrade(record).await {
+                Ok(AdoptScrubOutcome::Upgraded) => Ok(ReplicatedKeyOutcome::Upgraded),
+                Ok(AdoptScrubOutcome::AlreadyAdopted) => Ok(ReplicatedKeyOutcome::Unchanged),
+                // The atomic WHERE (or its Rust pre-checks) saw different
+                // state than the plan — a concurrent mutation. Fail-closed.
+                Err(crate::federation::Error::Conflict(_)) => Ok(ReplicatedKeyOutcome::Refused),
+                Err(e) => Err(e),
+            },
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -29633,5 +29676,118 @@ mod tests {
             .map(|a| a.attesting_key_id.as_str())
             .collect();
         assert!(granters.contains(dt_g1.as_str()) && granters.contains(dt_g2.as_str()));
+    }
+
+    /// v12.7.0 (#371) — postgres twin of
+    /// `store::sqlite::tests::apply_replicated_key_record_ambiguous_owner_refused_sqlite`:
+    /// a node carrying TWO live owner-bindings (the second a PRE-GATE
+    /// anomaly, raw-SQL-inserted past the v12.6.0 single-owner admission
+    /// gate) resolves `AmbiguousNodeOwner`, so a replicated anchor-scrubbed
+    /// record for it is Refused (fail-closed) and the self-signed row is
+    /// untouched. The rest of the #371 decision table runs Engine-level on
+    /// both backends in `federation::register::tests`.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn apply_replicated_key_record_ambiguous_owner_refused_postgres() {
+        use crate::federation::register::ReplicatedKeyOutcome;
+        use crate::federation::tier_ingest::test_support as ts;
+        use crate::federation::types::identity_type;
+        use crate::federation::FederationDirectory as _;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.expect("connect");
+        backend.run_migrations().await.expect("migrations run");
+
+        // Run-scoped unique ids (shared test DB).
+        let tag = uuid::Uuid::new_v4().simple().to_string();
+        let anchor = format!("apply-amb-anchor-{tag}");
+        let owner1 = format!("apply-amb-owner1-{tag}");
+        let owner2 = format!("apply-amb-owner2-{tag}");
+        let node = format!("apply-amb-node-{tag}");
+
+        ts::register_hybrid_key(&backend, &anchor).await;
+        ts::register_identity_key(&backend, &owner1, identity_type::USER).await;
+        ts::register_identity_key(&backend, &owner2, identity_type::USER).await;
+        // The node's self-signed boot row.
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: ts::replicated_key_record(&node, identity_type::NODE, &node, &node, "v1"),
+            })
+            .await
+            .unwrap();
+
+        // owner1 binds through the admission gate…
+        backend
+            .put_attestation(crate::federation::SignedAttestation {
+                attestation: ts::owner_binding_attestation(
+                    &uuid::Uuid::new_v4().to_string(),
+                    &owner1,
+                    &node,
+                ),
+            })
+            .await
+            .unwrap();
+        // …owner2's binding is the PRE-GATE anomaly, inserted via raw SQL
+        // (bypassing check_single_node_owner_admission, exactly the state a
+        // pre-v12.6.0 corpus can hold).
+        {
+            let anomaly =
+                ts::owner_binding_attestation(&uuid::Uuid::new_v4().to_string(), &owner2, &node);
+            let anomaly_uuid = uuid::Uuid::parse_str(&anomaly.attestation_id).unwrap();
+            let ts_stamp: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+            let hash_bytes: Vec<u8> = vec![0u8];
+            let client = backend.get_client().await.expect("client");
+            client
+                .execute(
+                    "INSERT INTO cirislens.federation_attestations (\
+                        attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                        asserted_at, attestation_envelope, original_content_hash, \
+                        scrub_signature_classical, scrub_key_id, scrub_timestamp, \
+                        persist_row_hash\
+                     ) VALUES ($1, $2, $3, 'delegates_to', $4, $5, $6, 'c2ln', $2, $4, '0')",
+                    &[
+                        &anomaly_uuid,
+                        &owner2,
+                        &node,
+                        &ts_stamp,
+                        &anomaly.attestation_envelope,
+                        &hash_bytes,
+                    ],
+                )
+                .await
+                .expect("raw anomaly insert");
+        }
+        // The anomaly is real: owner_of fails AmbiguousNodeOwner.
+        let err = crate::federation::admission::owner_of(&backend, &node)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::AmbiguousNodeOwner { .. }),
+            "expected AmbiguousNodeOwner, got {err:?}"
+        );
+
+        // A VERIFIABLE anchor-scrubbed record for the node ⇒ Refused
+        // (fail-closed), self-signed row untouched.
+        let scrubbed =
+            ts::replicated_key_record(&node, identity_type::NODE, &anchor, &anchor, "v1");
+        assert_eq!(
+            backend
+                .apply_replicated_key_record(crate::federation::SignedKeyRecord {
+                    record: scrubbed
+                })
+                .await
+                .unwrap(),
+            ReplicatedKeyOutcome::Refused
+        );
+        let row = crate::federation::FederationDirectory::lookup_public_key(&backend, &node)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.scrub_key_id, node,
+            "ambiguous-owner refusal must leave the self-signed row untouched"
+        );
     }
 }

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -150,6 +150,8 @@ impl PostgresBackend {
     /// - `postgres://user:pass@host:5432/dbname`
     /// - `host=db user=lens password=… dbname=cirislens`
     pub async fn connect(dsn: &str) -> Result<Self, Error> {
+        #[cfg(feature = "tls")]
+        ensure_rustls_provider();
         let pg_config: tokio_postgres::Config = dsn
             .parse()
             .map_err(|e: tokio_postgres::Error| Error::Backend(format!("dsn parse: {e}")))?;
@@ -522,6 +524,7 @@ impl PostgresBackend {
     async fn dedicated_connect(&self) -> Result<tokio_postgres::Client, Error> {
         use rustls::ClientConfig;
         use tokio_postgres_rustls::MakeRustlsConnect;
+        ensure_rustls_provider();
         let mut roots = rustls::RootCertStore::empty();
         let cert_result = rustls_native_certs::load_native_certs();
         for cert in cert_result.certs {
@@ -553,6 +556,23 @@ impl PostgresBackend {
         });
         Ok(client)
     }
+}
+
+/// AV-18 `tls` feature — idempotently install the process-level rustls
+/// [`CryptoProvider`](rustls::crypto::CryptoProvider) before building a
+/// `ClientConfig`. The dependency graph compiles BOTH providers — `ring`
+/// (via the verify/reqwest stack) and `aws-lc-rs` (rustls' own default) —
+/// so rustls 0.23 cannot infer a process default and
+/// `ClientConfig::builder()` PANICS unless one was installed. We install
+/// `aws-lc-rs` (rustls' preferred provider; with `prefer-post-quantum` in
+/// the graph it negotiates the X25519MLKEM768 hybrid, matching the
+/// federation's PQC posture). `Err(_)` from `install_default` means a
+/// provider is already installed — ours from an earlier connect, or the
+/// host application's — and first-install-wins is exactly the rustls
+/// contract, so it is deliberately ignored.
+#[cfg(feature = "tls")]
+fn ensure_rustls_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
 /// Walk the std::error::Error source chain; if a tokio-postgres
@@ -2795,11 +2815,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         // attesting key's identity_type. Backend-symmetric with SQLite + memory.
         crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
 
-        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
-        // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
-        // keyed on a community (`community_id`) is refused if C has lost its
-        // last live `moderate`-holder. No-op for local-tier rows, no
-        // community_id, or an unknown community. Backend-symmetric.
+        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11; keying broadened by
+        // #369) — no-moderator-no-federate FEDERATION-APPLY re-check (point
+        // ii). A federation-tier row keyed on a community under ANY substrate
+        // shape (envelope `community_id`/`community_key_id`/`cohort_key_id`,
+        // a row endpoint or subject_key_ids entry resolving as a stored
+        // community) is refused if C has lost its last live
+        // `moderate`-holder. No-op for local-tier rows, rows referencing no
+        // known community. Backend-symmetric.
         crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
 
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
@@ -21565,6 +21588,158 @@ mod tests {
         });
         pg_resign(&mut a); // envelope changed → re-sign (CC 5.3.2.4.3.1)
         a
+    }
+
+    /// #369 (CC 4.5.4 / §11.11) — no-moderator federation-APPLY gate,
+    /// broadened keying, END-TO-END through `put_attestation` (PG backend;
+    /// 3-backend parity with memory's decision table + the sqlite twin). A
+    /// federation-tier row attested TO a stored moderator-less community
+    /// (the membership shape — NO `community_id` envelope field) is refused
+    /// fail-secure; the same shape onto a moderatored community lands;
+    /// storage-only community ops stay untouched. Run-scoped uuid-suffixed
+    /// key ids (shared test DB).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_no_moderator_federate_apply_broadened_keying() {
+        use crate::federation::admission::MEMBER_ROLE_FOUNDER;
+        use crate::federation::FederationDirectory;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let now = chrono::Utc::now();
+        let suffix = uuid_like();
+        let founder_user = format!("nm-user-{suffix}");
+        let founder_prim = format!("nm-prim-{suffix}");
+        let comm_ok = format!("nm-ok-{suffix}");
+        let comm_no = format!("nm-no-{suffix}");
+        for (kid, ity) in [
+            (&founder_user, crate::federation::types::identity_type::USER),
+            (
+                &founder_prim,
+                crate::federation::types::identity_type::PRIMITIVE,
+            ),
+            (&comm_ok, crate::federation::types::identity_type::PRIMITIVE),
+            (&comm_no, crate::federation::types::identity_type::PRIMITIVE),
+        ] {
+            let mut k = fix_section_i_key(kid, "nm", now, true);
+            k.identity_type = ity.into();
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord { record: k })
+                .await
+                .unwrap();
+        }
+        let put_comm = |cid: &str, founder: &str| crate::federation::SignedCommunity {
+            community: crate::federation::Community {
+                community_key_id: cid.to_owned(),
+                community_name: "nm-test".into(),
+                members: vec![crate::federation::CommunityMember {
+                    key_id: founder.to_owned(),
+                    joined_at: now,
+                    role: Some(MEMBER_ROLE_FOUNDER.into()),
+                }],
+                founded_at: now,
+                consensus_protocol: crate::federation::types::consensus_protocol::FOUNDER_ONLY
+                    .into(),
+                policy_blob: None,
+                persist_row_hash: String::new(),
+            },
+        };
+        // Storage-only put_community is NOT the federate gate — both records
+        // (moderatored AND moderator-less) store fine.
+        backend
+            .put_community(put_comm(&comm_ok, &founder_user))
+            .await
+            .unwrap();
+        backend
+            .put_community(put_comm(&comm_no, &founder_prim))
+            .await
+            .unwrap();
+
+        // (1) Membership shape onto the moderator-less community → REFUSED
+        //     fail-secure, nothing stored.
+        let err = backend
+            .put_attestation(crate::federation::SignedAttestation {
+                attestation: pg_scores_attestation(
+                    &founder_prim,
+                    &comm_no,
+                    &founder_prim,
+                    "identity_binding:v1",
+                ),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::federation::Error::CommunityHasNoModerator { .. }
+            ),
+            "federation apply keyed on a moderator-less community must refuse, got {err:?}"
+        );
+        assert_eq!(err.kind(), "federation_community_no_moderator");
+        assert!(backend
+            .list_attestations_for(&comm_no)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // (2) Same shape onto the MODERATORED community → ADMITTED + stored.
+        backend
+            .put_attestation(crate::federation::SignedAttestation {
+                attestation: pg_scores_attestation(
+                    &founder_user,
+                    &comm_ok,
+                    &founder_user,
+                    "identity_binding:v1",
+                ),
+            })
+            .await
+            .expect("moderatored community continues to federate");
+        assert_eq!(
+            backend.list_attestations_for(&comm_ok).await.unwrap().len(),
+            1
+        );
+
+        // (3) Storage-only membership op on the moderator-less community →
+        //     untouched (loss-processing / recovery must not be blocked).
+        backend
+            .put_community_membership_revocation(
+                crate::federation::SignedCommunityMembershipRevocation {
+                    community_membership_revocation:
+                        crate::federation::CommunityMembershipRevocation {
+                            community_key_id: comm_no.clone(),
+                            removed_identity_key_id: founder_prim.clone(),
+                            removed_at: now,
+                            effective_at: now,
+                            reason: None,
+                            witness_set: Vec::new(),
+                            persist_row_hash: String::new(),
+                        },
+                },
+            )
+            .await
+            .expect("membership revocation is storage, not a federation apply step");
+
+        // (4) The drivable verdict mirrors the apply decision.
+        let v = crate::federation::admission::no_moderator_federate_verdict(&backend, &comm_no)
+            .await
+            .unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "admitted": false, "community_known": true,
+                "reason": "federation_community_no_moderator"
+            })
+        );
+        let v = crate::federation::admission::no_moderator_federate_verdict(&backend, &comm_ok)
+            .await
+            .unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({ "admitted": true, "community_known": true })
+        );
     }
 
     /// v8.9.0 (CIRISPersist#236, CC 4.4.3.4.3 / CC 1.13.5) — reject-agency-

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -23165,10 +23165,16 @@ mod tests {
         let agent_k = format!("pg-good-agt-§102-{}", uuid_like());
         backend
             .put_public_key(crate::federation::SignedKeyRecord {
+                // CC 3.4.8 (CIRISPersist#366) — `detection:correlated_action:*`
+                // is detector-only. Exercise the SET-membership gate with a
+                // folded `{agent, lenscore_detector}` LensCore-fold key.
                 record: pg_admission_key(
                     &steward,
                     "registry",
-                    crate::federation::types::identity_type::STEWARD,
+                    &crate::federation::types::identity_type::join_set([
+                        crate::federation::types::identity_type::AGENT,
+                        crate::federation::types::identity_type::LENSCORE_DETECTOR,
+                    ]),
                 ),
             })
             .await
@@ -23194,6 +23200,114 @@ mod tests {
             .await
             .unwrap();
         let rows = backend.list_attestations_for(&agent_k).await.unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_put_attestation_rejects_detection_from_non_detector() {
+        // CC 3.4.8 (CIRISPersist#366) — a plain `agent` key (no
+        // `lenscore_detector` in its identity_type set) MUST be rejected on a
+        // `detection:correlated_action:*` primary emission.
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::FederationDirectory;
+        let agent = format!("pg-nondet-agt-§366-{}", uuid_like());
+        let subj = format!("pg-nondet-sub-§366-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &agent,
+                    "registry",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &subj,
+                    "primitive-nondet",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        let att = pg_scores_attestation(
+            &agent,
+            &subj,
+            &agent,
+            "detection:correlated_action:rights_asymmetry:v1",
+        );
+        let err = backend
+            .put_attestation(crate::federation::SignedAttestation { attestation: att })
+            .await
+            .unwrap_err();
+        match err {
+            crate::federation::Error::ReservedPrefixEmitterMismatch {
+                prefix, required, ..
+            } => {
+                assert_eq!(prefix, "detection:correlated_action:");
+                assert_eq!(
+                    required,
+                    vec![crate::federation::types::identity_type::LENSCORE_DETECTOR.to_owned()]
+                );
+            }
+            other => panic!("expected ReservedPrefixEmitterMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_put_attestation_admits_truth_grounding_cross_attestation() {
+        // CC 3.4.8 (CIRISPersist#366) — a non-detector peer cross-checking a
+        // detector verdict emits under the DISTINCT `truth_grounding:detection:*`
+        // prefix, which is UNGATED (does not start with `detection:`).
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        use crate::federation::FederationDirectory;
+        let agent = format!("pg-cross-agt-§366-{}", uuid_like());
+        let subj = format!("pg-cross-sub-§366-{}", uuid_like());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &agent,
+                    "registry",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord {
+                record: pg_admission_key(
+                    &subj,
+                    "primitive-cross",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        let att = pg_scores_attestation(
+            &agent,
+            &subj,
+            &agent,
+            "truth_grounding:detection:correlated_action:rights_asymmetry:v1",
+        );
+        backend
+            .put_attestation(crate::federation::SignedAttestation { attestation: att })
+            .await
+            .unwrap();
+        let rows = backend.list_attestations_for(&subj).await.unwrap();
         assert_eq!(rows.len(), 1);
     }
 
@@ -23788,10 +23902,12 @@ mod tests {
         let agent_k = format!("pg-sch-agt-§102-{}", uuid_like());
         backend
             .put_public_key(crate::federation::SignedKeyRecord {
+                // CC 3.4.8 (CIRISPersist#366) — detector-only prefix; the
+                // detection emitter must hold `lenscore_detector`.
                 record: pg_admission_key(
                     &steward,
                     "registry",
-                    crate::federation::types::identity_type::STEWARD,
+                    crate::federation::types::identity_type::LENSCORE_DETECTOR,
                 ),
             })
             .await
@@ -23878,10 +23994,14 @@ mod tests {
         let agent_k = format!("pg-bsch-agt-§102-{}", uuid_like());
         backend
             .put_public_key(crate::federation::SignedKeyRecord {
+                // CC 3.4.8 (CIRISPersist#366) — detector-only prefix; the
+                // detection emitter must hold `lenscore_detector` so the row
+                // reaches the schema validator (rejected there for the missing
+                // envelope field, not at the emitter gate).
                 record: pg_admission_key(
                     &steward,
                     "registry",
-                    crate::federation::types::identity_type::STEWARD,
+                    crate::federation::types::identity_type::LENSCORE_DETECTOR,
                 ),
             })
             .await

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2127,6 +2127,13 @@ impl PostgresBackend {
             } else {
                 Some(&row.roles)
             };
+            // v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — wire None ⇔ the
+            // stored V020 'unregistered' default (column is NOT NULL).
+            crate::federation::types::consent_role::check_admissible(row.consent_role.as_deref())?;
+            let consent_role_stored = crate::federation::types::consent_role::stored_from_wire(
+                row.consent_role.as_deref(),
+            )
+            .to_owned();
             client
                 .execute(
                     "INSERT INTO cirislens.federation_keys (\
@@ -2134,8 +2141,8 @@ impl PostgresBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence\
-                     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) \
+                        attestation_evidence, consent_role\
+                     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) \
                      ON CONFLICT (key_id) DO NOTHING",
                     &[
                         &row.key_id,
@@ -2156,6 +2163,7 @@ impl PostgresBackend {
                         &row.persist_row_hash,
                         &roles_param,
                         &row.attestation_evidence,
+                        &consent_role_stored,
                     ],
                 )
                 .await
@@ -2233,6 +2241,12 @@ impl PostgresBackend {
             .await
             .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
         // WHERE re-asserts the guards atomically: self-signed + same pubkey.
+        //
+        // v12.7.0 (CIRISPersist#365, CC 3.4.7.2): `consent_role` is
+        // deliberately NOT in the SET list — it is an operational role
+        // marker (its OQ-1 overwrite surface is `set_consent_role`), not
+        // registration content; an anchor-scrub upgrade must not clobber
+        // an assigned role.
         let n = client
             .execute(
                 "UPDATE cirislens.federation_keys SET \
@@ -2343,6 +2357,14 @@ impl crate::federation::FederationDirectory for PostgresBackend {
         } else {
             Some(&row.roles)
         };
+        // v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — admission-gate the
+        // token (Rust-level, so PG's V020 CHECK and CHECK-less SQLite
+        // behave identically), then map wire None ⇔ the stored V020
+        // 'unregistered' default (the column is NOT NULL).
+        crate::federation::types::consent_role::check_admissible(row.consent_role.as_deref())?;
+        let consent_role_stored =
+            crate::federation::types::consent_role::stored_from_wire(row.consent_role.as_deref())
+                .to_owned();
         let result = client
             .execute(
                 "INSERT INTO cirislens.federation_keys (\
@@ -2350,8 +2372,8 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence\
-                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) \
+                    attestation_evidence, consent_role\
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) \
                  ON CONFLICT (key_id) DO NOTHING",
                 &[
                     &row.key_id,
@@ -2372,6 +2394,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     &row.persist_row_hash,
                     &roles_param,
                     &row.attestation_evidence,
+                    &consent_role_stored,
                 ],
             )
             .await
@@ -2415,7 +2438,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence \
+                    attestation_evidence, consent_role \
                  FROM cirislens.federation_keys WHERE key_id = $1",
                 &[&key_id],
             )
@@ -2440,7 +2463,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence \
+                    attestation_evidence, consent_role \
                  FROM cirislens.federation_keys WHERE identity_ref = $1",
                 &[&identity_ref],
             )
@@ -2470,7 +2493,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence \
+                    attestation_evidence, consent_role \
                  FROM cirislens.federation_keys WHERE identity_type = $1 \
                  ORDER BY key_id",
                 &[&identity_type],
@@ -2480,6 +2503,40 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 crate::federation::Error::Backend(format!("list_keys_by_identity_type: {e}"))
             })?;
         rows.into_iter().map(pg_row_to_key_record).collect()
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1) — overwrite-on-revoke
+    /// consent_role. Flat UPDATE of the single V020 column; `None` resets
+    /// to the stored `'unregistered'` default (revoke). No chain — a
+    /// subsequent call overwrites. Excluded from `persist_row_hash`, so
+    /// this does not touch the signed row.
+    async fn set_consent_role(
+        &self,
+        key_id: &str,
+        consent_role: Option<&str>,
+    ) -> Result<(), crate::federation::Error> {
+        crate::federation::types::consent_role::check_admissible(consent_role)?;
+        let stored =
+            crate::federation::types::consent_role::stored_from_wire(consent_role).to_owned();
+        let client = self
+            .get_client()
+            .await
+            .map_err(|e| crate::federation::Error::Backend(e.to_string()))?;
+        let n = client
+            .execute(
+                "UPDATE cirislens.federation_keys SET consent_role = $2 WHERE key_id = $1",
+                &[&key_id, &stored],
+            )
+            .await
+            .map_err(|e| {
+                crate::federation::Error::Backend(format!("set_consent_role {key_id}: {e}"))
+            })?;
+        if n == 0 {
+            return Err(crate::federation::Error::InvalidArgument(format!(
+                "set_consent_role: no federation_keys row for {key_id}"
+            )));
+        }
+        Ok(())
     }
 
     async fn put_attestation(
@@ -6109,6 +6166,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         key.persist_row_hash = crate::federation::types::compute_persist_row_hash(&key)?;
 
@@ -6145,14 +6203,18 @@ impl crate::federation::FederationDirectory for PostgresBackend {
             ))
         })?;
         let roles_param: Option<&Vec<String>> = None;
+        // v12.7.0 (CIRISPersist#365) — wire None ⇔ stored 'unregistered'.
+        let consent_role_stored =
+            crate::federation::types::consent_role::stored_from_wire(key.consent_role.as_deref())
+                .to_owned();
         tx.execute(
             "INSERT INTO cirislens.federation_keys (\
                 key_id, pubkey_ed25519_base64, pubkey_ml_dsa_65_base64, algorithm, \
                 identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                 original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                 scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                attestation_evidence\
-             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18) \
+                attestation_evidence, consent_role\
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19) \
              ON CONFLICT (key_id) DO NOTHING",
             &[
                 &key.key_id,
@@ -6173,6 +6235,7 @@ impl crate::federation::FederationDirectory for PostgresBackend {
                 &key.persist_row_hash,
                 &roles_param,
                 &key.attestation_evidence,
+                &consent_role_stored,
             ],
         )
         .await
@@ -9933,6 +9996,18 @@ fn pg_row_to_key_record(
         .try_get::<_, Option<serde_json::Value>>("attestation_evidence")
         .ok()
         .flatten();
+    // v12.7.0 (CIRISPersist#365, CC 3.4.7.2): consent_role is the V020
+    // `TEXT NOT NULL DEFAULT 'unregistered'` column. Tolerant read
+    // (matching roles/attestation_evidence above) — a SELECT that didn't
+    // pull the column maps to None, and the stored 'unregistered'
+    // default maps to wire None (`consent_role::wire_from_stored`).
+    let consent_role: Option<String> = row
+        .try_get::<_, Option<String>>("consent_role")
+        .ok()
+        .flatten()
+        .as_deref()
+        .and_then(crate::federation::types::consent_role::wire_from_stored)
+        .map(str::to_owned);
     Ok(crate::federation::KeyRecord {
         key_id: row.safe_get_with("key_id", mk_err)?,
         pubkey_ed25519_base64: row.safe_get_with("pubkey_ed25519_base64", mk_err)?,
@@ -9952,6 +10027,7 @@ fn pg_row_to_key_record(
         persist_row_hash: row.safe_get_with("persist_row_hash", mk_err)?,
         roles,
         attestation_evidence,
+        consent_role,
     })
 }
 
@@ -12514,7 +12590,7 @@ impl crate::read::ReadEngine for PostgresBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, \
-                    attestation_evidence \
+                    attestation_evidence, consent_role \
              FROM cirislens.federation_keys \
              {where_sql} \
              ORDER BY valid_from DESC, key_id DESC \
@@ -17669,7 +17745,73 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — consent_role round-trips
+    /// through put/lookup, OQ-1 overwrite-on-revoke via set_consent_role,
+    /// and the consent_role_of resolver — on the Postgres twin. Gated on a
+    /// live test PG (skips when `CIRIS_PERSIST_TEST_PG_URL` is unset).
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn consent_role_round_trip_overwrite_and_resolver_pg() {
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        use crate::federation::consent::consent_role_of;
+        use crate::federation::types::consent_role;
+        use crate::federation::FederationDirectory;
+        let backend = PostgresBackend::connect(&dsn).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let now = chrono::Utc::now();
+        let kid = format!("k-cr-{}", uuid_like());
+
+        // Born with consent_role = peer → round-trips.
+        let mut key = fix_section_i_key(&kid, "primitive-cr", now, true);
+        key.consent_role = Some(consent_role::PEER.into());
+        backend
+            .put_public_key(crate::federation::SignedKeyRecord { record: key })
+            .await
+            .unwrap();
+        let got = FederationDirectory::lookup_public_key(&backend, &kid)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.consent_role.as_deref(), Some(consent_role::PEER));
+        assert_eq!(
+            consent_role_of(&backend, &kid).await.unwrap().as_deref(),
+            Some(consent_role::PEER)
+        );
+
+        // OQ-1 overwrite → authorized_review.
+        FederationDirectory::set_consent_role(
+            &backend,
+            &kid,
+            Some(consent_role::AUTHORIZED_REVIEW),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            consent_role_of(&backend, &kid).await.unwrap().as_deref(),
+            Some(consent_role::AUTHORIZED_REVIEW)
+        );
+
+        // Revoke (overwrite to None).
+        FederationDirectory::set_consent_role(&backend, &kid, None)
+            .await
+            .unwrap();
+        assert_eq!(consent_role_of(&backend, &kid).await.unwrap(), None);
+
+        // Unknown key: setter errors, resolver stays total.
+        let missing = format!("k-cr-missing-{}", uuid_like());
+        assert!(
+            FederationDirectory::set_consent_role(&backend, &missing, Some("peer"))
+                .await
+                .is_err()
+        );
+        assert_eq!(consent_role_of(&backend, &missing).await.unwrap(), None);
     }
 
     /// V060 community substrate round-trip on Postgres — parity with
@@ -26264,6 +26406,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(crate::federation::SignedKeyRecord { record })
@@ -27121,6 +27264,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -1765,6 +1765,31 @@ impl Backend for PostgresBackend {
             .collect()
     }
 
+    // #227 (residual) — consent-decay clock enumerator (disk-independent).
+    async fn list_fountain_decay_candidates(
+        &self,
+    ) -> Result<Vec<crate::fountain::FountainDecayCandidate>, Error> {
+        let client = self.get_client().await?;
+        let rows = client
+            .query(
+                "SELECT content_id, corpus_kind, envelope, admitted_at \
+                 FROM cirislens.content_manifest",
+                &[],
+            )
+            .await
+            .map_err(|e| Error::Backend(format!("list_fountain_decay_candidates: {e}")))?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(crate::fountain::FountainDecayCandidate {
+                content_id: r.safe_get_with("content_id", Error::Backend)?,
+                corpus_kind: r.safe_get_with("corpus_kind", Error::Backend)?,
+                envelope: r.safe_get_with("envelope", Error::Backend)?,
+                admitted_at: r.safe_get_with("admitted_at", Error::Backend)?,
+            });
+        }
+        Ok(out)
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2533,13 +2533,12 @@ impl crate::federation::FederationDirectory for PostgresBackend {
 
         // v6.7.0 (CIRISPersist#146 Ask 5, CEG §5.6.8.7) — `consent_record`
         // ceremony admission (required fields / closed stance set /
-        // substrate-only `expired` / §10.1.3 revoked-not-local). No-op for
-        // every non-`consent_record` row.
-        crate::federation::admission::check_consent_record_admission(
-            &row.attestation_type,
-            &row.attestation_envelope,
-            &row.tier,
-        )?;
+        // substrate-only `expired`). v12.6.0 (CIRISPersist#171, §10.1.3
+        // transit-not-rest): a `revoked` consent_record at local tier MAY
+        // *transit* the local write path only if its bound-hybrid signature
+        // verifies (accept on VALID crypto only). No-op for non-consent_record
+        // rows and durable ones. Backend-symmetric with Memory + SQLite.
+        crate::federation::admission::verify_consent_record_transit_ingest(self, &row).await?;
 
         // v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4) — cohort_scope
         // admission-gate validation. Rejects out-of-closed-set values
@@ -9975,7 +9974,7 @@ impl PostgresBackend {
             )
         })?;
 
-        crate::federation::admission::check_local_tier_eligibility(
+        let disposition = crate::federation::admission::check_local_tier_eligibility(
             &input.attestation_type,
             Some(dimension.as_str()),
             &input.attesting_key_id,
@@ -9983,6 +9982,17 @@ impl PostgresBackend {
             &input.cohort_scope,
         )?;
         crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        // v12.6.0 (CIRISPersist#171, §10.1.3) — a subject-side revocation MAY
+        // *transit* the local write path only if its bound-hybrid signature
+        // verifies (accept on VALID crypto only). `None` for a durable
+        // producer-authority row. Runs before the client is checked out.
+        let transit = crate::federation::admission::verify_local_transit_revocation(
+            self,
+            disposition,
+            &input,
+        )
+        .await?;
 
         let mut client = self
             .get_client()
@@ -10015,11 +10025,25 @@ impl PostgresBackend {
         let attestation_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
         let attesting_key_id = input.attesting_key_id.clone();
-        let mut row = input.into_local_row(attestation_id.clone(), now);
+        // A durable row defers its signature (empty-sentinel scrub envelope);
+        // a TRANSIT revocation carries the caller's verified bound-hybrid
+        // signature + computed hash (§10.1.3 transit-not-rest).
+        let mut row = match transit {
+            Some((hash, sig_classical, sig_pqc)) => input.into_transit_revocation_row(
+                attestation_id.clone(),
+                now,
+                hash,
+                sig_classical,
+                sig_pqc,
+            ),
+            None => input.into_local_row(attestation_id.clone(), now),
+        };
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
         let subject_key_ids_json = serde_json::to_value(&row.subject_key_ids)
             .map_err(|e| Error::Backend(format!("subject_key_ids serialize: {e}")))?;
-        let original_content_hash: Vec<u8> = Vec::new(); // empty sentinel
+        // bytea: durable row hex "" → []; transit row = SHA-256 digest bytes.
+        let original_content_hash: Vec<u8> = hex::decode(&row.original_content_hash)
+            .map_err(|e| Error::Backend(format!("original_content_hash hex decode: {e}")))?;
         let attestation_uuid = uuid::Uuid::parse_str(&attestation_id)
             .map_err(|e| Error::Backend(format!("uuid parse: {e}")))?;
 
@@ -15155,6 +15179,147 @@ mod tests {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         format!("{nanos:x}")
+    }
+
+    /// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — Postgres parity
+    /// for the FULL consent-SLA loop through the REAL admission path: a
+    /// crypto-valid subject-side `consent:state:revoked` is ADMITTED as a
+    /// transit local-tier write, and `run_consent_sla_watch` fires
+    /// `consent_revocation_promotion_overdue` for it past the 24 h window (not
+    /// before). A crypto-INVALID one is rejected at admission. Suffix-scoped so
+    /// the assertions bind only to this run's fixtures on the shared test DB.
+    #[tokio::test]
+    #[serial_test::serial(postgres)]
+    async fn pg_consent_revocation_transit_admits_and_sla_fires_end_to_end() {
+        use crate::federation::tier_ingest::test_support::sign_envelope;
+        use crate::federation::types::{attestation_tier, attestation_type, LocalAttestationInput};
+        use crate::federation::FederationDirectory;
+        use std::time::Duration;
+        let Some(dsn) = pg_dsn() else {
+            eprintln!("skipping: CIRIS_PERSIST_TEST_PG_URL unset");
+            return;
+        };
+        let backend = PostgresBackend::connect(&dsn).await.expect("connect");
+        backend.run_migrations().await.expect("migrations run");
+
+        let now0 = chrono::Utc::now();
+        let suffix = uuid_like();
+        let subject = format!("subject-c-{suffix}");
+        let target = format!("target-c-{suffix}");
+        for kid in [&subject, &target] {
+            backend
+                .put_public_key(crate::federation::SignedKeyRecord {
+                    record: fix_section_i_key(kid, "registry", now0, true),
+                })
+                .await
+                .unwrap();
+        }
+
+        let env = serde_json::json!({
+            "id": format!("rev-{suffix}"), "dimension": "consent:state:revoked:v1",
+            "score": 1.0, "confidence": 0.9,
+        });
+        let (_hash, sig_classical, sig_pqc) = sign_envelope(&subject, &env);
+
+        backend
+            .attestation_upsert_local(LocalAttestationInput {
+                attesting_key_id: subject.clone(),
+                attested_key_id: Some(target.clone()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: env.clone(),
+                subject_key_ids: vec![subject.clone()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some(sig_classical),
+                scrub_signature_pqc: sig_pqc,
+            })
+            .await
+            .expect("crypto-valid subject-side revocation transits the local tier");
+
+        // Find THIS run's transit row (shared DB → filter by our subject).
+        let mine = backend
+            .list_consent_revocations(Some(now0))
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|a| a.attesting_key_id == subject)
+            .expect("revocation scan sees our transit row");
+        assert_eq!(mine.tier, attestation_tier::LOCAL);
+        assert!(mine.promoted_at.is_none());
+        assert!(
+            !mine.scrub_signature_classical.is_empty() && mine.scrub_signature_pqc.is_some(),
+            "transit row round-trips its real bound-hybrid signature"
+        );
+        let revoked_at = mine.asserted_at;
+        let window = Duration::from_secs(86_400);
+
+        // Helper: does OUR overdue hard_case exist? (shared test DB → filter
+        // to this run's subject/target).
+        async fn ours_fired(
+            backend: &PostgresBackend,
+            since: chrono::DateTime<chrono::Utc>,
+            subject: &str,
+            target: &str,
+        ) -> bool {
+            use crate::federation::hard_case::{kind, HardCaseFilter};
+            use crate::federation::FederationDirectory as _;
+            backend
+                .list_hard_case_events(HardCaseFilter {
+                    kind: Some(kind::CONSENT_REVOCATION_PROMOTION_OVERDUE.into()),
+                    since: Some(since),
+                })
+                .await
+                .unwrap()
+                .into_iter()
+                .any(|e| {
+                    e.subject_key_id.as_deref() == Some(subject)
+                        && e.target_key_id.as_deref() == Some(target)
+                })
+        }
+
+        // BEFORE the boundary → our revocation is in flight, not overdue.
+        let before = revoked_at + chrono::Duration::seconds(86_400 - 1);
+        backend.run_consent_sla_watch(before, window).await.unwrap();
+        assert!(
+            !ours_fired(&backend, now0, &subject, &target).await,
+            "within the window: our overdue hard_case must NOT have fired"
+        );
+
+        // AFTER the boundary → our overdue hard_case fires.
+        let after = revoked_at + chrono::Duration::seconds(86_400 + 1);
+        backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert!(
+            ours_fired(&backend, now0, &subject, &target).await,
+            "past the window: our overdue hard_case fires"
+        );
+
+        // crypto-INVALID revocation → rejected at admission (never transits).
+        let bad = backend
+            .attestation_insert_local(LocalAttestationInput {
+                attesting_key_id: subject.clone(),
+                attested_key_id: Some(target.clone()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: serde_json::json!({
+                    "id": format!("rev-bad-{suffix}"), "dimension": "consent:state:revoked:v1",
+                    "score": 1.0, "confidence": 0.9,
+                }),
+                subject_key_ids: vec![subject.clone()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some("AAAA".into()),
+                scrub_signature_pqc: Some("AAAA".into()),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                bad,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "crypto-invalid revocation rejected at admission, got {bad:?}"
+        );
     }
 
     // ─── Lens-derived schemas (v0.4.3, CIRISPersist#18) ────────────
@@ -22175,7 +22340,9 @@ mod tests {
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("substrate-emitted only"))
         );
-        let err = backend
+        // revoked / local (v12.6.0, §10.1.3 transit-not-rest): a crypto-VALID
+        // one TRANSITS the local tier (accepted); a forged one is rejected.
+        backend
             .put_attestation(crate::federation::SignedAttestation {
                 attestation: mk(
                     crate::federation::types::consent_record::stance::REVOKED,
@@ -22183,9 +22350,24 @@ mod tests {
                 ),
             })
             .await
+            .expect("crypto-valid revoked consent_record transits the local tier on PG");
+        let mut forged = mk(
+            crate::federation::types::consent_record::stance::REVOKED,
+            crate::federation::types::attestation_tier::LOCAL,
+        );
+        forged.scrub_signature_classical = "AAAA".into(); // not a valid sig
+        let err = backend
+            .put_attestation(crate::federation::SignedAttestation {
+                attestation: forged,
+            })
+            .await
             .unwrap_err();
         assert!(
-            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("local-tier-eligible"))
+            matches!(
+                err,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "forged revoked/local consent_record rejected at admission, got {err:?}"
         );
     }
 
@@ -27593,6 +27775,8 @@ mod tests {
             }),
             subject_key_ids: subjects,
             cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+            scrub_signature_classical: None,
+            scrub_signature_pqc: None,
         }
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2527,11 +2527,14 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         // so a rejected emission leaves no trace.
         crate::federation::admission::check_reserved_prefix_admission(self, &row).await?;
 
-        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11) — no-moderator-no-
-        // federate FEDERATION-APPLY re-check (point ii). A federation-tier row
-        // keyed on a community (`community_id`) is refused if C has lost its
-        // last live `moderate`-holder. No-op for local-tier rows, no
-        // community_id, or an unknown community. Backend-symmetric.
+        // v12.5.0 (CIRISPersist#238, CC 4.5.4 / §11.11; keying broadened by
+        // #369) — no-moderator-no-federate FEDERATION-APPLY re-check (point
+        // ii). A federation-tier row keyed on a community under ANY substrate
+        // shape (envelope `community_id`/`community_key_id`/`cohort_key_id`,
+        // a row endpoint or subject_key_ids entry resolving as a stored
+        // community) is refused if C has lost its last live
+        // `moderate`-holder. No-op for local-tier rows, rows referencing no
+        // known community. Backend-symmetric.
         crate::federation::admission::check_no_moderator_federate_apply(self, &row).await?;
 
         // v9.0.0 (CIRISPersist#237, CC 5.3.2.4.3.1) — PQC-mandatory
@@ -26184,6 +26187,152 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    /// #369 (CC 4.5.4 / §11.11) — no-moderator federation-APPLY gate,
+    /// broadened keying, END-TO-END through `put_attestation` (sqlite; parity
+    /// with memory's decision table + the postgres twin). A federation-tier
+    /// row attested TO a stored moderator-less community (the membership
+    /// shape — NO `community_id` envelope field) is refused fail-secure;
+    /// the same shape onto a moderatored community lands; local-tier +
+    /// storage-only community ops stay untouched.
+    #[tokio::test]
+    async fn no_moderator_federate_apply_broadened_keying_sqlite() {
+        use crate::federation::admission::MEMBER_ROLE_FOUNDER;
+        use crate::federation::types::{consensus_protocol, identity_type};
+        use crate::federation::FederationDirectory;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        // Keys: a USER founder (steward-bound ⇒ zero-hop moderator), a
+        // PRIMITIVE founder (passes the storage steward-binding gate — not
+        // node/agent — but is NOT steward-bound ⇒ no moderator), + the two
+        // community keys.
+        for (kid, ity) in [
+            ("nm-user", identity_type::USER),
+            ("nm-prim", identity_type::PRIMITIVE),
+            ("nm-ok", identity_type::PRIMITIVE),
+            ("nm-no", identity_type::PRIMITIVE),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fed_key_with_identity_type(kid, "nm", kid, ity),
+                })
+                .await
+                .unwrap();
+        }
+        let put_comm = |cid: &str, founder: &str| crate::federation::SignedCommunity {
+            community: crate::federation::Community {
+                community_key_id: cid.into(),
+                community_name: "nm-test".into(),
+                members: vec![crate::federation::CommunityMember {
+                    key_id: founder.into(),
+                    joined_at: "2026-06-04T00:00:00Z".parse().unwrap(),
+                    role: Some(MEMBER_ROLE_FOUNDER.into()),
+                }],
+                founded_at: "2026-06-04T00:00:00Z".parse().unwrap(),
+                consensus_protocol: consensus_protocol::FOUNDER_ONLY.into(),
+                policy_blob: None,
+                persist_row_hash: String::new(),
+            },
+        };
+        // Storage-only put_community is NOT the federate gate — both records
+        // (moderatored AND moderator-less) store fine.
+        backend
+            .put_community(put_comm("nm-ok", "nm-user"))
+            .await
+            .unwrap();
+        backend
+            .put_community(put_comm("nm-no", "nm-prim"))
+            .await
+            .unwrap();
+
+        // (1) Membership shape onto the moderator-less community → REFUSED
+        //     fail-secure, nothing stored.
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: fed_attestation("nm-a1", "nm-prim", "nm-no", "nm-prim"),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::federation::Error::CommunityHasNoModerator { .. }
+            ),
+            "federation apply keyed on a moderator-less community must refuse, got {err:?}"
+        );
+        assert_eq!(err.kind(), "federation_community_no_moderator");
+        assert!(
+            crate::federation::FederationDirectory::list_attestations_for(&backend, "nm-no")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // (2) Same shape onto the MODERATORED community → ADMITTED + stored.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: fed_attestation("nm-a2", "nm-user", "nm-ok", "nm-user"),
+            })
+            .await
+            .expect("moderatored community continues to federate");
+        assert_eq!(
+            crate::federation::FederationDirectory::list_attestations_for(&backend, "nm-ok")
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // (3) LOCAL-tier row keyed on the moderator-less community →
+        //     untouched (not a federation apply step).
+        let mut local = fed_attestation("nm-a3", "nm-prim", "nm-no", "nm-prim");
+        local.tier = crate::federation::types::attestation_tier::LOCAL.into();
+        local.cohort_scope = crate::federation::types::cohort_scope::SELF.into();
+        backend
+            .put_attestation(SignedAttestation { attestation: local })
+            .await
+            .expect("local-tier row is not a federation apply step");
+
+        // (4) Storage-only membership op on the moderator-less community →
+        //     untouched (loss-processing / recovery must not be blocked).
+        backend
+            .put_community_membership_revocation(
+                crate::federation::SignedCommunityMembershipRevocation {
+                    community_membership_revocation:
+                        crate::federation::CommunityMembershipRevocation {
+                            community_key_id: "nm-no".into(),
+                            removed_identity_key_id: "nm-prim".into(),
+                            removed_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                            effective_at: "2026-06-05T00:00:00Z".parse().unwrap(),
+                            reason: None,
+                            witness_set: Vec::new(),
+                            persist_row_hash: String::new(),
+                        },
+                },
+            )
+            .await
+            .expect("membership revocation is storage, not a federation apply step");
+
+        // (5) The drivable verdict mirrors the apply decision.
+        let v = crate::federation::admission::no_moderator_federate_verdict(&backend, "nm-no")
+            .await
+            .unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "admitted": false, "community_known": true,
+                "reason": "federation_community_no_moderator"
+            })
+        );
+        let v = crate::federation::admission::no_moderator_federate_verdict(&backend, "nm-ok")
+            .await
+            .unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({ "admitted": true, "community_known": true })
+        );
     }
 
     /// v11.5.0 (CIRISPersist#306, CC 3.2 / CC 3.3.12 / CC 1.15.6) — sqlite

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2068,6 +2068,14 @@ impl SqliteBackend {
                 row.algorithm
             )));
         }
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — adopt_scrub_upgrade is a
+        // self-signed → anchor-scrubbed UPDATE that CAN change identity_type,
+        // so it is a second path a `canonical` role could otherwise enter on.
+        // Re-run the accord-conferred gate: `canonical` is admitted here only
+        // if THIS incoming (anchor-scrubbed) record earned it via a real
+        // accord-holder scrubber. (The scrub_key_id != key_id guard above is
+        // necessary but not sufficient — the scrubber must be in the anchor.)
+        crate::federation::admission::check_canonical_role_admission(self, &row).await?;
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 
         // Resolve the existing row + classify the transition.
@@ -2221,6 +2229,49 @@ impl SqliteBackend {
             },
         }
     }
+
+    /// v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — enumerate the **canonical /
+    /// founding bootstrap servers**: `federation_keys` rows whose
+    /// `identity_type` **set** contains
+    /// [`crate::federation::types::identity_type::CANONICAL`], stable-sorted by
+    /// `key_id`. Every such row is (by the admission gate
+    /// [`crate::federation::admission::check_canonical_role_admission`])
+    /// necessarily anchor-scrub-conferred — the role cannot be self-claimed.
+    /// Inherent on the backend (dispatched by `Engine::list_canonical_servers`)
+    /// to avoid `FederationDirectory`/capsule bloat, mirroring
+    /// [`Self::adopt_scrub_upgrade`]. The SQL `LIKE` is a coarse prefilter; the
+    /// exact set-membership check is applied in Rust via `set_contains`.
+    pub async fn list_canonical_servers(
+        &self,
+    ) -> Result<Vec<crate::federation::KeyRecord>, crate::federation::Error> {
+        let conn = self.conn.clone();
+        (
+            move || -> Result<Vec<crate::federation::KeyRecord>, rusqlite::Error> {
+                let conn = conn.lock();
+                let mut stmt = conn.prepare(
+                    "SELECT key_id, pubkey_ed25519_base64, pubkey_ml_dsa_65_base64, algorithm, \
+                        identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
+                        original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
+                        scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
+                        attestation_evidence \
+                     FROM federation_keys WHERE identity_type LIKE '%canonical%' \
+                     ORDER BY key_id",
+                )?;
+                let rows = stmt.query_map([], sqlite_row_to_key_record)?;
+                rows.collect()
+            })()
+        .map_err(|e| crate::federation::Error::Backend(format!("list_canonical_servers: {e}")))
+        .map(|rows: Vec<crate::federation::KeyRecord>| {
+            rows.into_iter()
+                .filter(|r| {
+                    crate::federation::types::identity_type::set_contains(
+                        &r.identity_type,
+                        crate::federation::types::identity_type::CANONICAL,
+                    )
+                })
+                .collect()
+        })
+    }
 }
 
 #[async_trait::async_trait]
@@ -2248,6 +2299,18 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                 chrono::Utc::now(),
             )?;
         }
+
+        // v12.7.0 (CIRISPersist#372, CC 3.4.7.1) — the `canonical` (founding
+        // bootstrap server) role is accord-CONFERRED, never self-claimed: a row
+        // may carry `canonical` only when anchor-scrub-signed (scrub_key_id !=
+        // key_id AND the scrubber's ed25519 ∈ the pinned HUMANITY_ACCORD
+        // anchor). This is the substrate write chokepoint every registration
+        // path (register_federation_key, register_self_federation_key, direct
+        // FFI, replication of a peer row) funnels through, so a self-signed /
+        // non-anchor-scrubbed `canonical` claim is refused here before any
+        // INSERT (verify-before-mutation). Backend-symmetric with Postgres +
+        // memory.
+        crate::federation::admission::check_canonical_role_admission(self, &row).await?;
 
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -20827,7 +20827,20 @@ mod tests {
         backend.run_migrations().await.unwrap();
         backend
             .put_public_key(SignedKeyRecord {
-                record: fed_key("registry-steward", "registry", "registry-steward"),
+                // CC 3.4.8 (CIRISPersist#366) — detector-only prefix. Exercise
+                // the SET-membership gate with a folded `{agent,
+                // lenscore_detector}` LensCore-fold key: `lenscore_detector ∈
+                // set` admits, the cohabiting `agent` role neither grants nor
+                // blocks (CC 3.4.8 worked example).
+                record: fed_key_with_identity_type(
+                    "registry-steward",
+                    "registry",
+                    "registry-steward",
+                    &crate::federation::types::identity_type::join_set([
+                        crate::federation::types::identity_type::AGENT,
+                        crate::federation::types::identity_type::LENSCORE_DETECTOR,
+                    ]),
+                ),
             })
             .await
             .unwrap();
@@ -20843,6 +20856,96 @@ mod tests {
             "k-a",
             "registry-steward",
             "detection:correlated_action:rights_asymmetry:v1",
+        );
+        backend
+            .put_attestation(SignedAttestation { attestation: att })
+            .await
+            .unwrap();
+        let rows = crate::federation::FederationDirectory::list_attestations_for(&backend, "k-a")
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_put_attestation_rejects_detection_from_non_detector() {
+        // CC 3.4.8 (CIRISPersist#366) — a plain `agent` key (no
+        // `lenscore_detector` in its identity_type set) MUST be rejected on
+        // a `detection:correlated_action:*` primary emission.
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key_with_identity_type(
+                    "plain-agent",
+                    "registry",
+                    "plain-agent",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("k-a", "primitive-a", "plain-agent"),
+            })
+            .await
+            .unwrap();
+        let att = scores_attestation_with_dimension(
+            "att-nondetector-1",
+            "plain-agent",
+            "k-a",
+            "plain-agent",
+            "detection:correlated_action:rights_asymmetry:v1",
+        );
+        let err = backend
+            .put_attestation(SignedAttestation { attestation: att })
+            .await
+            .unwrap_err();
+        match err {
+            crate::federation::Error::ReservedPrefixEmitterMismatch {
+                prefix, required, ..
+            } => {
+                assert_eq!(prefix, "detection:correlated_action:");
+                assert_eq!(
+                    required,
+                    vec![crate::federation::types::identity_type::LENSCORE_DETECTOR.to_owned()]
+                );
+            }
+            other => panic!("expected ReservedPrefixEmitterMismatch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_put_attestation_admits_truth_grounding_cross_attestation() {
+        // CC 3.4.8 (CIRISPersist#366) — a non-detector peer cross-checking a
+        // detector verdict emits under the DISTINCT `truth_grounding:detection:*`
+        // prefix, which is UNGATED (does not start with `detection:`).
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key_with_identity_type(
+                    "plain-agent",
+                    "registry",
+                    "plain-agent",
+                    crate::federation::types::identity_type::AGENT,
+                ),
+            })
+            .await
+            .unwrap();
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("k-a", "primitive-a", "plain-agent"),
+            })
+            .await
+            .unwrap();
+        let att = scores_attestation_with_dimension(
+            "att-crosscheck-1",
+            "plain-agent",
+            "k-a",
+            "plain-agent",
+            "truth_grounding:detection:correlated_action:rights_asymmetry:v1",
         );
         backend
             .put_attestation(SignedAttestation { attestation: att })
@@ -25021,7 +25124,15 @@ mod tests {
         backend.run_migrations().await.unwrap();
         backend
             .put_public_key(SignedKeyRecord {
-                record: fed_key("rs", "registry", "rs"),
+                // CC 3.4.8 (CIRISPersist#366) — `detection:correlated_action:*`
+                // is a detector-only prefix; the emitter must hold
+                // `lenscore_detector`.
+                record: fed_key_with_identity_type(
+                    "rs",
+                    "registry",
+                    "rs",
+                    crate::federation::types::identity_type::LENSCORE_DETECTOR,
+                ),
             })
             .await
             .unwrap();
@@ -25123,7 +25234,16 @@ mod tests {
         backend.run_migrations().await.unwrap();
         backend
             .put_public_key(SignedKeyRecord {
-                record: fed_key("rs", "registry", "rs"),
+                // CC 3.4.8 (CIRISPersist#366) — detector-only prefix; the
+                // detection emitter must hold `lenscore_detector`. ("rs" also
+                // signs the schema blob below; put_blob does not gate
+                // identity_type, so this is inert for the blob path.)
+                record: fed_key_with_identity_type(
+                    "rs",
+                    "registry",
+                    "rs",
+                    crate::federation::types::identity_type::LENSCORE_DETECTOR,
+                ),
             })
             .await
             .unwrap();
@@ -25211,7 +25331,16 @@ mod tests {
         backend.run_migrations().await.unwrap();
         backend
             .put_public_key(SignedKeyRecord {
-                record: fed_key("rs", "registry", "rs"),
+                // CC 3.4.8 (CIRISPersist#366) — detector-only prefix; the
+                // detection emitter must hold `lenscore_detector` so the row
+                // reaches the schema validator (and gets rejected there for
+                // the missing envelope field, not at the emitter gate).
+                record: fed_key_with_identity_type(
+                    "rs",
+                    "registry",
+                    "rs",
+                    crate::federation::types::identity_type::LENSCORE_DETECTOR,
+                ),
             })
             .await
             .unwrap();

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1228,6 +1228,97 @@ impl Backend for SqliteBackend {
         .map_err(|e| Error::Backend(format!("list_held_fountain_content: {e}")))
     }
 
+    // ─── v12.7.0 — §Q pin-INSTALL surface (CIRISPersist#370) ─────────
+
+    async fn put_installed_storage_budget(
+        &self,
+        budget: &crate::fountain::storage_contention::InstalledStorageBudget,
+    ) -> Result<bool, Error> {
+        let revision = i64::try_from(budget.revision)
+            .map_err(|_| Error::Backend("storage budget revision exceeds i64".into()))?;
+        let scopes = serde_json::to_string(&budget.scopes)
+            .map_err(|e| Error::Backend(format!("serialize budget scopes: {e}")))?;
+        let pinned_class = serde_json::to_string(&budget.pinned_class)
+            .map_err(|e| Error::Backend(format!("serialize budget pinned_class: {e}")))?;
+        let node_id = budget.node_id.clone();
+        let epoch_id = budget.epoch_id.clone();
+        let wire_json = budget.wire_json.clone();
+        let installed_at = budget.installed_at.to_rfc3339();
+        let conn = self.conn.clone();
+        (move || -> Result<bool, rusqlite::Error> {
+            let conn = conn.lock();
+            // §Q B3 anti-rollback, ATOMIC at the row: the DO UPDATE only
+            // fires when the incoming revision is STRICTLY higher;
+            // changed-rows == 0 ⇒ refused (the Engine surfaces
+            // RevisionRollback). Identical semantics to the PG dialect.
+            let n = conn.execute(
+                "INSERT INTO storage_budget_installed (\
+                     node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at\
+                 ) VALUES (?1,?2,?3,?4,?5,?6,?7) \
+                 ON CONFLICT (node_id) DO UPDATE SET \
+                     revision = excluded.revision, \
+                     epoch_id = excluded.epoch_id, \
+                     scopes = excluded.scopes, \
+                     pinned_class = excluded.pinned_class, \
+                     wire = excluded.wire, \
+                     installed_at = excluded.installed_at \
+                 WHERE storage_budget_installed.revision < excluded.revision",
+                rusqlite::params![
+                    node_id,
+                    revision,
+                    epoch_id,
+                    scopes,
+                    pinned_class,
+                    wire_json,
+                    installed_at
+                ],
+            )?;
+            Ok(n > 0)
+        })()
+        .map_err(|e| Error::Backend(format!("put_installed_storage_budget: {e}")))
+    }
+
+    async fn get_installed_storage_budget(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let node_id = node_id.to_owned();
+        let conn = self.conn.clone();
+        let row = (move || -> Result<Option<InstalledBudgetColumns>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at \
+                 FROM storage_budget_installed WHERE node_id = ?1",
+            )?;
+            let mut rows =
+                stmt.query_map(rusqlite::params![node_id], sqlite_installed_budget_row)?;
+            rows.next().transpose()
+        })()
+        .map_err(|e| Error::Backend(format!("get_installed_storage_budget: {e}")))?;
+        row.map(decode_installed_storage_budget).transpose()
+    }
+
+    async fn list_installed_storage_budgets(
+        &self,
+    ) -> Result<Vec<crate::fountain::storage_contention::InstalledStorageBudget>, Error> {
+        let conn = self.conn.clone();
+        let rows = (move || -> Result<Vec<InstalledBudgetColumns>, rusqlite::Error> {
+            let conn = conn.lock();
+            let mut stmt = conn.prepare(
+                "SELECT node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at \
+                 FROM storage_budget_installed ORDER BY node_id ASC",
+            )?;
+            let rows = stmt
+                .query_map([], sqlite_installed_budget_row)?
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })()
+        .map_err(|e| Error::Backend(format!("list_installed_storage_budgets: {e}")))?;
+        rows.into_iter()
+            .map(decode_installed_storage_budget)
+            .collect()
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(
@@ -1698,6 +1789,49 @@ impl SqliteBackend {
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────
+
+/// #370 — raw `storage_budget_installed` column tuple
+/// (`node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at`).
+type InstalledBudgetColumns = (String, i64, String, String, String, String, String);
+
+/// #370 — map one `storage_budget_installed` row to its raw column tuple
+/// (`node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at`).
+fn sqlite_installed_budget_row(
+    row: &rusqlite::Row<'_>,
+) -> Result<InstalledBudgetColumns, rusqlite::Error> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+    ))
+}
+
+/// #370 — decode the raw column tuple into an
+/// [`InstalledStorageBudget`](crate::fountain::storage_contention::InstalledStorageBudget).
+fn decode_installed_storage_budget(
+    (node_id, revision, epoch_id, scopes, pinned_class, wire, installed_at): InstalledBudgetColumns,
+) -> Result<crate::fountain::storage_contention::InstalledStorageBudget, Error> {
+    Ok(
+        crate::fountain::storage_contention::InstalledStorageBudget {
+            node_id,
+            revision: u64::try_from(revision)
+                .map_err(|_| Error::Backend("installed budget revision negative".into()))?,
+            epoch_id,
+            scopes: serde_json::from_str(&scopes)
+                .map_err(|e| Error::Backend(format!("decode budget scopes: {e}")))?,
+            pinned_class: serde_json::from_str(&pinned_class)
+                .map_err(|e| Error::Backend(format!("decode budget pinned_class: {e}")))?,
+            wire_json: wire,
+            installed_at: chrono::DateTime::parse_from_rfc3339(&installed_at)
+                .map_err(|e| Error::Backend(format!("decode budget installed_at: {e}")))?
+                .with_timezone(&chrono::Utc),
+        },
+    )
+}
 
 fn opt_text(v: Option<&str>) -> SqlValue {
     match v {
@@ -8773,7 +8907,7 @@ impl SqliteBackend {
         (move || -> Result<Vec<crate::federation::EvictionCandidate>, rusqlite::Error> {
             let conn = conn.lock();
             let mut stmt = conn.prepare(
-                "SELECT sha256, size_bytes, access_count, last_accessed_at \
+                "SELECT sha256, size_bytes, access_count, last_accessed_at, media_type \
                      FROM federation_blobs \
                      ORDER BY last_accessed_at ASC, access_count ASC \
                      LIMIT ?1",
@@ -8783,11 +8917,12 @@ impl SqliteBackend {
                 let size_bytes: i64 = r.get(1)?;
                 let access_count: i64 = r.get(2)?;
                 let last_str: String = r.get(3)?;
-                Ok((sha_vec, size_bytes, access_count, last_str))
+                let media_type: Option<String> = r.get(4)?;
+                Ok((sha_vec, size_bytes, access_count, last_str, media_type))
             })?;
             let mut out = Vec::new();
             for row in rows {
-                let (sha_vec, size_bytes, access_count, last_str) = row?;
+                let (sha_vec, size_bytes, access_count, last_str, media_type) = row?;
                 let mut sha = [0u8; 32];
                 if sha_vec.len() != 32 {
                     // Defense in depth — schema enforces 32-byte
@@ -8809,11 +8944,45 @@ impl SqliteBackend {
                     // from the signer's holds_bytes index, not the blob
                     // table (which has no attesting_key_id column).
                     attesting_key_id: None,
+                    // v12.7.0 (§Q B5, #370): the corpus-class token the
+                    // Engine matches against the installed pinned_class
+                    // set.
+                    media_type,
                 });
             }
             Ok(out)
         })()
         .map_err(|e| crate::federation::BlobError::Backend(format!("sweep_candidates: {e}")))
+    }
+
+    /// v12.7.0 (§Q B5 / CIRISPersist#370) — total bytes currently held by
+    /// blobs whose `media_type` is one of `media_types` (the installed
+    /// `pinned_class` set). §Q consumption accounting is edge-internal —
+    /// recomputed from held content, never taken from the wire. Empty set
+    /// ⇒ 0. PG parity: `PostgresBackend::pinned_blob_bytes`.
+    pub async fn pinned_blob_bytes(
+        &self,
+        media_types: &[String],
+    ) -> Result<u64, crate::federation::BlobError> {
+        if media_types.is_empty() {
+            return Ok(0);
+        }
+        let media_types = media_types.to_vec();
+        let conn = self.conn.clone();
+        (move || -> Result<u64, rusqlite::Error> {
+            let conn = conn.lock();
+            let placeholders = vec!["?"; media_types.len()].join(",");
+            let sql = format!(
+                "SELECT COALESCE(SUM(size_bytes), 0) FROM federation_blobs \
+                 WHERE media_type IN ({placeholders})"
+            );
+            let total: i64 =
+                conn.query_row(&sql, rusqlite::params_from_iter(media_types.iter()), |r| {
+                    r.get(0)
+                })?;
+            Ok(total.max(0) as u64)
+        })()
+        .map_err(|e| crate::federation::BlobError::Backend(format!("pinned_blob_bytes: {e}")))
     }
 
     /// v3.4.0 (CIRISPersist#123) — delete one `federation_blobs` row

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1785,6 +1785,9 @@ impl SqliteBackend {
                 )));
             }
             row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
+            // v12.7.0 (CIRISPersist#365) — same consent_role admission
+            // gate as put_public_key (backend-symmetric with PG's twin).
+            crate::federation::types::consent_role::check_admissible(row.consent_role.as_deref())?;
             let envelope_text = serde_json::to_string(&row.registration_envelope)
                 .map_err(|e| crate::federation::Error::Backend(format!("envelope: {e}")))?;
             let attestation_text: Option<String> =
@@ -1812,8 +1815,8 @@ impl SqliteBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence\
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18) \
+                        attestation_evidence, consent_role\
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19) \
                      ON CONFLICT (key_id) DO NOTHING",
                     rusqlite::params![
                         row.key_id,
@@ -1836,6 +1839,11 @@ impl SqliteBackend {
                         row.persist_row_hash,
                         roles_text,
                         attestation_text,
+                        // v12.7.0 (CIRISPersist#365) — wire None ⇔ the
+                        // stored V020 'unregistered' default (NOT NULL).
+                        crate::federation::types::consent_role::stored_from_wire(
+                            row.consent_role.as_deref(),
+                        ),
                     ],
                 )?;
                 Ok(())
@@ -1939,6 +1947,12 @@ impl SqliteBackend {
             let conn = conn.lock();
             // The WHERE re-asserts the guards atomically: self-signed + same
             // pubkey. The Ed25519 pubkey is the guard, so it is NOT updated.
+            //
+            // v12.7.0 (CIRISPersist#365, CC 3.4.7.2): `consent_role` is
+            // deliberately NOT in the SET list — it is an operational role
+            // marker (its OQ-1 overwrite surface is `set_consent_role`),
+            // not registration content; an anchor-scrub upgrade must not
+            // clobber an assigned role.
             conn.execute(
                 "UPDATE federation_keys SET \
                     pubkey_ml_dsa_65_base64 = ?2, algorithm = ?3, identity_type = ?4, \
@@ -2072,6 +2086,14 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     crate::federation::Error::Backend(format!("roles serialize: {e}"))
                 })?)
             };
+        // v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — admission-gate the
+        // token (Rust-level; SQLite's V020 ALTER could not add the PG
+        // CHECK, this keeps the backends symmetric), then map wire None
+        // ⇔ the stored V020 'unregistered' default (NOT NULL column).
+        crate::federation::types::consent_role::check_admissible(row.consent_role.as_deref())?;
+        let consent_role_stored =
+            crate::federation::types::consent_role::stored_from_wire(row.consent_role.as_deref())
+                .to_owned();
         let conn = self.conn.clone();
         (move || -> Result<(), rusqlite::Error> {
             let conn = conn.lock();
@@ -2081,8 +2103,8 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                     original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                     scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence\
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                    attestation_evidence, consent_role\
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                 rusqlite::params![
                     row.key_id,
                     row.pubkey_ed25519_base64,
@@ -2102,6 +2124,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                     row.persist_row_hash,
                     roles_text,
                     attestation_evidence_text,
+                    consent_role_stored,
                 ],
             )?;
             Ok(())
@@ -2124,7 +2147,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence \
+                        attestation_evidence, consent_role \
                      FROM federation_keys WHERE key_id = ?1",
                     [&key_id],
                     sqlite_row_to_key_record,
@@ -2148,7 +2171,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence \
+                        attestation_evidence, consent_role \
                      FROM federation_keys WHERE identity_ref = ?1",
                 )?;
                 let rows = stmt.query_map([&identity_ref], sqlite_row_to_key_record)?;
@@ -2175,7 +2198,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence \
+                        attestation_evidence, consent_role \
                      FROM federation_keys WHERE identity_type = ?1 \
                      ORDER BY key_id",
                 )?;
@@ -2185,6 +2208,38 @@ impl crate::federation::FederationDirectory for SqliteBackend {
         .map_err(|e| {
             crate::federation::Error::Backend(format!("list_keys_by_identity_type: {e}"))
         })
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1) — overwrite-on-revoke
+    /// consent_role. Flat UPDATE of the single V020 column; `None` resets
+    /// to the stored `'unregistered'` default (revoke). No chain — a
+    /// subsequent call overwrites. Excluded from `persist_row_hash`, so
+    /// this does not touch the signed row.
+    async fn set_consent_role(
+        &self,
+        key_id: &str,
+        consent_role: Option<&str>,
+    ) -> Result<(), crate::federation::Error> {
+        crate::federation::types::consent_role::check_admissible(consent_role)?;
+        let stored =
+            crate::federation::types::consent_role::stored_from_wire(consent_role).to_owned();
+        let conn = self.conn.clone();
+        let key_id = key_id.to_owned();
+        let key_id_for_exec = key_id.clone();
+        let n = (move || -> Result<usize, rusqlite::Error> {
+            let conn = conn.lock();
+            conn.execute(
+                "UPDATE federation_keys SET consent_role = ?2 WHERE key_id = ?1",
+                rusqlite::params![key_id_for_exec, stored],
+            )
+        })()
+        .map_err(|e| crate::federation::Error::Backend(format!("set_consent_role: {e}")))?;
+        if n == 0 {
+            return Err(crate::federation::Error::InvalidArgument(format!(
+                "set_consent_role: no federation_keys row for {key_id}"
+            )));
+        }
+        Ok(())
     }
 
     async fn put_attestation(
@@ -5784,6 +5839,7 @@ impl crate::federation::FederationDirectory for SqliteBackend {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         key.persist_row_hash = crate::federation::types::compute_persist_row_hash(&key)?;
 
@@ -5836,8 +5892,8 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         identity_type, identity_ref, valid_from, valid_until, registration_envelope, \
                         original_content_hash, scrub_signature_classical, scrub_signature_pqc, \
                         scrub_key_id, scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                        attestation_evidence\
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18) \
+                        attestation_evidence, consent_role\
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19) \
                      ON CONFLICT(key_id) DO NOTHING",
                     rusqlite::params![
                         key_id_owned,
@@ -5858,6 +5914,10 @@ impl crate::federation::FederationDirectory for SqliteBackend {
                         key_hash,
                         Option::<String>::None,
                         Option::<String>::None,
+                        // v12.7.0 (CIRISPersist#365) — the V020 column is
+                        // NOT NULL; peer rows carry the 'unregistered'
+                        // default (wire None).
+                        crate::federation::types::consent_role::UNREGISTERED,
                     ],
                 )?;
 
@@ -9824,6 +9884,18 @@ fn sqlite_row_to_key_record(
         .as_deref()
         .filter(|s| !s.is_empty())
         .and_then(|s| serde_json::from_str(s).ok());
+    // v12.7.0 (CIRISPersist#365, CC 3.4.7.2): consent_role is the V020
+    // `TEXT NOT NULL DEFAULT 'unregistered'` column. Tolerant read
+    // (matching roles/attestation_evidence) — an absent column maps to
+    // None, and the stored 'unregistered' default maps to wire None
+    // (`consent_role::wire_from_stored`).
+    let consent_role: Option<String> = row
+        .get::<_, Option<String>>("consent_role")
+        .ok()
+        .flatten()
+        .as_deref()
+        .and_then(crate::federation::types::consent_role::wire_from_stored)
+        .map(str::to_owned);
     Ok(crate::federation::KeyRecord {
         key_id: row.get("key_id")?,
         pubkey_ed25519_base64: row.get("pubkey_ed25519_base64")?,
@@ -9843,6 +9915,7 @@ fn sqlite_row_to_key_record(
         persist_row_hash: row.get("persist_row_hash")?,
         roles,
         attestation_evidence,
+        consent_role,
     })
 }
 
@@ -12390,7 +12463,7 @@ impl crate::read::ReadEngine for SqliteBackend {
                     registration_envelope, original_content_hash, \
                     scrub_signature_classical, scrub_signature_pqc, scrub_key_id, \
                     scrub_timestamp, pqc_completed_at, persist_row_hash, roles, \
-                    attestation_evidence \
+                    attestation_evidence, consent_role \
              FROM federation_keys {where_sql} \
              ORDER BY valid_from DESC, key_id DESC LIMIT ?{p_limit}"
         );
@@ -15096,6 +15169,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 
@@ -22307,6 +22381,150 @@ mod tests {
         assert!(got.roles.contains(&"cirislens_secrets_reader".to_owned()));
     }
 
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2) — consent_role round-trips
+    /// through put_public_key → lookup_public_key, and
+    /// persist_row_hash is INDEPENDENT of the role (OQ-1: excluded from
+    /// the signed-registration hash).
+    #[tokio::test]
+    async fn consent_role_round_trip_and_hash_independent_sqlite() {
+        use crate::federation::types::consent_role;
+        let backend = trust_test_backend().await;
+
+        // Baseline row with NO consent_role → None on read (the V020
+        // stored 'unregistered' default maps to wire None).
+        let plain = fed_key("k-cr-none", "primitive-cr", "registry-steward");
+        backend
+            .put_public_key(SignedKeyRecord { record: plain })
+            .await
+            .unwrap();
+        let got = FederationDirectory::lookup_public_key(&backend, "k-cr-none")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.consent_role, None);
+
+        // Row born with consent_role = peer → round-trips.
+        let mut keyed = fed_key("k-cr-peer", "primitive-cr", "registry-steward");
+        keyed.consent_role = Some(consent_role::PEER.to_owned());
+        backend
+            .put_public_key(SignedKeyRecord { record: keyed })
+            .await
+            .unwrap();
+        let got = FederationDirectory::lookup_public_key(&backend, "k-cr-peer")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.consent_role.as_deref(), Some(consent_role::PEER));
+
+        // An unrecognized token is rejected at admission (Rust-level, so
+        // CHECK-less SQLite matches the PG V020 CHECK).
+        let mut bogus = fed_key("k-cr-bogus", "primitive-cr", "registry-steward");
+        bogus.consent_role = Some("emperor".into());
+        let err = backend
+            .put_public_key(SignedKeyRecord { record: bogus })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+
+        // persist_row_hash is INDEPENDENT of consent_role (OQ-1: excluded
+        // from the signed-registration hash) — compute over the same
+        // identity with the field unset vs set and require byte-equality.
+        let mut same_ident = fed_key("k-cr-hash", "primitive-cr", "registry-steward");
+        same_ident.consent_role = None;
+        let hash_no_role = crate::federation::types::compute_persist_row_hash(&same_ident).unwrap();
+        same_ident.consent_role = Some(consent_role::AUTHORIZED_REVIEW.to_owned());
+        let hash_with_role =
+            crate::federation::types::compute_persist_row_hash(&same_ident).unwrap();
+        assert_eq!(
+            hash_no_role, hash_with_role,
+            "consent_role must not affect persist_row_hash"
+        );
+    }
+
+    /// v12.7.0 (CIRISPersist#365, CC 3.4.7.2 OQ-1) — set_consent_role is
+    /// non-recursive overwrite-on-revoke, and consent_role_of resolves the
+    /// current value. Absent role and revoked-to-None both resolve to None.
+    #[tokio::test]
+    async fn consent_role_oq1_overwrite_and_resolver_sqlite() {
+        use crate::federation::consent::consent_role_of;
+        use crate::federation::types::consent_role;
+        let backend = trust_test_backend().await;
+        let key = fed_key("k-cr-oq1", "primitive-cr", "registry-steward");
+        backend
+            .put_public_key(SignedKeyRecord { record: key })
+            .await
+            .unwrap();
+
+        // Absent role → resolver None.
+        assert_eq!(consent_role_of(&backend, "k-cr-oq1").await.unwrap(), None);
+
+        // Assign temporary (a base consent role).
+        FederationDirectory::set_consent_role(&backend, "k-cr-oq1", Some(consent_role::TEMPORARY))
+            .await
+            .unwrap();
+        assert_eq!(
+            consent_role_of(&backend, "k-cr-oq1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(consent_role::TEMPORARY)
+        );
+
+        // OQ-1 overwrite → authorized_review (no chain; prior value gone).
+        FederationDirectory::set_consent_role(
+            &backend,
+            "k-cr-oq1",
+            Some(consent_role::AUTHORIZED_REVIEW),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            consent_role_of(&backend, "k-cr-oq1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(consent_role::AUTHORIZED_REVIEW)
+        );
+
+        // Revoke (overwrite back to the stored 'unregistered' default).
+        FederationDirectory::set_consent_role(&backend, "k-cr-oq1", None)
+            .await
+            .unwrap();
+        assert_eq!(consent_role_of(&backend, "k-cr-oq1").await.unwrap(), None);
+
+        // Setting the literal 'unregistered' token behaves as revoke
+        // (wire None) — stored/wire forms cohere.
+        FederationDirectory::set_consent_role(&backend, "k-cr-oq1", Some(consent_role::PEER))
+            .await
+            .unwrap();
+        FederationDirectory::set_consent_role(
+            &backend,
+            "k-cr-oq1",
+            Some(consent_role::UNREGISTERED),
+        )
+        .await
+        .unwrap();
+        assert_eq!(consent_role_of(&backend, "k-cr-oq1").await.unwrap(), None);
+
+        // An unrecognized token is rejected (backend-symmetric admission).
+        let err = FederationDirectory::set_consent_role(&backend, "k-cr-oq1", Some("emperor"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+
+        // set_consent_role on an unknown key errors.
+        let err = FederationDirectory::set_consent_role(&backend, "k-cr-missing", Some("peer"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+
+        // Resolver on an absent key is total → Ok(None).
+        assert_eq!(
+            consent_role_of(&backend, "k-cr-missing").await.unwrap(),
+            None
+        );
+    }
+
     // ─── Pipeline read+write tests (v1.5.8, CIRISPersist#57) ────────
     //
     // V023 parity sweep: mirrors postgres.rs::pipeline_read_features_and_
@@ -28108,6 +28326,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         };
         backend
             .put_public_key(SignedKeyRecord { record })

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1319,6 +1319,48 @@ impl Backend for SqliteBackend {
             .collect()
     }
 
+    // #227 (residual) — consent-decay clock enumerator (disk-independent).
+    async fn list_fountain_decay_candidates(
+        &self,
+    ) -> Result<Vec<crate::fountain::FountainDecayCandidate>, Error> {
+        let conn = self.conn.clone();
+        (move || -> Result<Vec<crate::fountain::FountainDecayCandidate>, Error> {
+            let conn = conn.lock();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT content_id, corpus_kind, envelope, admitted_at \
+                     FROM content_manifest",
+                )
+                .map_err(|e| Error::Backend(format!("list_fountain_decay_candidates: {e}")))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let content_id: String = row.get(0)?;
+                    let corpus_kind: String = row.get(1)?;
+                    let envelope_text: String = row.get(2)?;
+                    let admitted_at_text: String = row.get(3)?;
+                    Ok((content_id, corpus_kind, envelope_text, admitted_at_text))
+                })
+                .map_err(|e| Error::Backend(format!("list_fountain_decay_candidates: {e}")))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| Error::Backend(format!("list_fountain_decay_candidates: {e}")))?;
+            let mut out = Vec::with_capacity(rows.len());
+            for (content_id, corpus_kind, envelope_text, admitted_at_text) in rows {
+                let envelope: serde_json::Value = serde_json::from_str(&envelope_text)
+                    .map_err(|e| Error::Backend(format!("decay candidate envelope: {e}")))?;
+                let admitted_at = chrono::DateTime::parse_from_rfc3339(&admitted_at_text)
+                    .map_err(|e| Error::Backend(format!("decay candidate admitted_at: {e}")))?
+                    .with_timezone(&chrono::Utc);
+                out.push(crate::fountain::FountainDecayCandidate {
+                    content_id,
+                    corpus_kind,
+                    envelope,
+                    admitted_at,
+                });
+            }
+            Ok(out)
+        })()
+    }
+
     // ─── v8.3.0 — §19.7 inter-object aggregation (CIRISPersist#230) ──
 
     async fn put_aggregated_tier(

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2240,13 +2240,12 @@ impl crate::federation::FederationDirectory for SqliteBackend {
 
         // v6.7.0 (CIRISPersist#146 Ask 5, CEG §5.6.8.7) — `consent_record`
         // ceremony admission (required fields / closed stance set /
-        // substrate-only `expired` / §10.1.3 revoked-not-local). No-op for
-        // every non-`consent_record` row.
-        crate::federation::admission::check_consent_record_admission(
-            &row.attestation_type,
-            &row.attestation_envelope,
-            &row.tier,
-        )?;
+        // substrate-only `expired`). v12.6.0 (CIRISPersist#171, §10.1.3
+        // transit-not-rest): a `revoked` consent_record at local tier MAY
+        // *transit* the local write path only if its bound-hybrid signature
+        // verifies (accept on VALID crypto only). No-op for non-consent_record
+        // rows and durable ones. Backend-symmetric with Memory + Postgres.
+        crate::federation::admission::verify_consent_record_transit_ingest(self, &row).await?;
 
         // v3.9.1 (CIRISPersist#150 Ask 3, CEG 0.4 §4.2.4) — cohort_scope
         // admission-gate validation. Rejects out-of-closed-set values
@@ -9869,8 +9868,9 @@ impl SqliteBackend {
             )
         })?;
 
-        // §4.1 local-tier gate: refuse capacity:* + subject-side revocation.
-        crate::federation::admission::check_local_tier_eligibility(
+        // §4.1 local-tier gate: refuse capacity:*; classify subject-side
+        // revocation as TRANSIT (§10.1.3 transit-not-rest).
+        let disposition = crate::federation::admission::check_local_tier_eligibility(
             &input.attestation_type,
             Some(dimension.as_str()),
             &input.attesting_key_id,
@@ -9880,6 +9880,17 @@ impl SqliteBackend {
 
         // cohort_scope value validation (closed set).
         crate::federation::admission::check_cohort_scope(&input.cohort_scope)?;
+
+        // v12.6.0 (CIRISPersist#171, §10.1.3) — a subject-side revocation MAY
+        // *transit* the local write path only if its bound-hybrid signature
+        // verifies (accept on VALID crypto only). `None` for a durable
+        // producer-authority row. Runs before the DB write.
+        let transit = crate::federation::admission::verify_local_transit_revocation(
+            self,
+            disposition,
+            &input,
+        )
+        .await?;
 
         // FK precondition + §7.0.1 emitter gate: the attesting key must
         // exist; its identity_type gates the dimension. Mirrors
@@ -9912,19 +9923,31 @@ impl SqliteBackend {
             &identity_type,
         )?;
 
-        // Build the local row + its persist_row_hash.
+        // Build the local row + its persist_row_hash. A durable row defers
+        // its signature (empty-sentinel scrub envelope); a TRANSIT revocation
+        // carries the caller's verified bound-hybrid signature + computed hash.
         let attestation_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
         let attesting_key_id = input.attesting_key_id.clone();
-        let mut row = input.into_local_row(attestation_id.clone(), now);
+        let mut row = match transit {
+            Some((hash, sig_classical, sig_pqc)) => input.into_transit_revocation_row(
+                attestation_id.clone(),
+                now,
+                hash,
+                sig_classical,
+                sig_pqc,
+            ),
+            None => input.into_local_row(attestation_id.clone(), now),
+        };
         row.persist_row_hash = crate::federation::types::compute_persist_row_hash(&row)?;
 
         let envelope_text = serde_json::to_string(&row.attestation_envelope)
             .map_err(|e| Error::Backend(format!("envelope serialize: {e}")))?;
         let subject_key_ids_json = serde_json::to_string(&row.subject_key_ids)
             .map_err(|e| Error::Backend(format!("subject_key_ids serialize: {e}")))?;
-        // Empty-sentinel scrub envelope: original_content_hash hex "" → [].
-        let original_content_hash: Vec<u8> = Vec::new();
+        // BLOB bytes: durable row hex "" → []; transit row = SHA-256 digest.
+        let original_content_hash: Vec<u8> = hex::decode(&row.original_content_hash)
+            .map_err(|e| Error::Backend(format!("original_content_hash hex decode: {e}")))?;
         let conn = self.conn.clone();
 
         (move || -> Result<(), rusqlite::Error> {
@@ -15899,9 +15922,10 @@ mod tests {
         assert!(
             matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("substrate-emitted only"))
         );
-        // revoked / local → reject (§10.1.3).
+        // revoked / local (v12.6.0, §10.1.3 transit-not-rest): a crypto-VALID
+        // one TRANSITS the local tier (accepted); a forged one is rejected.
         let rid = format!("r-{}", uuid::Uuid::new_v4());
-        let err = backend
+        backend
             .put_attestation(SignedAttestation {
                 attestation: mk(
                     &rid,
@@ -15910,9 +15934,26 @@ mod tests {
                 ),
             })
             .await
+            .expect("crypto-valid revoked consent_record transits the local tier");
+        let bid = format!("rb-{}", uuid::Uuid::new_v4());
+        let mut forged = mk(
+            &bid,
+            crate::federation::types::consent_record::stance::REVOKED,
+            crate::federation::types::attestation_tier::LOCAL,
+        );
+        forged.scrub_signature_classical = "AAAA".into(); // not a valid sig
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: forged,
+            })
+            .await
             .unwrap_err();
         assert!(
-            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("local-tier-eligible"))
+            matches!(
+                err,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "forged revoked/local consent_record rejected at admission, got {err:?}"
         );
     }
 
@@ -20099,6 +20140,8 @@ mod tests {
             }),
             subject_key_ids: subjects,
             cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+            scrub_signature_classical: None,
+            scrub_signature_pqc: None,
         }
     }
 
@@ -20255,8 +20298,9 @@ mod tests {
     #[tokio::test]
     async fn sqlite_local_rejects_subject_side_revocation() {
         let backend = fresh_backend_with_occurrence("occ").await;
-        // withdraws where the writer is in subject_key_ids = a subject-side
-        // revocation → must be federation-tier signed (§10.1.3).
+        // A subject-side revocation (writer ∈ subject_key_ids) with NO signature
+        // is rejected at admission (§10.1.3 transit-not-rest): it may transit the
+        // local tier only on a VALID bound-hybrid signature — never unsigned.
         let err = backend
             .attestation_upsert_local(local_input(
                 "occ",
@@ -20267,8 +20311,109 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation")),
+            matches!(err, crate::federation::Error::InvalidArgument(ref m) if m.contains("revocation") && m.contains("bound-hybrid signature")),
             "got: {err:?}"
+        );
+    }
+
+    /// v12.6.0 (CIRISPersist#171, §10.1.3 transit-not-rest) — SQLite parity for
+    /// the FULL consent-SLA loop through the REAL admission path: a crypto-valid
+    /// subject-side `consent:state:revoked` is ADMITTED as a transit local-tier
+    /// write, the revocation scan sees it, and `run_consent_sla_watch` fires
+    /// `consent_revocation_promotion_overdue` past the 24 h window (not before).
+    /// A crypto-INVALID one is rejected at admission.
+    #[tokio::test]
+    async fn sqlite_consent_revocation_transit_admits_and_sla_fires_end_to_end() {
+        use crate::federation::hard_case::{kind, HardCaseFilter};
+        use crate::federation::tier_ingest::test_support::sign_envelope;
+        use crate::federation::types::{attestation_tier, attestation_type, LocalAttestationInput};
+        use std::time::Duration;
+        let backend = fresh_backend_with_occurrence("subject-c").await;
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fed_key("target-c", "registry", "target-c"),
+            })
+            .await
+            .unwrap();
+
+        let env = serde_json::json!({
+            "id": "rev-c", "dimension": "consent:state:revoked:v1",
+            "score": 1.0, "confidence": 0.9,
+        });
+        let (_hash, sig_classical, sig_pqc) = sign_envelope("subject-c", &env);
+
+        backend
+            .attestation_upsert_local(LocalAttestationInput {
+                attesting_key_id: "subject-c".into(),
+                attested_key_id: Some("target-c".into()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: env.clone(),
+                subject_key_ids: vec!["subject-c".into()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some(sig_classical),
+                scrub_signature_pqc: sig_pqc,
+            })
+            .await
+            .expect("crypto-valid subject-side revocation transits the local tier");
+
+        let rows = backend.list_consent_revocations(None).await.unwrap();
+        assert_eq!(rows.len(), 1, "revocation scan sees the transit row");
+        let rev = &rows[0];
+        assert_eq!(rev.tier, attestation_tier::LOCAL);
+        assert!(rev.promoted_at.is_none());
+        assert!(
+            !rev.scrub_signature_classical.is_empty() && rev.scrub_signature_pqc.is_some(),
+            "transit row round-trips its real bound-hybrid signature"
+        );
+        let revoked_at = rev.asserted_at;
+        let window = Duration::from_secs(86_400);
+
+        let before = revoked_at + chrono::Duration::seconds(86_400 - 1);
+        let r = backend.run_consent_sla_watch(before, window).await.unwrap();
+        assert_eq!(r.revocations_scanned, 1);
+        assert_eq!(r.promotion_overdue, 0, "within window: not overdue");
+
+        let after = revoked_at + chrono::Duration::seconds(86_400 + 1);
+        let r = backend.run_consent_sla_watch(after, window).await.unwrap();
+        assert_eq!(r.promotion_overdue, 1, "past window: overdue fires");
+        let evs = backend
+            .list_hard_case_events(HardCaseFilter {
+                kind: Some(kind::CONSENT_REVOCATION_PROMOTION_OVERDUE.into()),
+                since: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(evs.len(), 1);
+        assert_eq!(evs[0].target_key_id.as_deref(), Some("target-c"));
+        assert_eq!(evs[0].subject_key_id.as_deref(), Some("subject-c"));
+
+        // crypto-INVALID revocation → rejected at admission.
+        let bad = backend
+            .attestation_insert_local(LocalAttestationInput {
+                attesting_key_id: "subject-c".into(),
+                attested_key_id: Some("target-c".into()),
+                attestation_type: attestation_type::SCORES.into(),
+                weight: None,
+                expires_at: None,
+                attestation_envelope: serde_json::json!({
+                    "id": "rev-bad", "dimension": "consent:state:revoked:v1",
+                    "score": 1.0, "confidence": 0.9,
+                }),
+                subject_key_ids: vec!["subject-c".into()],
+                cohort_scope: crate::federation::types::cohort_scope::SELF.to_string(),
+                scrub_signature_classical: Some("AAAA".into()),
+                scrub_signature_pqc: Some("AAAA".into()),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                bad,
+                crate::federation::Error::FederationTierUnverified { .. }
+            ),
+            "crypto-invalid revocation rejected at admission, got {bad:?}"
         );
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1996,6 +1996,55 @@ impl SqliteBackend {
         }
         Ok(AdoptScrubOutcome::Upgraded)
     }
+
+    /// v12.7.0 (CIRISPersist#371) — **upgrade-aware replicated Key-plane
+    /// apply**. The anti-entropy apply the edge replication bridge routes
+    /// `apply_key` to, replacing its raw `put_public_key` call (which stays
+    /// unchanged for direct registration): a fresh `key_id` inserts as today,
+    /// and an anchor-scrubbed record arriving at a node that already holds
+    /// the SAME identity's **self-signed** row auto-upgrades it in place —
+    /// the [`adopt_scrub_upgrade`](Self::adopt_scrub_upgrade) path riding
+    /// replication instead of a per-node out-of-band endpoint call.
+    ///
+    /// All policy lives in the shared, backend-agnostic
+    /// [`plan_replicated_key_apply`](crate::federation::register::plan_replicated_key_apply)
+    /// (see its decision table): the `verify_key_registration` Strict scrub
+    /// gate and the v12.6.0 `owner_of` single-owner gate run INSIDE this
+    /// method (unlike #351's Engine-layer split), so no caller can reach the
+    /// upgrade transition unverified. Refusals are outcomes, not errors —
+    /// see [`ReplicatedKeyOutcome`](crate::federation::register::ReplicatedKeyOutcome).
+    /// A `Conflict` from the underlying store step (a row that changed
+    /// between plan and act) also resolves to `Refused`: on the replication
+    /// plane a lost race is fail-closed + re-offerable, never fatal.
+    pub async fn apply_replicated_key_record(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, crate::federation::Error> {
+        use crate::federation::register::{
+            plan_replicated_key_apply, AdoptScrubOutcome, ReplicatedKeyOutcome, ReplicatedKeyPlan,
+        };
+        match plan_replicated_key_apply(self, &record.record).await? {
+            ReplicatedKeyPlan::Unchanged => Ok(ReplicatedKeyOutcome::Unchanged),
+            ReplicatedKeyPlan::Refused => Ok(ReplicatedKeyOutcome::Refused),
+            ReplicatedKeyPlan::Insert => {
+                match crate::federation::FederationDirectory::put_public_key(self, record).await {
+                    Ok(()) => Ok(ReplicatedKeyOutcome::Inserted),
+                    // A row appeared between plan and act with different
+                    // content — first-seen wins on the replication plane.
+                    Err(crate::federation::Error::Conflict(_)) => Ok(ReplicatedKeyOutcome::Refused),
+                    Err(e) => Err(e),
+                }
+            }
+            ReplicatedKeyPlan::Upgrade => match self.adopt_scrub_upgrade(record).await {
+                Ok(AdoptScrubOutcome::Upgraded) => Ok(ReplicatedKeyOutcome::Upgraded),
+                Ok(AdoptScrubOutcome::AlreadyAdopted) => Ok(ReplicatedKeyOutcome::Unchanged),
+                // The atomic WHERE (or its Rust pre-checks) saw different
+                // state than the plan — a concurrent mutation. Fail-closed.
+                Err(crate::federation::Error::Conflict(_)) => Ok(ReplicatedKeyOutcome::Refused),
+                Err(e) => Err(e),
+            },
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -15284,6 +15333,115 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+    }
+
+    /// v12.7.0 (#371) — `apply_replicated_key_record` owner-gate fail-closed
+    /// rows that need a **pre-gate anomaly** (raw SQL, since the v12.6.0
+    /// single-owner admission gate refuses a second live owner going
+    /// forward): a node with TWO live owner-bindings resolves
+    /// `AmbiguousNodeOwner`, and a replicated anchor-scrubbed record for it
+    /// is Refused — never upgraded — leaving the self-signed row untouched.
+    /// (The rest of the #371 decision table runs Engine-level on both
+    /// backends in `federation::register::tests::run_apply_replicated_matrix`;
+    /// postgres twin of THIS anomaly test lives in `store::postgres::tests`.)
+    #[tokio::test]
+    async fn apply_replicated_key_record_ambiguous_owner_refused_sqlite() {
+        use crate::federation::register::ReplicatedKeyOutcome;
+        use crate::federation::tier_ingest::test_support as ts;
+        use crate::federation::types::identity_type;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        ts::register_hybrid_key(&backend, "apply-amb-anchor").await;
+        ts::register_identity_key(&backend, "apply-amb-owner1", identity_type::USER).await;
+        ts::register_identity_key(&backend, "apply-amb-owner2", identity_type::USER).await;
+        // The node's self-signed boot row.
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: ts::replicated_key_record(
+                    "apply-amb-node",
+                    identity_type::NODE,
+                    "apply-amb-node",
+                    "apply-amb-node",
+                    "v1",
+                ),
+            })
+            .await
+            .unwrap();
+
+        // owner1 binds through the admission gate…
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: ts::owner_binding_attestation(
+                    &uuid::Uuid::new_v4().to_string(),
+                    "apply-amb-owner1",
+                    "apply-amb-node",
+                ),
+            })
+            .await
+            .unwrap();
+        // …owner2's binding is the PRE-GATE anomaly, inserted via raw SQL
+        // (bypassing check_single_node_owner_admission, exactly the state a
+        // pre-v12.6.0 corpus can hold).
+        {
+            let anomaly = ts::owner_binding_attestation(
+                &uuid::Uuid::new_v4().to_string(),
+                "apply-amb-owner2",
+                "apply-amb-node",
+            );
+            let env_text = serde_json::to_string(&anomaly.attestation_envelope).unwrap();
+            let conn = backend.conn.clone();
+            (move || -> Result<(), rusqlite::Error> {
+                let conn = conn.lock();
+                conn.execute(
+                    "INSERT INTO federation_attestations (\
+                        attestation_id, attesting_key_id, attested_key_id, attestation_type, \
+                        asserted_at, attestation_envelope, original_content_hash, \
+                        scrub_signature_classical, scrub_key_id, scrub_timestamp, \
+                        persist_row_hash\
+                     ) VALUES (?1, 'apply-amb-owner2', 'apply-amb-node', 'delegates_to', \
+                        '2026-05-01T00:00:00+00:00', ?2, x'00', 'c2ln', 'apply-amb-owner2', \
+                        '2026-05-01T00:00:00+00:00', '0')",
+                    rusqlite::params![anomaly.attestation_id, env_text],
+                )?;
+                Ok(())
+            })()
+            .unwrap();
+        }
+        // The anomaly is real: owner_of fails AmbiguousNodeOwner.
+        let err = crate::federation::admission::owner_of(&backend, "apply-amb-node")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::federation::Error::AmbiguousNodeOwner { .. }),
+            "expected AmbiguousNodeOwner, got {err:?}"
+        );
+
+        // A VERIFIABLE anchor-scrubbed record for the node ⇒ Refused
+        // (fail-closed — an ambiguous owner is not a resolvable `self`
+        // boundary), and the self-signed row is untouched.
+        let scrubbed = ts::replicated_key_record(
+            "apply-amb-node",
+            identity_type::NODE,
+            "apply-amb-anchor",
+            "apply-amb-anchor",
+            "v1",
+        );
+        assert_eq!(
+            backend
+                .apply_replicated_key_record(SignedKeyRecord { record: scrubbed })
+                .await
+                .unwrap(),
+            ReplicatedKeyOutcome::Refused
+        );
+        let row = FederationDirectory::lookup_public_key(&backend, "apply-amb-node")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.scrub_key_id, "apply-amb-node",
+            "ambiguous-owner refusal must leave the self-signed row untouched"
+        );
     }
 
     /// v9.3.0 (#247) — the DERIVED federation key_id for `alias`'s

--- a/tests/fountain_content.rs
+++ b/tests/fountain_content.rs
@@ -28,6 +28,7 @@ use ed25519_dalek::{Signer as _, SigningKey};
 
 use ciris_persist::fountain::storage_contention::{
     assemble_storage_budget_wire, storage_budget_preimage, verify_storage_budget_wire,
+    InstalledStorageBudget,
 };
 use ciris_persist::fountain::{
     symbol_sha256_hex, FountainContent, FountainManifestV1, FountainSymbolV1, FountainTier,
@@ -140,18 +141,19 @@ async fn build_manifest_and_symbols(
 }
 
 /// §Q B6/N5 (CIRISPersist#359): build + VERIFY a signed `StorageBudgetV1`
-/// whose `pinned_class` covers `corpus_kind` with a non-zero
-/// `pin_reserve_bytes`. Returns the verified wire JSON. This proves a *valid,
-/// aggregator-signed* pin advertisement covering the subject_kind exists — the
-/// exact state B6 says must NOT shield content from revocation.
-async fn build_and_verify_trace_pin(corpus_kind: &str) -> String {
+/// bound to `node_id` whose `pinned_class` covers `corpus_kind` with a
+/// non-zero `pin_reserve_bytes`. Returns the verified wire JSON. This proves
+/// a *valid, aggregator-signed* pin advertisement covering the subject_kind
+/// exists — the exact state B6 says must NOT shield content from revocation.
+/// (#370: section (k) additionally INSTALLS one as durable pin state.)
+async fn build_and_verify_trace_pin(corpus_kind: &str, node_id: &str) -> String {
     let (ed_sk, ed_pk_b64, mldsa) = producer_pubkeys();
     let mldsa_pk_b64 = BASE64.encode(mldsa.public_key().await.unwrap());
 
     // A budget that PINS `corpus_kind` (in pinned_class) with a real byte
     // reserve — i.e. the strongest pin the §Q surface can express.
     let payload = format!(
-        r#"{{"node_id":"n-pin","epoch_id":"e1","revision":1,
+        r#"{{"node_id":"{node_id}","epoch_id":"e1","revision":1,
             "scopes":[{{"cohort_scope":"community","budget_bytes":100000,"pin_reserve_bytes":50000}}],
             "pinned_class":["{corpus_kind}"]}}"#
     );
@@ -379,13 +381,15 @@ async fn run_fountain_assertions<B: Backend>(backend: &B, suffix: &str) {
     // (j) §Q B6/N5 (CIRISPersist#359): PINNING NEVER DEFEATS REVOCATION.
     //     A *verified*, aggregator-signed StorageBudgetV1 whose pinned_class
     //     covers `corpus` ("trace") with pin_reserve_bytes > 0 does NOT shield
-    //     that content from hard-delete. The pin is a verified-at-ingest
-    //     advertisement, not stored pin STATE — there is no pin table and
-    //     evict_fountain_content_hard_delete has no §Q pin parameter, so the
-    //     pin structurally cannot reach the deletion path. B6: a pin holds
-    //     content above the floor against CAPACITY pressure only, never
-    //     against revocation.
-    let pin_wire = build_and_verify_trace_pin(corpus).await;
+    //     that content from hard-delete. Here the pin is a verified-at-ingest
+    //     ADVERTISEMENT only (never installed — the #359 thin form); as of
+    //     #370 durable pin STATE exists too, and section (k) below proves the
+    //     INSTALLED form is equally powerless against revocation. Either way,
+    //     evict_fountain_content_hard_delete has no §Q pin parameter and
+    //     reads no pin state, so a pin structurally cannot reach the deletion
+    //     path. B6: a pin holds content above the floor against CAPACITY
+    //     pressure only, never against revocation.
+    let pin_wire = build_and_verify_trace_pin(corpus, "n-pin").await;
     assert!(
         pin_wire.contains(corpus),
         "(j) the verified pin advertisement covers the subject_kind being revoked"
@@ -428,6 +432,84 @@ async fn run_fountain_assertions<B: Backend>(backend: &B, suffix: &str) {
     assert!(
         matches!(pin_revoked, FountainContent::EnvelopeOnly { .. }),
         "(j) pinned content → EnvelopeOnly after revocation, got {pin_revoked:?}"
+    );
+
+    // (k) §Q B6 with INSTALLED pin state (CIRISPersist#370): the pin-install
+    //     surface persists REAL pin state now (V092 storage_budget_installed
+    //     — the state the B5 capacity sweep honors), and revocation STILL
+    //     runs unconditionally: `evict_fountain_content_hard_delete` takes
+    //     only (content_id, corpus_kind) and reads no §Q state, so even an
+    //     installed, reserve-backed pin covering the class cannot shield it.
+    //     This is the staging the conformance B6 test wants: install a pin,
+    //     then prove revocation defeats it.
+    let pin_node = format!("n-pin-{suffix}");
+    let installed_wire = build_and_verify_trace_pin(corpus, &pin_node).await;
+    let installed = InstalledStorageBudget::from_wire_json(&installed_wire, chrono::Utc::now())
+        .expect("(k) verified wire denormalizes");
+    assert!(
+        backend
+            .put_installed_storage_budget(&installed)
+            .await
+            .expect("(k) install pin state"),
+        "(k) a fresh node_id installs"
+    );
+    // Read-back: the installed row is live pin state covering `corpus`.
+    let got = backend
+        .get_installed_storage_budget(&pin_node)
+        .await
+        .expect("(k) getter")
+        .expect("(k) installed row present");
+    assert_eq!(got.revision, 1);
+    assert!(
+        got.pinned_class.iter().any(|c| c == corpus),
+        "(k) the installed pin covers the subject_kind being revoked"
+    );
+    assert!(got.pin_reserve_total() > 0, "(k) a real byte reserve");
+    // §Q B3 anti-rollback at the row: an equal revision is refused.
+    assert!(
+        !backend
+            .put_installed_storage_budget(&installed)
+            .await
+            .expect("(k) re-put"),
+        "(k) equal revision refused (B3 anti-rollback)"
+    );
+    // Admit content of the PINNED class, then revoke — the INSTALLED pin
+    // must not shield it.
+    let kcid = format!("c-installed-pin-revoke-{suffix}");
+    let (kman, ksyms) =
+        build_manifest_and_symbols(&kcid, n_source, k_repair, symbol_size, true).await;
+    backend
+        .put_fountain_content(&kman, &ksyms)
+        .await
+        .expect("(k) admit installed-pinned-class content");
+    let kdropped = backend
+        .evict_fountain_content_hard_delete(&kcid, corpus)
+        .await
+        .expect("(k) hard delete over INSTALLED pinned class");
+    assert_eq!(
+        kdropped,
+        u64::from(total),
+        "(k) HardDelete drops ALL symbols even under an INSTALLED pin (§Q B6)"
+    );
+    assert_eq!(
+        backend
+            .get_fountain_content(&kcid, corpus)
+            .await
+            .unwrap()
+            .expect("(k) manifest survives as EnvelopeOnly")
+            .present(),
+        0,
+        "(k) installed pinning never defeats revocation — zero symbols survive"
+    );
+    // The pin state itself is untouched by the revocation (the two paths
+    // never meet): the row is still installed.
+    assert!(
+        backend
+            .get_installed_storage_budget(&pin_node)
+            .await
+            .unwrap()
+            .is_some(),
+        "(k) revocation neither consulted nor mutated the installed pin"
     );
 
     // (#227 publisher view) list_held_fountain_content — the publisher sees

--- a/tests/fountain_content.rs
+++ b/tests/fountain_content.rs
@@ -604,6 +604,363 @@ async fn postgres_fountain_content() {
     run_fountain_assertions(&backend, &suffix).await;
 }
 
+// ───────────────────────────────────────────────────────────────────
+// #227 (residual) — consent-decay clock, proven on BOTH durable backends.
+// ───────────────────────────────────────────────────────────────────
+
+/// Build + hybrid-sign a manifest whose signed envelope carries an extra
+/// object (e.g. the consent-decay class) merged over the producer pubkeys.
+async fn build_manifest_with_envelope(
+    content_id: &str,
+    n_source: u32,
+    k_repair: u32,
+    symbol_size: u32,
+    extra: serde_json::Value,
+) -> (FountainManifestV1, Vec<FountainSymbolV1>) {
+    let (ed_sk, ed_pk_b64, mldsa) = producer_pubkeys();
+    let (symbols, symbol_hashes) = synth_symbols(content_id, n_source, k_repair, symbol_size);
+    let pqc_pk = mldsa.public_key().await.unwrap();
+
+    let mut envelope = serde_json::json!({
+        "content_id": content_id,
+        "pubkey_ed25519": ed_pk_b64,
+        "pubkey_ml_dsa_65": BASE64.encode(&pqc_pk),
+    });
+    if let (Some(base), Some(add)) = (envelope.as_object_mut(), extra.as_object()) {
+        for (k, v) in add {
+            base.insert(k.clone(), v.clone());
+        }
+    }
+
+    let mut manifest = FountainManifestV1 {
+        content_id: content_id.to_owned(),
+        corpus_kind: "trace".to_owned(),
+        manifest_version: MANIFEST_VERSION_V1,
+        n_source,
+        k_repair,
+        symbol_size,
+        original_content_length: u64::from(n_source) * u64::from(symbol_size) - 3,
+        min_viable_symbols: 2,
+        symbol_hashes,
+        envelope,
+        signature: String::new(),
+        signature_ml_dsa_65: String::new(),
+        pqc_key_id: "fountain-mldsa".to_owned(),
+    };
+    let canonical = manifest
+        .canonical_bytes(&PythonJsonDumpsCanonicalizer)
+        .unwrap();
+    let ed_sig = ed_sk.sign(&canonical).to_bytes();
+    manifest.signature = BASE64.encode(ed_sig);
+    let mut bound = Vec::with_capacity(canonical.len() + ed_sig.len());
+    bound.extend_from_slice(&canonical);
+    bound.extend_from_slice(&ed_sig);
+    let pqc_sig = mldsa.sign(&bound).await.unwrap();
+    manifest.signature_ml_dsa_65 = BASE64.encode(&pqc_sig);
+    (manifest, symbols)
+}
+
+/// Shared body: the consent-decay clock decisions the
+/// `sweep_consent_decay_once` loop makes, per candidate, exercised on a
+/// migrated backend and scoped to `suffix`ed content_ids (so it is
+/// self-isolating on the shared PG twin). Mirrors the Engine sweep:
+/// enumerate → read decay class + admitted_at → `consent_decay_target_tier`
+/// → reuse `evict_fountain_content_to_tier`.
+async fn run_consent_decay_assertions<B: Backend>(backend: &B, suffix: &str) {
+    use ciris_persist::fountain::{consent_decay_target_tier, FountainReadClass};
+    let (n, k, size) = (8u32, 4u32, 16u32);
+    let total = u64::from(n + k);
+
+    let cid_temp = format!("c-decay-temp-{suffix}");
+    let cid_pat = format!("c-decay-pat-{suffix}");
+    let cid_none = format!("c-decay-none-{suffix}");
+
+    let (m_temp, s_temp) = build_manifest_with_envelope(
+        &cid_temp,
+        n,
+        k,
+        size,
+        serde_json::json!({ "consent_decay_class": "temporary" }),
+    )
+    .await;
+    let (m_pat, s_pat) = build_manifest_with_envelope(
+        &cid_pat,
+        n,
+        k,
+        size,
+        serde_json::json!({ "decay_protocol": "ciris-agent-90day" }),
+    )
+    .await;
+    // No decay class declared ⇒ the clock never touches it (fail-safe).
+    let (m_none, s_none) =
+        build_manifest_with_envelope(&cid_none, n, k, size, serde_json::json!({})).await;
+
+    for (m, s) in [(&m_temp, &s_temp), (&m_pat, &s_pat), (&m_none, &s_none)] {
+        backend.put_fountain_content(m, s).await.expect("admit");
+    }
+
+    // The enumerate method returns our three units with their admitted_at
+    // + the signed decay-class envelope (both backends, identical shape).
+    let candidates = backend
+        .list_fountain_decay_candidates()
+        .await
+        .expect("enumerate decay candidates");
+    let mine: std::collections::HashMap<String, _> = candidates
+        .into_iter()
+        .filter(|c| c.content_id.ends_with(suffix))
+        .map(|c| (c.content_id.clone(), c))
+        .collect();
+    assert!(mine.contains_key(&cid_temp), "temp enumerated");
+    assert!(mine.contains_key(&cid_pat), "pattern enumerated");
+    assert!(mine.contains_key(&cid_none), "unclassed enumerated");
+    // The unclassed unit resolves to no target tier ⇒ never decayed.
+    let none_cand = &mine[&cid_none];
+    assert_eq!(
+        consent_decay_target_tier(
+            &none_cand.envelope,
+            none_cand.admitted_at,
+            none_cand.admitted_at + chrono::Duration::days(365)
+        ),
+        None,
+        "no decay class ⇒ clock opts out"
+    );
+
+    let temp_admitted = mine[&cid_temp].admitted_at;
+    let pat_admitted = mine[&cid_pat].admitted_at;
+    let temp_env = mine[&cid_temp].envelope.clone();
+    let pat_env = mine[&cid_pat].envelope.clone();
+
+    // A single per-candidate step, exactly as the sweep does it: resolve
+    // the target tier at `now`; evict via the shared mechanism unless the
+    // clock is still at `Full`. Returns symbols evicted this step.
+    async fn decay_step<B: Backend>(
+        backend: &B,
+        cid: &str,
+        env: &serde_json::Value,
+        admitted: chrono::DateTime<chrono::Utc>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> u64 {
+        match consent_decay_target_tier(env, admitted, now) {
+            None => 0,
+            Some(FountainTier::Full) => 0,
+            Some(tier) => backend
+                .evict_fountain_content_to_tier(cid, "trace", tier)
+                .await
+                .expect("evict to decay tier"),
+        }
+    }
+    async fn read_class<B: Backend>(backend: &B, cid: &str, n: u32) -> FountainReadClass {
+        FountainContent::classify(
+            backend
+                .get_fountain_content(cid, "trace")
+                .await
+                .unwrap()
+                .unwrap()
+                .present(),
+            n,
+            2,
+        )
+    }
+
+    // (1) BELOW THRESHOLD stays: at +1d neither the 14d nor the 90d clock
+    //     has reached its first breakpoint ⇒ nothing evicted, both Full.
+    let now1 = temp_admitted + chrono::Duration::days(1);
+    assert_eq!(
+        decay_step(backend, &cid_temp, &temp_env, temp_admitted, now1).await,
+        0
+    );
+    assert_eq!(
+        decay_step(backend, &cid_pat, &pat_env, pat_admitted, now1).await,
+        0
+    );
+    assert_eq!(
+        read_class(backend, &cid_temp, n).await,
+        FountainReadClass::Full
+    );
+    assert_eq!(
+        read_class(backend, &cid_pat, n).await,
+        FountainReadClass::Full
+    );
+
+    // (2) TEMPORARY past 14d decays: at +20d the 14d clock is >= 1.0 ⇒ T5
+    //     (EnvelopeOnly). The 90d pattern at +20d is still < 0.25 ⇒ Full
+    //     (pattern-below-threshold stays).
+    let now2 = temp_admitted + chrono::Duration::days(20);
+    let temp_evicted = decay_step(backend, &cid_temp, &temp_env, temp_admitted, now2).await;
+    assert_eq!(
+        temp_evicted, total,
+        "TEMPORARY past 14d evicts every symbol (T5)"
+    );
+    assert_eq!(
+        decay_step(backend, &cid_pat, &pat_env, pat_admitted, now2).await,
+        0
+    );
+    assert_eq!(
+        read_class(backend, &cid_temp, n).await,
+        FountainReadClass::EnvelopeOnly,
+        "TEMPORARY decayed to EnvelopeOnly"
+    );
+    assert_eq!(
+        read_class(backend, &cid_pat, n).await,
+        FountainReadClass::Full
+    );
+
+    // (3) IDEMPOTENT: re-running the temporary step at the same `now`
+    //     evicts nothing further (already at/below the keep-count).
+    assert_eq!(
+        decay_step(backend, &cid_temp, &temp_env, temp_admitted, now2).await,
+        0,
+        "decay is idempotent at a fixed now"
+    );
+
+    // (4) PATTERN past 90d decays: at +100d the 90d clock is >= 1.0 ⇒ T5.
+    let now3 = pat_admitted + chrono::Duration::days(100);
+    let pat_evicted = decay_step(backend, &cid_pat, &pat_env, pat_admitted, now3).await;
+    assert_eq!(
+        pat_evicted, total,
+        "pattern past 90d evicts every symbol (T5)"
+    );
+    assert_eq!(
+        read_class(backend, &cid_pat, n).await,
+        FountainReadClass::EnvelopeOnly,
+        "pattern decayed to EnvelopeOnly"
+    );
+    // Idempotent again.
+    assert_eq!(
+        decay_step(backend, &cid_pat, &pat_env, pat_admitted, now3).await,
+        0
+    );
+
+    // The unclassed unit was NEVER touched by any step ⇒ still Full.
+    assert_eq!(
+        read_class(backend, &cid_none, n).await,
+        FountainReadClass::Full
+    );
+    let _ = s_none;
+}
+
+#[tokio::test]
+async fn sqlite_consent_decay() {
+    let backend = ciris_persist::store::SqliteBackend::open_in_memory()
+        .await
+        .expect("open sqlite");
+    backend
+        .run_migrations()
+        .await
+        .expect("sqlite migrations (incl. V084)");
+    run_consent_decay_assertions(&backend, "sqlite").await;
+}
+
+#[tokio::test]
+async fn postgres_consent_decay() {
+    let Some(dsn) = std::env::var("CIRIS_PERSIST_TEST_PG_URL").ok() else {
+        eprintln!("postgres_consent_decay skipped: CIRIS_PERSIST_TEST_PG_URL unset");
+        return;
+    };
+    let backend = ciris_persist::store::PostgresBackend::connect(&dsn)
+        .await
+        .expect("connect postgres");
+    backend
+        .run_migrations()
+        .await
+        .expect("pg migrations (incl. V084)");
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    run_consent_decay_assertions(&backend, &suffix).await;
+}
+
+/// The full `Engine::sweep_consent_decay_once` entry, end-to-end on an
+/// isolated in-memory SQLite engine (the sweep enumerates ALL manifests,
+/// so it is proven on the isolated backend; the per-candidate decisions +
+/// pg/sqlite parity are covered by `{sqlite,postgres}_consent_decay`).
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+async fn engine_sweep_consent_decay_once_sqlite() {
+    use ciris_persist::fountain::FountainReadClass;
+    use ciris_persist::signing::LocalSigner;
+    use std::sync::Arc;
+
+    // A minimal plaintext signer — the engine signer plays no part in
+    // fountain admission (the manifest is producer-signed) or in the decay
+    // sweep (which emits nothing).
+    let signer = Arc::new(LocalSigner::from_parts(
+        SigningKey::from_bytes(&[0x5Au8; 32]),
+        "decay-test-engine".to_string(),
+        None,
+        None,
+    ));
+    let engine = ciris_persist::Engine::with_signer(signer, "sqlite::memory:")
+        .await
+        .expect("engine");
+
+    let (n, k, size) = (8u32, 4u32, 16u32);
+    let (m_temp, s_temp) = build_manifest_with_envelope(
+        "c-eng-temp",
+        n,
+        k,
+        size,
+        serde_json::json!({ "consent_decay_class": "temporary" }),
+    )
+    .await;
+    let (m_none, s_none) =
+        build_manifest_with_envelope("c-eng-none", n, k, size, serde_json::json!({})).await;
+    let t0 = chrono::Utc::now();
+    engine
+        .put_fountain_content(&m_temp, &s_temp)
+        .await
+        .expect("put temp");
+    engine
+        .put_fountain_content(&m_none, &s_none)
+        .await
+        .expect("put none");
+
+    // Below threshold: +1d ⇒ nothing decays.
+    let r = engine
+        .sweep_consent_decay_once(t0 + chrono::Duration::days(1))
+        .await
+        .expect("sweep +1d");
+    assert_eq!(r.symbols_evicted, 0, "below-threshold sweep evicts nothing");
+    assert_eq!(
+        r.content_with_decay_class, 1,
+        "only the temporary unit has a class"
+    );
+
+    // Past 14d: +20d ⇒ the temporary unit decays to EnvelopeOnly.
+    let r = engine
+        .sweep_consent_decay_once(t0 + chrono::Duration::days(20))
+        .await
+        .expect("sweep +20d");
+    assert_eq!(
+        r.symbols_evicted,
+        u64::from(n + k),
+        "TEMPORARY drops all symbols"
+    );
+    assert_eq!(r.content_decayed, 1);
+    let temp = engine
+        .get_fountain_content("c-eng-temp", "trace")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        FountainContent::classify(temp.present(), n, 2),
+        FountainReadClass::EnvelopeOnly
+    );
+
+    // Idempotent: an identical re-sweep evicts nothing further.
+    let r = engine
+        .sweep_consent_decay_once(t0 + chrono::Duration::days(20))
+        .await
+        .expect("sweep +20d again");
+    assert_eq!(r.symbols_evicted, 0, "decay sweep is idempotent");
+
+    // The unclassed unit is untouched (still Full).
+    let none = engine
+        .get_fountain_content("c-eng-none", "trace")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(none.present(), n + k, "unclassed unit never decays");
+}
+
 /// (h) DiskPressure tier → keep-count mapping (unit test, no backend).
 #[tokio::test]
 async fn disk_pressure_tier_maps_to_keep_count() {

--- a/tests/trace_hybrid_hard_cut.rs
+++ b/tests/trace_hybrid_hard_cut.rs
@@ -70,6 +70,7 @@ async fn register_producer<D: FederationDirectory>(dir: &D, key_id: &str, ed_pk_
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         },
     })
     .await


### PR DESCRIPTION
The CC 1.0 RC1 compliance cut — nine conformance issues read against **CIRISConstitution v0.9.3**, integrated in one major. Closes #171, #227, #365, #366, #367, #368, #369, #370, #371, #372.

## ⚠ BREAKING (Rust-crate consumers only — wire/JSON stable)
- **`KeyRecord` gained `consent_role: Option<String>`** (#365) — Rust literals need `consent_role: None`. `#[serde(default)]`, so JSON is unchanged. **CIRISEdge constructs `KeyRecord` literals and must update** (adoption issue to follow).
- **`check_local_tier_eligibility` → `Result<LocalTierDisposition>`** + `check_consent_record_admission` same; `LocalAttestationInput` gained optional `scrub_signature_*` fields (#171).
- **`federation::Error` new variants** + `StorageContentionError::RevisionRollback` + `EvictionCandidate.media_type`.
- **Reserved-prefix admission is now set-membership** on `identity_type` (#366, CC 3.4.7.1) — behavior-preserving for single-role keys, newly admits conformant folded keys.

verify pin **unchanged v8.7.0**; `Requires-Dist <9` unchanged.

## What's in it
| # | Conformance item |
|---|---|
| #171 | crypto-gated transit-write acceptance → consent-overdue SLA functional (+ closed a local-tier sig bypass) |
| #227 | fountain consent-decay eviction (14d/90d, disk-independent) |
| #365 | `consent_role` on the wire (Counter-RII) |
| #366 | `detection:*` gate + set-membership fix |
| #367+#368 | witness-targets-subject age → minor-guardianship drivable |
| #369 | broadened no-moderator federate-apply gate keying |
| #370 | §Q pin-install surface + B5 cache-before-pinned (B6 stays absolute) |
| #371 | `apply_replicated_key_record` (owner_of-gated upgrade-aware Key-plane apply) |
| #372 | accord-conferred `canonical` role (self-claim fail-closed) |

## Verification (clean DB)
**1355 pg+sqlite lib tests + 13 integration tests + wheel build + all 11 new FFI methods present & functionally smoke-tested, 0 failed.** Full-feature clippy `-D warnings` clean. Migrations V092 (`consent_role` index) + V093 (`storage_budget_installed`). No pg/sqlite asymmetry.

## Downstream (adoption issues to follow)
CIRISEdge (major re-pin >=13,<14 + **`consent_role: None` on KeyRecord literals** + route `apply_key` → `apply_replicated_key_record`), CIRISServer (major re-pin; transit-write behavior change; can retire `POST /adopt-scrubbed`; canonical add op), CIRISConformance (test_271/351/360/361/530 flips + consent-overdue + consent_role probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)