### PR TITLE
v13.0.1: lift apply_replicated_key_record onto the FederationDirectory trait (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Patch: no wire change, no schema change, verify pin unchanged (v8.7.0).
   fail-closed, re-offerable). Unblocks CIRISEdge#277.
   Purely additive to the trait — a `Result<ReplicatedKeyOutcome, Error>` method with a
   default body, so existing `impl FederationDirectory` blocks keep compiling unchanged.
+  - **Capsule path routed too** (#320 ABI-stable `OpsDirectory`): edge consumes persist
+    through the C-ABI directory capsule, whose `OpsDirectory` overrides ~40 trait methods
+    but would otherwise inherit the new insert-only default — so the fix adds an
+    append-only `DirectoryOp::ApplyReplicatedKeyRecord` + `DirectoryOpResult::ReplicatedKeyOutcome`
+    and an `OpsDirectory` override, so the *capsule* consumer (the real edge shape) reaches
+    the upgrade-aware backend apply, not `put_public_key` DO-NOTHING. `DIRECTORY_ABI_VERSION`
+    unchanged (append-only serde op contract; the vtable C struct is untouched). Proven by a
+    sqlite-backed capsule round-trip that drives a real `Upgraded` through `build_op`.
 
 ## [13.0.0] — 2026-07-04 — CC 1.0 RC1 compliance cut
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes per release. Format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html), with mission /
 threat-model citations because this crate's audit story is the point.
 
+## [13.0.1] — 2026-07-04 — dyn-reachable replicated Key-plane apply (#375)
+
+Patch: no wire change, no schema change, verify pin unchanged (v8.7.0).
+
+### Fixed
+- **#375** — `apply_replicated_key_record` (the #371 upgrade-aware, `owner_of`-gated
+  replicated Key-plane apply) is now a method on the **`FederationDirectory` trait**,
+  not only an inherent method on `SqliteBackend`/`PostgresBackend`/`Engine`. CIRISEdge's
+  anti-entropy bridge holds an `Arc<dyn FederationDirectory>` with no concrete backend
+  type, so it could previously only reach `put_public_key` (`ON CONFLICT DO NOTHING`) —
+  silently dropping an anchor-scrubbed record for a `key_id` already held self-signed,
+  the exact DO-NOTHING #371 exists to replace. The sqlite/postgres impls delegate to the
+  existing inherent method (single source of truth); the trait default preserves the
+  memory/mock backends with first-seen insert semantics (collision ⇒ `Refused`,
+  fail-closed, re-offerable). Unblocks CIRISEdge#277.
+  Purely additive to the trait — a `Result<ReplicatedKeyOutcome, Error>` method with a
+  default body, so existing `impl FederationDirectory` blocks keep compiling unchanged.
+
 ## [13.0.0] — 2026-07-04 — CC 1.0 RC1 compliance cut
 
 Nine conformance issues, read against the standalone **CIRISConstitution v0.9.3**,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-persist"
-version = "13.0.0"
+version = "13.0.1"
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Unified Rust persistence for the CIRIS federation — signed events, time-series, runtime state."

--- a/src/federation/mod.rs
+++ b/src/federation/mod.rs
@@ -354,6 +354,41 @@ pub trait FederationDirectory: Send + Sync {
     /// differing content.
     async fn put_public_key(&self, record: SignedKeyRecord) -> Result<(), Error>;
 
+    /// v13.0.1 (CIRISPersist#375) — the **upgrade-aware, `owner_of`-gated
+    /// Key-plane apply** for anti-entropy replication, dyn-dispatchable.
+    ///
+    /// This is the trait surface for the #371 apply. Edge's replication
+    /// bridge holds an `Arc<dyn FederationDirectory>` and has no concrete
+    /// backend type, so the inherent
+    /// `apply_replicated_key_record` on `SqliteBackend`/`PostgresBackend`
+    /// (dispatched by [`Engine::apply_replicated_key_record`](crate::Engine::apply_replicated_key_record))
+    /// was unreachable — a receiver could only call [`Self::put_public_key`]
+    /// (`ON CONFLICT DO NOTHING`), silently dropping an anchor-scrubbed
+    /// record for a `key_id` it already holds self-signed. That DO-NOTHING
+    /// is exactly what #371 replaces over replication.
+    ///
+    /// The real sqlite/postgres backends **override** this to run the
+    /// monotonic, verify-before-mutation upgrade path (the
+    /// [`plan_replicated_key_apply`](register::plan_replicated_key_apply)
+    /// classification + `adopt_scrub_upgrade` on the Upgrade arm). The
+    /// default body here preserves the memory/mock backends: they have no
+    /// scrub-upgrade plane, so an incoming record is a **first-seen
+    /// insert** — `put_public_key` already leaves an existing differing row
+    /// untouched, so a collision resolves to `Refused` (fail-closed,
+    /// re-offerable) rather than aborting the anti-entropy loop.
+    async fn apply_replicated_key_record(
+        &self,
+        record: SignedKeyRecord,
+    ) -> Result<register::ReplicatedKeyOutcome, Error> {
+        match self.put_public_key(record).await {
+            Ok(()) => Ok(register::ReplicatedKeyOutcome::Inserted),
+            // First-seen wins on the replication plane: a differing row
+            // already present ⇒ not applied, but safe to re-offer.
+            Err(Error::Conflict(_)) => Ok(register::ReplicatedKeyOutcome::Refused),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Fetch a single pubkey row by `key_id`. Returns `None` if absent.
     async fn lookup_public_key(&self, key_id: &str) -> Result<Option<KeyRecord>, Error>;
 

--- a/src/ffi/directory_capsule.rs
+++ b/src/ffi/directory_capsule.rs
@@ -442,6 +442,16 @@ pub enum DirectoryOp {
         /// The opaque consumer-owned policy blob (round-tripped JSON).
         policy: types::PeerPolicyBlob,
     },
+    /// [`FederationDirectory::apply_replicated_key_record`] (#375) — the
+    /// #371 upgrade-aware, `owner_of`-gated replicated Key-plane apply.
+    /// Routed so capsule consumers (CIRISEdge's anti-entropy bridge, which
+    /// holds an `Arc<dyn FederationDirectory>` = [`OpsDirectory`]) reach the
+    /// real backend upgrade path instead of the trait default's insert-only
+    /// `put_public_key` DO-NOTHING. APPEND-ONLY: added at the end.
+    ApplyReplicatedKeyRecord {
+        /// The signed pubkey row to apply (fresh insert or scrub-upgrade).
+        record: SignedKeyRecord,
+    },
 }
 
 /// The mirror of each [`DirectoryOp`]'s return, plus the flattened error.
@@ -503,6 +513,12 @@ pub enum DirectoryOpResult {
     HybridVerify(Result<crate::verify::hybrid::VerifyOutcome, String>),
     /// `build_delegation_graph`.
     DelegationGraph(crate::federation::topology::DelegationGraph),
+    /// `apply_replicated_key_record` (#375) — the upgrade-aware apply
+    /// OUTCOME (`Inserted` / `Upgraded` / `Unchanged` / `Refused`). A
+    /// `Refused` is a *policy* outcome carried HERE, NOT flattened to the
+    /// top-level [`DirectoryOpResult::Err`] (which is reserved for a real
+    /// backend error that means the apply could not run). APPEND-ONLY.
+    ReplicatedKeyOutcome(crate::federation::register::ReplicatedKeyOutcome),
 }
 
 /// Run one [`DirectoryOp`] against `dir` and wrap the outcome.
@@ -583,6 +599,15 @@ pub async fn dispatch_directory_op(
             Ok(()) => DirectoryOpResult::Unit,
             Err(e) => DirectoryOpResult::Err(e.to_string()),
         },
+        // #375 — the whole apply (plan + adopt_scrub_upgrade) runs INSIDE
+        // persist's .so against persist's own vtable, so the capsule
+        // consumer gets the real upgrade-aware outcome, not DO-NOTHING.
+        DirectoryOp::ApplyReplicatedKeyRecord { record } => {
+            match dir.apply_replicated_key_record(record).await {
+                Ok(outcome) => DirectoryOpResult::ReplicatedKeyOutcome(outcome),
+                Err(e) => DirectoryOpResult::Err(e.to_string()),
+            }
+        }
         DirectoryOp::PutLocationProof { proof } => match dir.put_location_proof(proof).await {
             Ok(()) => DirectoryOpResult::Unit,
             Err(e) => DirectoryOpResult::Err(e.to_string()),
@@ -1212,6 +1237,25 @@ impl FederationDirectory for OpsDirectory {
     async fn put_public_key(&self, record: SignedKeyRecord) -> Result<(), Error> {
         match self.run_op(&DirectoryOp::PutPublicKey { record }).await? {
             DirectoryOpResult::Unit => Ok(()),
+            DirectoryOpResult::Err(s) => Err(Error::Backend(s)),
+            _ => Err(Error::Backend(
+                "directory ops proxy: unexpected result variant".into(),
+            )),
+        }
+    }
+
+    // #375 — override so the capsule routes to the real upgrade-aware apply
+    // (the trait default would run put_public_key DO-NOTHING here, silently
+    // dropping an anchor-scrubbed record for an existing self-signed key_id).
+    async fn apply_replicated_key_record(
+        &self,
+        record: SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, Error> {
+        match self
+            .run_op(&DirectoryOp::ApplyReplicatedKeyRecord { record })
+            .await?
+        {
+            DirectoryOpResult::ReplicatedKeyOutcome(outcome) => Ok(outcome),
             DirectoryOpResult::Err(s) => Err(Error::Backend(s)),
             _ => Err(Error::Backend(
                 "directory ops proxy: unexpected result variant".into(),
@@ -2247,6 +2291,89 @@ mod tests {
         assert_eq!(via_capsule.expect("some").key_id, "primitive-abc");
 
         // Keep `directory.data` owned by us; drop it through the vtable.
+        // SAFETY: single-drop, matched vtable.
+        unsafe { (directory.vtable.drop)(directory.data) };
+    }
+
+    /// #375 — the anti-entropy-critical proof: an anchor-scrubbed record
+    /// for an EXISTING self-signed key_id UPGRADES *through the C-ABI
+    /// capsule* (the shape CIRISEdge's replication bridge holds). Backed by
+    /// a real SqliteBackend so the upgrade plane exists — `Upgraded` is an
+    /// outcome the pre-#375 default (`put_public_key` DO-NOTHING → `Unit`)
+    /// could never produce, so reaching it proves the capsule now routes to
+    /// the real upgrade-aware backend apply, not the insert-only fallback.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn apply_replicated_key_record_via_capsule_upgrades_sqlite() {
+        use crate::federation::register::ReplicatedKeyOutcome as O;
+        use crate::federation::tier_ingest::test_support as ts;
+        use crate::federation::types::identity_type;
+        use crate::store::backend::Backend;
+
+        let rt = test_runtime();
+        let backend = rt.block_on(async {
+            let b = crate::store::sqlite::SqliteBackend::open_in_memory()
+                .await
+                .expect("open sqlite");
+            b.run_migrations().await.expect("migrate");
+            Arc::new(b)
+        });
+        let dir: Arc<dyn FederationDirectory> = backend.clone();
+        let directory = build_persist_directory(dir.clone());
+
+        // Seed the granting anchor, the node's single `user`-role owner, the
+        // self-signed boot row, and the single-owner binding (owner_of).
+        rt.block_on(async {
+            ts::register_hybrid_key(dir.as_ref(), "cap-anchor").await;
+            ts::register_identity_key(dir.as_ref(), "cap-owner", identity_type::USER).await;
+            dir.apply_replicated_key_record(SignedKeyRecord {
+                record: ts::replicated_key_record(
+                    "cap-node",
+                    identity_type::NODE,
+                    "cap-node",
+                    "cap-node",
+                    "v1",
+                ),
+            })
+            .await
+            .expect("seed self-signed");
+            dir.put_attestation(crate::federation::SignedAttestation {
+                attestation: ts::owner_binding_attestation(
+                    &uuid::Uuid::new_v4().to_string(),
+                    "cap-owner",
+                    "cap-node",
+                ),
+            })
+            .await
+            .expect("owner-binding");
+        });
+
+        // The UPGRADE, driven entirely through the capsule build_op path.
+        let scrubbed = ts::replicated_key_record(
+            "cap-node",
+            identity_type::NODE,
+            "cap-anchor",
+            "cap-anchor",
+            "v1",
+        );
+        let res = run_op(
+            &rt,
+            &directory,
+            &DirectoryOp::ApplyReplicatedKeyRecord {
+                record: SignedKeyRecord { record: scrubbed },
+            },
+        );
+        assert!(
+            matches!(res, DirectoryOpResult::ReplicatedKeyOutcome(O::Upgraded)),
+            "capsule apply must UPGRADE (not DO-NOTHING), got {res:?}"
+        );
+        // The backend row is really anchor-scrubbed now.
+        let row = rt
+            .block_on(dir.lookup_public_key("cap-node"))
+            .expect("lookup")
+            .expect("row");
+        assert_eq!(row.scrub_key_id, "cap-anchor");
+
         // SAFETY: single-drop, matched vtable.
         unsafe { (directory.vtable.drop)(directory.data) };
     }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -10038,6 +10038,41 @@ mod tests {
         .unwrap());
     }
 
+    /// v13.0.1 (#375) — the DEFAULT `FederationDirectory::apply_replicated_key_record`
+    /// trait body (memory/mock backends, no scrub-upgrade plane): a new
+    /// key_id is a first-seen Inserted; a differing record for an existing
+    /// key_id is Refused (fail-closed, first-seen wins) and leaves the row
+    /// untouched — no panic, no error propagated up the anti-entropy loop.
+    #[tokio::test]
+    async fn apply_replicated_key_record_default_first_seen_wins_memory() {
+        use crate::federation::register::ReplicatedKeyOutcome;
+        use crate::federation::FederationDirectory;
+        let backend = MemoryBackend::new();
+        let dir: &dyn FederationDirectory = &backend;
+
+        // First-seen insert.
+        assert_eq!(
+            dir.apply_replicated_key_record(SignedKeyRecord {
+                record: fix_key("node-x", "primitive", "node-x"),
+            })
+            .await
+            .unwrap(),
+            ReplicatedKeyOutcome::Inserted
+        );
+
+        // A differing record for the same key_id — Refused, original kept.
+        let mut differing = fix_key("node-x", "primitive", "A1");
+        differing.pubkey_ed25519_base64 = "AAAA-different-pubkey".into();
+        assert_eq!(
+            dir.apply_replicated_key_record(SignedKeyRecord { record: differing })
+                .await
+                .unwrap(),
+            ReplicatedKeyOutcome::Refused
+        );
+        let row = dir.lookup_public_key("node-x").await.unwrap().unwrap();
+        assert_eq!(row.scrub_key_id, "node-x", "original self-signed row kept");
+    }
+
     /// reachable_under_scope_with_reasons (#272): the refusal-reason
     /// companion classifies each "no" — Reachable / MissingScope /
     /// RetractedAtRoot / SignerUnreached / NoTrustRoots — and stays

--- a/src/store/postgres.rs
+++ b/src/store/postgres.rs
@@ -2546,6 +2546,18 @@ impl PostgresBackend {
 
 #[async_trait::async_trait]
 impl crate::federation::FederationDirectory for PostgresBackend {
+    // v13.0.1 (CIRISPersist#375) — expose the #371 upgrade-aware apply on
+    // the trait so `Arc<dyn FederationDirectory>` holders (CIRISEdge's
+    // anti-entropy bridge) reach the real path, not `put_public_key`'s
+    // DO-NOTHING. Delegates to the inherent method (the single source of
+    // truth for the plan + adopt_scrub_upgrade logic).
+    async fn apply_replicated_key_record(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, crate::federation::Error> {
+        PostgresBackend::apply_replicated_key_record(self, record).await
+    }
+
     async fn put_public_key(
         &self,
         record: crate::federation::SignedKeyRecord,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2276,6 +2276,18 @@ impl SqliteBackend {
 
 #[async_trait::async_trait]
 impl crate::federation::FederationDirectory for SqliteBackend {
+    // v13.0.1 (CIRISPersist#375) — expose the #371 upgrade-aware apply on
+    // the trait so `Arc<dyn FederationDirectory>` holders (CIRISEdge's
+    // anti-entropy bridge) reach the real path, not `put_public_key`'s
+    // DO-NOTHING. Delegates to the inherent method (the single source of
+    // truth for the plan + adopt_scrub_upgrade logic).
+    async fn apply_replicated_key_record(
+        &self,
+        record: crate::federation::SignedKeyRecord,
+    ) -> Result<crate::federation::register::ReplicatedKeyOutcome, crate::federation::Error> {
+        SqliteBackend::apply_replicated_key_record(self, record).await
+    }
+
     async fn put_public_key(
         &self,
         record: crate::federation::SignedKeyRecord,
@@ -15568,6 +15580,83 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, crate::federation::Error::InvalidArgument(_)));
+    }
+
+    /// v13.0.1 (#375) — the #371 upgrade-aware apply is reachable through
+    /// `&dyn FederationDirectory` (the shape CIRISEdge's anti-entropy bridge
+    /// holds) and runs the REAL path, not `put_public_key`'s DO-NOTHING:
+    /// a self-signed row is upgraded in place by a dyn-dispatched
+    /// anchor-scrubbed record, and a re-apply is Unchanged.
+    #[tokio::test]
+    async fn apply_replicated_key_record_dyn_dispatch_upgrades_sqlite() {
+        use crate::federation::register::ReplicatedKeyOutcome as O;
+        use crate::federation::tier_ingest::test_support as ts;
+        use crate::federation::types::identity_type;
+        use crate::federation::FederationDirectory;
+        let backend = SqliteBackend::open_in_memory().await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        // Reach the apply ONLY through the trait object — no concrete
+        // backend type, exactly like FederationDirectoryReplicationBridge
+        // (which holds `Arc<dyn FederationDirectory>`).
+        let dir: &dyn FederationDirectory = &backend;
+
+        // The anchor scrubber (granting authority) and the node's single
+        // `user`-role owner must exist for the Strict scrub gate + owner_of.
+        ts::register_hybrid_key(dir, "anchor-a").await;
+        ts::register_identity_key(dir, "owner-a", identity_type::USER).await;
+
+        // (1) fresh insert of the self-signed boot row — dyn-dispatched.
+        let self_rec =
+            ts::replicated_key_record("node-x", identity_type::NODE, "node-x", "node-x", "v1");
+        assert_eq!(
+            dir.apply_replicated_key_record(SignedKeyRecord { record: self_rec })
+                .await
+                .unwrap(),
+            O::Inserted,
+            "(1) dyn fresh insert"
+        );
+
+        // Seed the single-owner binding (v12.6.0) so owner_of resolves.
+        dir.put_attestation(crate::federation::SignedAttestation {
+            attestation: ts::owner_binding_attestation(
+                &uuid::Uuid::new_v4().to_string(),
+                "owner-a",
+                "node-x",
+            ),
+        })
+        .await
+        .expect("owner-binding admitted");
+
+        // (2) anchor-scrubbed record ⇒ UPGRADE — an outcome the default
+        // trait body can NEVER produce, so reaching it proves dyn dispatch
+        // hit the real upgrade-aware method, not put_public_key DO-NOTHING.
+        let scrubbed =
+            ts::replicated_key_record("node-x", identity_type::NODE, "anchor-a", "anchor-a", "v1");
+        assert_eq!(
+            dir.apply_replicated_key_record(SignedKeyRecord {
+                record: scrubbed.clone(),
+            })
+            .await
+            .unwrap(),
+            O::Upgraded,
+            "(2) dyn-dispatched apply must UPGRADE, not silently DO-NOTHING"
+        );
+        let row = dir.lookup_public_key("node-x").await.unwrap().unwrap();
+        assert_eq!(
+            row.scrub_key_id, "anchor-a",
+            "row is anchor-scrubbed via dyn"
+        );
+        assert_ne!(row.scrub_key_id, row.key_id, "no longer self-signed");
+
+        // (3) idempotent re-apply over the same trait object.
+        assert_eq!(
+            dir.apply_replicated_key_record(SignedKeyRecord { record: scrubbed })
+                .await
+                .unwrap(),
+            O::Unchanged,
+            "(3) dyn idempotent"
+        );
     }
 
     /// #351 — a pubkey change (different identity) is refused even with a


### PR DESCRIPTION
## v13.0.1 — dyn-reachable replicated Key-plane apply (closes #375)

**Patch. No wire change, no schema change, verify pin unchanged (v8.7.0). Purely additive to the trait.**

### The gap
v13.0.0 (#371) added `apply_replicated_key_record` — the upgrade-aware, `owner_of`-gated replicated Key-plane apply — as an **inherent** method on `SqliteBackend` / `PostgresBackend` / `Engine`, but **not** on the `FederationDirectory` trait. CIRISEdge's anti-entropy bridge (`FederationDirectoryReplicationBridge`) holds an `Arc<dyn FederationDirectory>` with no concrete backend type, so `apply_key` could only reach the trait's `put_public_key` (`ON CONFLICT DO NOTHING`) — silently dropping an anchor-scrubbed record for a `key_id` already held self-signed. That DO-NOTHING is exactly what #371 exists to replace over replication.

### The fix
- **Trait method** `apply_replicated_key_record(&self, SignedKeyRecord) -> Result<ReplicatedKeyOutcome, Error>` on `FederationDirectory`, with a **default body** that preserves memory/mock backends (first-seen insert; collision ⇒ `Refused`, fail-closed + re-offerable).
- **sqlite/postgres overrides** delegate to the existing inherent method — single source of truth for the plan classification + `adopt_scrub_upgrade` upgrade arm. `Engine`'s dispatch is unchanged (inherent-method priority).
- Additive: existing `impl FederationDirectory` blocks compile unchanged.

### Tests
- `apply_replicated_key_record_dyn_dispatch_upgrades_sqlite` — drives a real self→anchor-scrubbed **Upgrade** entirely through `&dyn FederationDirectory` (an outcome the default body can *never* produce, proving dyn dispatch reaches the real method).
- `apply_replicated_key_record_default_first_seen_wins_memory` — the default trait body: new key ⇒ `Inserted`, differing record ⇒ `Refused`, original row untouched.

Full suite green: **1406 pg+sqlite lib, 0 failed** (real postgres:16 + sqlite). fmt + full-feature clippy `-D warnings` clean.

Unblocks **CIRISEdge#277** (routes `apply_key` → `directory.apply_replicated_key_record(...)`, retiring the out-of-band adopt-scrubbed endpoint per CIRISServer#150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
